### PR TITLE
Enable `font-display: swap` for Open Sans

### DIFF
--- a/src/components/styles/Fonts.tsx
+++ b/src/components/styles/Fonts.tsx
@@ -24,7 +24,7 @@ const Fonts = createGlobalStyle`
   }
 
   /* Open Sans */
-  @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700');
+  @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap');
 `;
 
 export default Fonts;


### PR DESCRIPTION
## Summary 🍿

Google Fonts is [finally supporting `font-display: swap`](https://www.zachleat.com/web/google-fonts-display/).

We recently added this strategy for the _"display"_ font, **Alvereta**, and to be consistent I recommend we add it too for the _"text"_ font, **Open Sans**. 

During the time it takes **Open Sans** to load, the browser will display a [system font stack](https://github.com/zopaUK/react-components/blob/master/src/constants/fonts.ts#L2).

This strategy brings benefits in page load performance on _slow networks_ ( as suggested by [Google Lighthouse](https://developers.google.com/web/tools/lighthouse/) ), as the browser doesn't need to paint invisible text and the content is available straight away once the user lands on the page.