### PR TITLE
fix(styleguide): fix column space of props & methods

### DIFF
--- a/src/styleguide-components/README.md
+++ b/src/styleguide-components/README.md
@@ -1,3 +1,7 @@
 This folder contains all the custom wrappers for the style guide.
 
-More info: https://react-styleguidist.js.org/docs/cookbook.html#how-to-change-styles-of-a-style-guide
+The code is in Javascript in order to keep the code as close as possible to the original code for easy refactoring.
+
+In order to add custom styles you must map those components in [our styleguide config](/styleguide.config.js).
+
+[official docs](https://react-styleguidist.js.org/docs/cookbook.html#how-to-change-styles-of-a-style-guide) | [original source files](https://github.com/styleguidist/react-styleguidist/tree/master/src/client/rsg-components)

--- a/src/styleguide-components/Table.js
+++ b/src/styleguide-components/Table.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Styled from 'rsg-components/Styled';
+
+export const styles = ({ space, color, fontFamily, fontSize }) => ({
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    marginBottom: space[4],
+    tableLayout: 'auto',
+  },
+  tableHead: {
+    borderBottom: [[1, color.border, 'solid']],
+  },
+  cellHeading: {
+    color: color.base,
+    paddingRight: space[1],
+    paddingBottom: space[1],
+    textAlign: 'left',
+    fontFamily: fontFamily.base,
+    fontWeight: 'bold',
+    fontSize: fontSize.small,
+    whiteSpace: 'nowrap',
+  },
+  cell: {
+    color: color.base,
+    paddingRight: space[1],
+    paddingTop: space[1],
+    paddingBottom: space[1],
+    verticalAlign: 'top',
+    fontFamily: fontFamily.base,
+    fontSize: fontSize.small,
+    '&:last-child': {
+      isolate: false,
+      paddingRight: 0,
+    },
+    '& p:last-child': {
+      isolate: false,
+      marginBottom: 0,
+    },
+  },
+});
+
+export function TableRenderer({ classes, columns, rows, getRowKey }) {
+  return (
+    <table className={classes.table}>
+      <thead className={classes.tableHead}>
+        <tr>
+          {columns.map(({ caption }) => (
+            <th key={caption} className={classes.cellHeading}>
+              {caption}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(row => (
+          <tr key={getRowKey(row)}>
+            {columns.map(({ render }, index) => (
+              <td key={index} className={classes.cell}>
+                {render(row)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+TableRenderer.propTypes = {
+  classes: PropTypes.object.isRequired,
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      caption: PropTypes.string.isRequired,
+      render: PropTypes.func.isRequired,
+    }),
+  ).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  getRowKey: PropTypes.func.isRequired,
+};
+
+export default Styled(styles)(TableRenderer);

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -139,6 +139,7 @@ module.exports = {
     LogoRenderer: path.resolve(__dirname, './src/styleguide-components/Logo'),
     PathlineRenderer: path.resolve(__dirname, './src/styleguide-components/Pathline'),
     StyleGuideRenderer: path.resolve(__dirname, './src/styleguide-components/StyleGuide'),
+    TableRenderer: path.resolve(__dirname, './src/styleguide-components/Table'),
     VersionRenderer: path.resolve(__dirname, './src/styleguide-components/Version'),
   },
   // Used to convert type definitions to documentation. More info: https://github.com/styleguidist/react-docgen-typescript


### PR DESCRIPTION
Fix #18 

Before:
![](https://user-images.githubusercontent.com/5938217/58485573-9b13f580-8164-11e9-8d5f-6a5484300bfb.png)

Now:
<img width="1155" alt="React_components" src="https://user-images.githubusercontent.com/7198934/58716156-b0895980-83c8-11e9-81ee-9d7987eff692.png">
