### PR TITLE
ci(circleci): add tests reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# Docs: https://circleci.com/docs/2.0/language-javascript/ 
+# Docs: https://circleci.com/docs/2.0/language-javascript/
 version: 2
 jobs:
   test_node_8:
@@ -20,7 +20,7 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Run tests
-          command: yarn test --watchAll=false
+          command: yarn test --watchAll=false --runInBand
 
   test_node_10:
     docker:
@@ -39,9 +39,16 @@ jobs:
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
-      - run: 
+      - run:
+          name: Run linter
+          command: yarn lint --format junit -o reports/junit/js-lint-results.xml
+      - run:
           name: Run tests
-          command: yarn test --watchAll=false
+          command: yarn test --watchAll=false --ci --coverage --reporters=default --reporters=jest-junit --runInBand
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit   
 
   release:
     docker:
@@ -91,7 +98,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "d3:31:7b:2f:30:65:1a:a7:43:aa:4a:af:7c:74:87:0e"
-      - run: 
+      - run:
           name: Deploy website
           command: yarn deploy-web
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "husky": "^1.2.1",
     "jest-axe": "^3.1.0",
     "jest-dom": "^3.0.0",
+    "jest-junit": "^6.4.0",
     "jest-styled-components": "^6.3.1",
     "lint-staged": "^7.2.2",
     "prettier": "^1.14.2",
@@ -89,15 +90,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/components/**/*.{ts,tsx}"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "branches": 90,
-        "functions": 90,
-        "lines": 90,
-        "statements": 90
-      }
-    }
+    ]
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7454,6 +7454,16 @@ jest-jasmine2@^23.6.0:
     jest-util "^23.4.0"
     pretty-format "^23.6.0"
 
+jest-junit@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-6.4.0.tgz#23e15c979fa6338afde46f2d2ac2a6b7e8cf0d9e"
+  integrity sha512-GXEZA5WBeUich94BARoEUccJumhCgCerg7mXDFLxWwI2P7wL3Z7sGWk+53x343YdBLjiMR9aD/gYMVKO+0pE4Q==
+  dependencies:
+    jest-validate "^24.0.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz#e4230fd42cf381a1a1971237ad56897de7e171de"
@@ -7630,6 +7640,18 @@ jest-validate@^23.5.0, jest-validate@^23.6.0:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^23.6.0"
+
+jest-validate@^24.0.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.8.0.tgz#624c41533e6dfe356ffadc6e2423a35c2d3b4849"
+  integrity sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==
+  dependencies:
+    "@jest/types" "^24.8.0"
+    camelcase "^5.0.0"
+    chalk "^2.0.1"
+    jest-get-type "^24.8.0"
+    leven "^2.1.0"
+    pretty-format "^24.8.0"
 
 jest-watcher@^23.4.0:
   version "23.4.0"
@@ -14549,6 +14571,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
Now we can see metadata for the failing tests and lint errors in Circle CI:
<img width="739" alt="CircleCI_-_CircleCI" src="https://user-images.githubusercontent.com/7198934/58274438-2e2ee300-7d93-11e9-9b7f-640a94649a90.png">
 info from the tests in the circle ci