### PR TITLE
Documentation fixes  🗒 ... 🖍 

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -11,7 +11,7 @@ This project aims to have all the common styled react components as a library/do
 - ⚠️ **In order to use this UI you must import the `<GlobalStyles />` component and use it in the root of your project.**
 
   ```js static
-  import { GlobalStyles } from 'zopa-react-components';
+  import { GlobalStyles } from '@zopauk/react-components';
 
   // root component
   const App = () => (
@@ -25,7 +25,7 @@ This project aims to have all the common styled react components as a library/do
 - **Fonts** (_optional_): This is not added in the default module because there are better ways to do it in terms of performance.
 
   ```js static
-  import { Fonts } from 'zopa-react-components';
+  import { Fonts } from '@zopauk/react-components';
 
   // root component
   const App = () => (

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -9,7 +9,7 @@ shown as code examples but are not exported as a single component itself to avoi
 To use the components in your project simply import the desired component to your project as follows:
 
 ```js static
-import { Button } from 'zopa-react-components';
+import { Button } from '@zopauk/react-components';
 ```
 
 For complex components (organisms, templates, pages, ...) we can just click on "show code" and copy/paste the code to our project.

--- a/src/components/atoms/AlertBox/AlertBox.md
+++ b/src/components/atoms/AlertBox/AlertBox.md
@@ -1,12 +1,12 @@
 Styled AlertBox component
 
 ```js
-import Link from 'zopa-react-components/components/atoms/Link/Link';
+import { AlertBox, Link } from '@zopauk/react-components';
 
-<AlertBox style={{ width: '650px' }}>
-  <p>
-    Your data protection rights have changed, giving you extra control and visibility over your data.
+<AlertBox>
+  <div>
+    <p>Your data protection rights have changed, giving you extra control and visibility over your data.</p>
     <Link href="#">Tell me more in plain English</Link>
-  </p>
+  </div>
 </AlertBox>;
 ```

--- a/src/components/atoms/Badge/Badge.md
+++ b/src/components/atoms/Badge/Badge.md
@@ -3,11 +3,27 @@ Use the `<Badge />` component to label elements in the user interface.
 There's four different styles available:
 
 ```js
-<Badge>Default</Badge> <Badge styling="waiting">Pending</Badge> <Badge styling="confirmed">Approved</Badge> <Badge styling="invalid">Invalid</Badge>
+import { Fragment } from 'react';
+import { Badge } from '@zopauk/react-components';
+
+<Fragment>
+  <Badge>Default</Badge>
+  <Badge styling="waiting">Pending</Badge>
+  <Badge styling="confirmed">Approved</Badge>
+  <Badge styling="invalid">Invalid</Badge>
+</Fragment>;
 ```
 
 For sizing, you can supply the same `"size"` prop as for [`<Text />`](#/Components?id=text)
 
 ```js
-<Badge size="xs">Compact</Badge> <Badge>Default</Badge> <Badge size="m">Medium</Badge> <Badge size="l">Large</Badge>
+import { Fragment } from 'react';
+import { Badge } from '@zopauk/react-components';
+
+<Fragment>
+  <Badge size="xs">Compact</Badge>
+  <Badge>Default</Badge>
+  <Badge size="m">Medium</Badge>
+  <Badge size="l">Large</Badge>
+</Fragment>;
 ```

--- a/src/components/atoms/Button/Button.md
+++ b/src/components/atoms/Button/Button.md
@@ -21,7 +21,9 @@ Styled button component
 Used for the main call to action. Should only appear once per screen.
 
 ```jsx
-<Button styling="primary">Button smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button styling="primary">Button smash</Button>;
 ```
 
 ### Secondary
@@ -29,7 +31,9 @@ Used for the main call to action. Should only appear once per screen.
 Standard button for most actions.
 
 ```jsx
-<Button styling="secondary">Button smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button styling="secondary">Button smash</Button>;
 ```
 
 ### Disabled
@@ -37,7 +41,9 @@ Standard button for most actions.
 For use when actions are disabled, both primary and secondary.
 
 ```jsx
-<Button disabled={true}>Button smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button disabled={true}>Button smash</Button>;
 ```
 
 ### Link button
@@ -45,7 +51,9 @@ For use when actions are disabled, both primary and secondary.
 Used to navigate to other pages, always in current window unless external icon is present.
 
 ```jsx
-<Button styling="link">Link smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button styling="link">Link smash</Button>;
 ```
 
 ### Warning
@@ -53,7 +61,9 @@ Used to navigate to other pages, always in current window unless external icon i
 For potentially risky actions.
 
 ```jsx
-<Button styling="warning">Proceed</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button styling="warning">Proceed</Button>;
 ```
 
 ### Alert
@@ -61,7 +71,9 @@ For potentially risky actions.
 For very dangerous actions!
 
 ```jsx
-<Button styling="alert">Delete</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button styling="alert">Delete</Button>;
 ```
 
 ### Large
@@ -69,7 +81,9 @@ For very dangerous actions!
 Rarely to be used, but it's here.
 
 ```jsx
-<Button sizing="large">Big smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button sizing="large">Big smash</Button>;
 ```
 
 ### Small
@@ -77,7 +91,9 @@ Rarely to be used, but it's here.
 Mainly used when many actions are available in close proximity.
 
 ```jsx
-<Button sizing="small">Little smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button sizing="small">Little smash</Button>;
 ```
 
 ### Compact
@@ -85,7 +101,9 @@ Mainly used when many actions are available in close proximity.
 For when the link style just won't work.
 
 ```jsx
-<Button sizing="compact">Tiny smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button sizing="compact">Tiny smash</Button>;
 ```
 
 ### Right icon
@@ -93,7 +111,7 @@ For when the link style just won't work.
 Can be used with arrows, among other icons.
 
 ```jsx
-import Alert from 'zopa-react-components/components/icons/Alert/Alert';
+import { Alert, Button } from '@zopauk/react-components';
 
 <Button rightIcon={<Alert fillColor="#fff" />}>Learn more</Button>;
 ```
@@ -103,7 +121,7 @@ import Alert from 'zopa-react-components/components/icons/Alert/Alert';
 For when the icon conveys the meaning faster than text.
 
 ```jsx
-import Alert from 'zopa-react-components/components/icons/Alert/Alert';
+import { Alert, Button } from '@zopauk/react-components';
 
 <Button leftIcon={<Alert fillColor="#fff" />}>Smash now</Button>;
 ```
@@ -113,39 +131,41 @@ import Alert from 'zopa-react-components/components/icons/Alert/Alert';
 For when the button should stretch the entire width of the divider.
 
 ```jsx
-<Button fullWidth={true}>Button smash</Button>
+import { Button } from '@zopauk/react-components';
+
+<Button fullWidth={true}>Button smash</Button>;
 ```
 
 ### Primary contrast
 
 Note that the text colour is the same as the background (always!)
 
-```jsx
-<div style={{ backgroundColor: '#293272', padding: '32px' }}>
-  <Button styling="contrastPrimary" contrastColor="#293272">
-    Button smash
-  </Button>
-</div>
+```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { Button, colors } from '@zopauk/react-components';
+
+<Button styling="contrastPrimary" contrastColor={colors.primary.navy800}>
+  Button smash
+</Button>;
 ```
 
 ### Secondary contrast
 
 The border should be the colour's shade in 50 or close to that.
 
-```jsx
-<div style={{ backgroundColor: '#293272', padding: '32px' }}>
-  <Button styling="contrastSecondary" contrastColor="#293272">
-    Button smash
-  </Button>
-</div>
+```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { Button, colors } from '@zopauk/react-components';
+
+<Button styling="contrastSecondary" contrastColor={colors.extended.blue25}>
+  Button smash
+</Button>;
 ```
 
 ### Link contrast
 
 See above.
 
-```jsx
-<div style={{ backgroundColor: '#293272', padding: '32px' }}>
-  <Button styling="contrastLink">Link smash</Button>
-</div>
+```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { Button } from '@zopauk/react-components';
+
+<Button styling="contrastLink">Link smash</Button>;
 ```

--- a/src/components/atoms/Card/Card.md
+++ b/src/components/atoms/Card/Card.md
@@ -5,10 +5,11 @@ The design team has agreed on three types of cards depending on the context.
 A standard or default card, which we'll assume if the type property has been omitted or set explicitly to card. As of this writing, cards of this type are non-interactable and have a border radius of 4px.
 
 ```js { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { Card } from '@zopauk/react-components';
+
 <Card type="card">
-  <div>I'm a card</div>
-  <div>with an explicit type prop.</div>
-</Card>
+  <p>I'm a card 😀 , with an explicit type prop.</p>
+</Card>;
 ```
 
 #### linkCard type
@@ -17,12 +18,12 @@ A card that is meant to be clickable and respond to user interactions (hover eff
 
 Cards of type `"linkCard"` are meant to be used to build components that interact with user actions.
 
-```js
-import Header3 from 'zopa-react-components/components/typography/Header3/Header3';
+```js { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { Card, Header3 } from '@zopauk/react-components';
 
-<div style={{ cursor: 'pointer' }} onClick={() => alert("You're a winner!")}>
-  <Card borderColor={colors.primary.blue500} backgroundColor={colors.primary.teal600} type="linkCard">
-    <Header3>New rates today!</Header3>
+<div onClick={() => alert("You're a winner!")}>
+  <Card type="linkCard">
+    <Header3>New rates today! 💸</Header3>
     <p>Find out how you can benefit the most from our new rates.</p>
   </Card>
 </div>;

--- a/src/components/atoms/Dropdown/Dropdown.md
+++ b/src/components/atoms/Dropdown/Dropdown.md
@@ -6,22 +6,22 @@ It consists of 2 components:
 - `<Option />`: which extends from html `<option>` element
 
 ```jsx
-import { Option } from './Dropdown';
+import { Dropdown, DropdownOption } from '@zopauk/react-components';
 
 <Dropdown name="I ❤️ dropdowns" defaultValue="third">
-  <Option value="first">First value</Option>
-  <Option value="second">Second value</Option>
-  <Option value="third">Third value</Option>
-  <Option value="fourth">This value is really quite long</Option>
+  <DropdownOption value="first">First value</DropdownOption>
+  <DropdownOption value="second">Second value</DropdownOption>
+  <DropdownOption value="third">Third value</DropdownOption>
+  <DropdownOption value="fourth">This value is really quite long</DropdownOption>
 </Dropdown>;
 ```
 
 #### hasError
 
 ```jsx
-import { Option } from './Dropdown';
+import { Dropdown, DropdownOption } from '@zopauk/react-components';
 
 <Dropdown hasError={true}>
-  <Option value="first">First value</Option>
+  <DropdownOption value="first">First value</DropdownOption>
 </Dropdown>;
 ```

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -15,7 +15,8 @@ export interface IDropdownProps extends React.SelectHTMLAttributes<HTMLSelectEle
 
 export interface IOption extends React.OptionHTMLAttributes<HTMLOptionElement> {}
 
-const SSelect = styled.select<IDropdownProps>`
+const Option: React.FunctionComponent<IOption> = styled.option``;
+const Dropdown: React.FunctionComponent<IDropdownProps> = styled.select<IDropdownProps>`
   appearance: none;
 
   background: ${colors.base.white} url(${chevronDown}) no-repeat calc(100% - 13px) center;
@@ -35,12 +36,5 @@ const SSelect = styled.select<IDropdownProps>`
   }
 `;
 
-const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
-  return <SSelect {...props} />;
-};
-
 export default Dropdown;
-
-export const Option: React.FunctionComponent<IOption> = props => {
-  return <option {...props} />;
-};
+export { Option };

--- a/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`<Dropdown /> renders the Dropdown with one option 1`] = `
   class="c0"
 >
   <option
+    class=""
     value="first"
   >
     First value
@@ -59,11 +60,13 @@ exports[`<Dropdown /> renders the Dropdown with options 1`] = `
   class="c0"
 >
   <option
+    class=""
     value="first"
   >
     First value
   </option>
   <option
+    class=""
     value="second"
   >
     Second value
@@ -97,11 +100,13 @@ exports[`<Dropdown /> renders the Dropdown with options and a default selected v
   class="c0"
 >
   <option
+    class=""
     value="otherValue"
   >
     Other Value
   </option>
   <option
+    class=""
     selected=""
     value="defaultValue"
   >
@@ -136,16 +141,19 @@ exports[`<Dropdown /> renders the Dropdown with options passed through an array.
   class="c0"
 >
   <option
+    class=""
     value=""
   >
     Select a value
   </option>
   <option
+    class=""
     value="value1"
   >
     value1
   </option>
   <option
+    class=""
     value="value2"
   >
     value2

--- a/src/components/atoms/ErrorMessage/ErrorMessage.md
+++ b/src/components/atoms/ErrorMessage/ErrorMessage.md
@@ -2,4 +2,8 @@ Error message for input Components. This component is meant to be used with an i
 
 For a more complex component check `TextField`.
 
-    <ErrorMessage>Oops ! There has been an error !</ErrorMessage>
+```jsx
+import { ErrorMessage } from '@zopauk/react-components';
+
+<ErrorMessage>Oops ! There has been an error !</ErrorMessage>;
+```

--- a/src/components/atoms/HelpText/HelpText.md
+++ b/src/components/atoms/HelpText/HelpText.md
@@ -2,4 +2,8 @@ Additional information for input Components. This component is meant to be used 
 
 For a more complex component check `TextField`.
 
-    <HelpText>Additional information</HelpText>
+```jsx
+import { HelpText } from '@zopauk/react-components';
+
+<HelpText>Additional information</HelpText>;
+```

--- a/src/components/atoms/InputLabel/InputLabel.md
+++ b/src/components/atoms/InputLabel/InputLabel.md
@@ -3,5 +3,7 @@ Label for input Components. This component is meant to be used with an input.
 For a more complex component check `TextField`.
 
 ```jsx
-<InputLabel htmlFor="username">Username</InputLabel>
+import { InputLabel } from '@zopauk/react-components';
+
+<InputLabel htmlFor="username">Username</InputLabel>;
 ```

--- a/src/components/atoms/InputText/InputText.md
+++ b/src/components/atoms/InputText/InputText.md
@@ -3,23 +3,31 @@ Input native component. Simple component for input text, for more complex approa
 #### Default state
 
 ```jsx
-<InputText name="default" defaultValue="example of input" />
+import { InputText } from '@zopauk/react-components';
+
+<InputText name="default" defaultValue="example of input" />;
 ```
 
 #### IsValid
 
 ```jsx
-<InputText name="isValid" isValid={true} />
+import { InputText } from '@zopauk/react-components';
+
+<InputText name="isValid" isValid={true} />;
 ```
 
 #### hasError
 
 ```jsx
-<InputText name="error" hasError={true} />
+import { InputText } from '@zopauk/react-components';
+
+<InputText name="error" hasError={true} />;
 ```
 
 #### Disabled
 
 ```jsx
-<InputText name="disabled" disabled={true} value="Ha ! You cannot edit me !" />
+import { InputText } from '@zopauk/react-components';
+
+<InputText name="disabled" disabled={true} value="Ha ! You cannot edit me !" />;
 ```

--- a/src/components/atoms/Link/Link.md
+++ b/src/components/atoms/Link/Link.md
@@ -15,7 +15,7 @@ Creates a hyperlink to other web pages, files, locations within the same page, e
 Component with `target="_blank"`:
 
 ```js
-import Lead from 'zopa-react-components/components/typography/Lead/Lead';
+import { Lead, Link } from '@zopauk/react-components';
 
 <Lead>
   Lead component text with
@@ -28,7 +28,7 @@ import Lead from 'zopa-react-components/components/typography/Lead/Lead';
 Component without `target="_blank"` (notice that the square disappeared!)
 
 ```js
-import Lead from 'zopa-react-components/components/typography/Lead/Lead';
+import { Lead, Link } from '@zopauk/react-components';
 
 <Lead>
   Lead component text with

--- a/src/components/atoms/SidekickCard/SidekickCard.md
+++ b/src/components/atoms/SidekickCard/SidekickCard.md
@@ -11,10 +11,12 @@ There are 3 types of SidekickCards:
 For success messages. It shows a green left border and a green check mark.
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { SidekickCard } from '@zopauk/react-components';
+
 <SidekickCard type="triumph">
   <h2>The action has been successfully completed</h2>
   <p>Awesome everything is alright</p>
-</SidekickCard>
+</SidekickCard>;
 ```
 
 #### verified type
@@ -22,10 +24,12 @@ For success messages. It shows a green left border and a green check mark.
 For verification messages. It shows a green left border and a green squiggly circle check mark.
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { SidekickCard } from '@zopauk/react-components';
+
 <SidekickCard type="verified">
   <h2>Your account has been verfied</h2>
   <p>You can star using your account now :)</p>
-</SidekickCard>
+</SidekickCard>;
 ```
 
 #### alert type
@@ -33,8 +37,10 @@ For verification messages. It shows a green left border and a green squiggly cir
 For alert/warning messages. It shows a yellow left border and a yellow warning icon.
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+import { SidekickCard } from '@zopauk/react-components';
+
 <SidekickCard type="alert">
   <h2>The action has a problem</h2>
   <p>Ops, something went wrong</p>
-</SidekickCard>
+</SidekickCard>;
 ```

--- a/src/components/atoms/Spinner/Spinner.md
+++ b/src/components/atoms/Spinner/Spinner.md
@@ -1,5 +1,12 @@
 Spinner component
 
 ```js
-<Spinner backgroundColor="#EDEDF0" frontColor="#4DD9CB" size="100px" borderWidth="16px" />
+import { colors, Spinner } from '@zopauk/react-components';
+
+<Spinner
+  backgroundColor={colors.extended.blue25}
+  frontColor={colors.primary.teal600}
+  size="100px"
+  borderWidth="16px"
+/>;
 ```

--- a/src/components/icons/Alert/Alert.md
+++ b/src/components/icons/Alert/Alert.md
@@ -1,5 +1,7 @@
 An Alert icon
 
 ```js
-<Alert size="24px" fillColor="rebeccaPurple" />
+import { Alert as AlertIcon } from '@zopauk/react-components';
+
+<AlertIcon size="24px" fillColor="rebeccaPurple" />;
 ```

--- a/src/components/icons/Arrow/Arrow.md
+++ b/src/components/icons/Arrow/Arrow.md
@@ -1,12 +1,17 @@
 This component is a wrapper around the svg code for Arrow's icon.
 
-Allowed directions are 'down' | 'up' | 'left' | 'right' | number | string
+Allowed directions are: `down` | `up` | `left` | `right` | `number` | `string`
 
 ```jsx
-<Arrow color="blue" direction="down"/>
-<Arrow color="blue" direction="up"/>
-<Arrow color="blue" direction="left"/>
-<Arrow color="blue" direction="right"/>
-<Arrow color="blue" direction={45}/>
-<Arrow color="blue" direction="225"/>
+import { Fragment } from 'react';
+import { Arrow as ArrowIcon } from '@zopauk/react-components';
+
+<Fragment>
+  <ArrowIcon color="blue" direction="down" />
+  <ArrowIcon color="blue" direction="up" />
+  <ArrowIcon color="blue" direction="left" />
+  <ArrowIcon color="blue" direction="right" />
+  <ArrowIcon color="blue" direction={45} />
+  <ArrowIcon color="blue" direction="225" />
+</Fragment>;
 ```

--- a/src/components/icons/CheckMark/CheckMark.md
+++ b/src/components/icons/CheckMark/CheckMark.md
@@ -1,5 +1,7 @@
 Wrapper around svg code for a checkmark icon.
 
 ```jsx
-<CheckMark />
+import { CheckMark as CheckMarkIcon } from '@zopauk/react-components';
+
+<CheckMarkIcon />;
 ```

--- a/src/components/icons/Chevron/Chevron.md
+++ b/src/components/icons/Chevron/Chevron.md
@@ -3,10 +3,15 @@ This component is a wrapper around the svg code for Chevron's icon.
 Allowed directions are 'down' | 'up' | 'left' | 'right' | number | string
 
 ```jsx
-<Chevron color="blue" direction="down"/>
-<Chevron color="blue" direction="up"/>
-<Chevron color="blue" direction="left"/>
-<Chevron color="blue" direction="right"/>
-<Chevron color="blue" direction={45}/>
-<Chevron color="blue" direction="225"/>
+import { Fragment } from 'react';
+import { Chevron as ChevronIcon } from '@zopauk/react-components';
+
+<Fragment>
+  <ChevronIcon color="blue" direction="down" />
+  <ChevronIcon color="blue" direction="up" />
+  <ChevronIcon color="blue" direction="left" />
+  <ChevronIcon color="blue" direction="right" />
+  <ChevronIcon color="blue" direction={45} />
+  <ChevronIcon color="blue" direction="225" />
+</Fragment>;
 ```

--- a/src/components/icons/Facebook/Facebook.md
+++ b/src/components/icons/Facebook/Facebook.md
@@ -1,7 +1,12 @@
 This component is a wrapper around the svg code for Facebook's icon.
 
 ```jsx
-<Facebook size="24px" />
-<Facebook size="36px" />
-<Facebook size="48px" />
+import { Fragment } from 'react';
+import { Facebook as FacebookIcon } from '@zopauk/react-components';
+
+<Fragment>
+  <FacebookIcon size="24px" />
+  <FacebookIcon size="36px" />
+  <FacebookIcon size="48px" />
+</Fragment>;
 ```

--- a/src/components/icons/Hamburger/Hamburger.md
+++ b/src/components/icons/Hamburger/Hamburger.md
@@ -1,3 +1,7 @@
 This component is a wrapper around the svg code for Hamburger's icon.
 
-    <Hamburger active size="30px" activeColor="blue" inactiveColor="gray" />
+```jsx
+import { Hamburger as HamburgerIcon } from '@zopauk/react-components';
+
+<HamburgerIcon active size="30px" activeColor="blue" inactiveColor="gray" />;
+```

--- a/src/components/icons/Profile/Profile.md
+++ b/src/components/icons/Profile/Profile.md
@@ -1,3 +1,7 @@
 This component is a wrapper around the svg code for Profile's icon.
 
-    <Profile active size="24px" activeColor="blue" inactiveColor="gray" />
+```jsx
+import { ProfileIcon } from '@zopauk/react-components';
+
+<ProfileIcon active size="24px" activeColor="blue" inactiveColor="gray" />;
+```

--- a/src/components/icons/Twitter/Twitter.md
+++ b/src/components/icons/Twitter/Twitter.md
@@ -1,7 +1,12 @@
 This component is a wrapper around the svg code for Twitter's icon.
 
 ```jsx
-<Twitter size="24" />
-<Twitter size="36" />
-<Twitter size="48" />
+import { Fragment } from 'react';
+import { Twitter as TwitterIcon } from '@zopauk/react-components';
+
+<Fragment>
+  <TwitterIcon size="24" />
+  <TwitterIcon size="36" />
+  <TwitterIcon size="48" />
+</Fragment>;
 ```

--- a/src/components/icons/ZopaLogo/ZopaLogo.md
+++ b/src/components/icons/ZopaLogo/ZopaLogo.md
@@ -1,3 +1,7 @@
 This component is a wrapper around the svg code for Zopa's logo.
 
-    <ZopaLogo width="70px" height="50px" color="red" />
+```jsx
+import { ZopaLogo as ZopaLogoIcon } from '@zopauk/react-components';
+
+<ZopaLogoIcon width="70px" height="50px" color="red" />;
+```

--- a/src/components/layout/FlexCol/FlexCol.md
+++ b/src/components/layout/FlexCol/FlexCol.md
@@ -3,8 +3,7 @@ The `FlexCol` component is meant to be used a child component of `FlexRow` as it
 Standard grid:
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer gutter={0}>
   <FlexRow>
@@ -24,8 +23,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Content based grid (collapsing on mobile)
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow>
@@ -42,8 +40,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Flexbox responsive layouts:
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow justify="space-between">
@@ -60,8 +57,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Layout with a column hidden on small screen:
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow justify="space-between">
@@ -78,8 +74,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Grid aligned vertically:
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow align="center">
@@ -96,8 +91,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Each column with different vertical alignment
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow>
@@ -120,8 +114,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Grid with custom gutter (48px):
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow gutter={48}>
@@ -141,8 +134,7 @@ import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
 Grid with custom number of column (5):
 
 ```jsx
-import FlexContainer from 'zopa-react-components/components/layout/FlexContainer/FlexContainer';
-import FlexRow from 'zopa-react-components/components/layout/FlexRow/FlexRow';
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 
 <FlexContainer>
   <FlexRow cols={5}>

--- a/src/components/layout/FlexContainer/FlexContainer.md
+++ b/src/components/layout/FlexContainer/FlexContainer.md
@@ -1,2 +1,3 @@
-The `FlexContainer` component is meant to be used as a wrapper for grid built of `FlexRow`s and `FlexCol`s.
-It sets the grid's max-width and centers it horizontally.
+`<FlexContainer />` component is meant to be used as a wrap `<FlexRow />` when building a grid.
+
+Its responsibility is to set the grid's `max-width`, `gutter` and making sure it's centred horizontally within the viewport.

--- a/src/components/layout/FlexRow/FlexRow.md
+++ b/src/components/layout/FlexRow/FlexRow.md
@@ -1,3 +1,5 @@
-The `FlexRow` component is usually used as a child of `FlexContainer`s.
-However, in case of nested grids it can also be a child of a `FlexCol` or any div element.
-`FlexCol`s should be his direct children.
+`<FlexRow />` is meant to be a child of `<FlexContainer />`.
+
+If your goal is to make a nested layout, then it can also be a child of a `<FlexCol />` or any JSX element.
+
+**Be mindful** that `<FlexCol />` should be his direct child.

--- a/src/components/layout/SizedContainer/SizedContainer.md
+++ b/src/components/layout/SizedContainer/SizedContainer.md
@@ -1,37 +1,41 @@
-Component that basically adds max-width to components. This component is meant to be used other components such as input.
-
-For a more complex component check `TextField`.
-
-_The dashed border is only shown for example purposes_
+Use `<SiedContainer />` to set a `max-width` around its children:
 
 #### Short size
 
 ```jsx
+import { SizedContainer } from '@zopauk/react-components';
+
 <SizedContainer size="short">
-  <div style={{ border: '2px dashed navy', height: '100%' }}>This is a container</div>
-</SizedContainer>
+  <div style={{ backgroundColor: 'tomato', height: '100%' }}>This is a container</div>
+</SizedContainer>;
 ```
 
 #### Medium size
 
 ```jsx
+import { SizedContainer } from '@zopauk/react-components';
+
 <SizedContainer size="medium">
-  <div style={{ border: '2px dashed navy', height: '100%' }}>This is a container</div>
-</SizedContainer>
+  <div style={{ backgroundColor: 'tomato', height: '100%' }}>This is a container</div>
+</SizedContainer>;
 ```
 
 #### Long size
 
 ```jsx
+import { SizedContainer } from '@zopauk/react-components';
+
 <SizedContainer size="long">
-  <div style={{ border: '2px dashed navy', height: '100%' }}>This is a container</div>
-</SizedContainer>
+  <div style={{ backgroundColor: 'tomato', height: '100%' }}>This is a container</div>
+</SizedContainer>;
 ```
 
 #### FullLength size
 
 ```jsx
+import { SizedContainer } from '@zopauk/react-components';
+
 <SizedContainer size="fullLength">
-  <div style={{ border: '2px dashed navy', height: '100%' }}>This is a container</div>
-</SizedContainer>
+  <div style={{ backgroundColor: 'tomato', height: '100%' }}>This is a container</div>
+</SizedContainer>;
 ```

--- a/src/components/molecules/CheckboxField/CheckboxField.md
+++ b/src/components/molecules/CheckboxField/CheckboxField.md
@@ -14,25 +14,35 @@ This is a wrapper of 2 different components:
 #### Default state
 
 ```jsx
-<CheckboxField inputProps={{ name: 'check1' }} />
+import { CheckboxField } from '@zopauk/react-components';
+
+<CheckboxField inputProps={{ name: 'check1' }} />;
 ```
 
 #### Checked
 
 ```jsx
-<CheckboxField inputProps={{ name: 'text2', defaultChecked: true }} />
+import { CheckboxField } from '@zopauk/react-components';
+
+<CheckboxField inputProps={{ name: 'text2', defaultChecked: true }} />;
 ```
 
 #### With label
 
 ```jsx
-<CheckboxField label="Do you accept?" inputProps={{name: 'text3', defaultChecked: true}} />
-<CheckboxField label="Are you sure?" inputProps={{name: 'text4'}} />
-<CheckboxField label="Do you really accept?" inputProps={{name: 'text5'}} />
+import { CheckboxField } from '@zopauk/react-components';
+
+<>
+  <CheckboxField label="Do you accept?" inputProps={{ name: 'text3', defaultChecked: true }} />
+  <CheckboxField label="Are you sure?" inputProps={{ name: 'text4' }} />
+  <CheckboxField label="Do you really accept?" inputProps={{ name: 'text5' }} />
+</>;
 ```
 
 #### With error
 
 ```jsx
-<CheckboxField label="Do you agree?" errorMessage="Oops! You forgot to check this" inputProps={{ name: 'text6' }} />
+import { CheckboxField } from '@zopauk/react-components';
+
+<CheckboxField label="Do you agree?" errorMessage="Oops! You forgot to check this" inputProps={{ name: 'text6' }} />;
 ```

--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.md
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.md
@@ -33,6 +33,8 @@ Under the hood:
 Basic example:
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { value: 'grape' }, { value: 'banana' }];
 
 <DropdownFiltered
@@ -50,6 +52,8 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 #### With default value
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { value: 'grape' }, { value: 'banana' }];
 
 <DropdownFiltered
@@ -68,6 +72,8 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 #### Long list and a optionsListMaxHeight
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [
   { alpha2: 'GB', value: 'British' },
   { alpha2: 'AO', value: 'Angolan' },
@@ -138,6 +144,8 @@ const items = [
 #### With errorMessage
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { value: 'grape' }, { value: 'banana' }];
 
 <DropdownFiltered
@@ -156,6 +164,8 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 #### isValid
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { value: 'grape' }, { value: 'banana' }];
 
 <DropdownFiltered
@@ -174,6 +184,8 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 #### disabled
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { value: 'grape' }, { value: 'banana' }];
 
 <DropdownFiltered
@@ -193,6 +205,8 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 #### size is "short"
 
 ```jsx
+import { DropdownFiltered } from '@zopauk/react-components';
+
 const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { value: 'grape' }, { value: 'banana' }];
 
 <DropdownFiltered

--- a/src/components/molecules/Help/Help.md
+++ b/src/components/molecules/Help/Help.md
@@ -1,5 +1,7 @@
 This is a Help component that should sit ontop of the Footer to give the customer information about our opening hours and the phone numbers to call for specific products.
 
 ```jsx
-<Help email="savings@zopa.com" />
+import { Help } from '@zopauk/react-components';
+
+<Help email="savings@zopa.com" />;
 ```

--- a/src/components/molecules/Modal/Modal.md
+++ b/src/components/molecules/Modal/Modal.md
@@ -11,26 +11,15 @@ All the props are being passed down to `react-modal` so if you want to customize
 - Note that in order to make `<Modal />` to close when the user clicks on the overlay, you'll need to do so in a handler supplied to the `onRequestClose` prop. See [`react-modal` documentation](http://reactcommunity.org/react-modal/examples/on_request_close.html) for more background about this.
 
 ```jsx
-import Button from 'zopa-react-components/components/atoms/Button/Button';
+import { Modal, Button } from '@zopauk/react-components';
 
-// set it to the root element
+// Sets where there should be inserted within the DOM
 Modal.setAppElement('#rsg-root');
 
-// root component
-class App extends React.Component {
-  render() {
-    return (
-      <div>
-        <Modal.Styles />
-        <ModalDemo />
-      </div>
-    );
-  }
-}
-
-const ModalDemo = () => {
+function ModalDemo() {
   const [isOpen, update] = React.useState(false);
   const toggleModal = () => update(prevState => !prevState);
+
   return (
     <>
       <Button onClick={toggleModal} styling="link">
@@ -45,7 +34,10 @@ const ModalDemo = () => {
       </Modal>
     </>
   );
-};
+}
 
-<App />;
+<>
+  <Modal.Styles />
+  <ModalDemo />
+</>;
 ```

--- a/src/components/molecules/Progress/Progress.md
+++ b/src/components/molecules/Progress/Progress.md
@@ -1,3 +1,7 @@
 Progress bar to show the current step of a journey and its total steps.
 
-    <Progress totalSteps="4" currentStep="2" style={{ backgroundColor: "#F6F6F6" }} />
+```jsx { "props": { "style": { "padding": "20px 10px 30px" } } }
+import { colors, Progress } from '@zopauk/react-components';
+
+<Progress totalSteps="4" currentStep="2" style={{ backgroundColor: colors.neutral.neutral25 }} />;
+```

--- a/src/components/molecules/RadioField/RadioField.md
+++ b/src/components/molecules/RadioField/RadioField.md
@@ -1,81 +1,84 @@
-RadioField is a single radio button element.
+`<RadioField />` is a single radio field element.
 
-The error message is not shown because it's mean to be shown in a group of radio buttons.
+Its error message is meant to be shown in a group of them.
 
-It's build with 3 html elements:
+It's composed of three HTML elements:
 
-- `input`: Input radio component. It is hidden for styling purposes. The label component is the one in charge of this styling.
-- `label`: Text to show next to the radio button. It's attached to the input and not build as an standalone component because
-  it uses `after` and `before` to style the circle of the radio button.
-- `div`: Container
+- `input`: input radio component, hidden for styling purposes\_
+- `label`: text to show next to the radio field. It uses CSS `::after` and `::before` to draw the actual circles of the radio field
+- `div`: container to wrap the two previous elements.
 
-`inputProps.value` must be set so it's used to automatically set:
+`value` must be provided so that it internally sets:
 
-- `htmlFor` in the `InputLabel` component.
-- `id` in `InputRadio` for automation test purposes.
+- `htmlFor` prop on the `<InputLabel />` component.
+- `id` prop on `<InputRadio />` so that is easily to query (.i.e automated tests).
 
-#### Default
+#### default
 
 ```jsx
-<RadioField label="Option 1" inputProps={{ value: 'radio1', name: 'radio1' }} />
+import { RadioField } from '@zopauk/react-components';
+
+<RadioField label="option" inputProps={{ value: 'option', name: 'option' }} />;
 ```
 
-#### hasError
+#### with error
 
 ```jsx
-<RadioField hasError={true} label="Option 2" inputProps={{ value: 'radio2', name: 'radio2' }} />
+import { RadioField } from '@zopauk/react-components';
+
+<RadioField hasError={true} label="option" inputProps={{ value: 'radio2', name: 'radio2' }} />;
 ```
 
-#### isValid
+#### valid
 
 ```jsx
-<RadioField isValid={true} label="Option 2" inputProps={{ value: 'radio3', name: 'radio2' }} />
+import { RadioField } from '@zopauk/react-components';
+
+<RadioField isValid={true} label="option" inputProps={{ value: 'radio3', name: 'radio3' }} />;
 ```
 
-#### defaultChecked
+#### pre-selected
 
 ```jsx
-  <RadioField label="Option 3" inputProps={{value: 'radio3', name: 'radio4', defaultChecked: true}} />
-  <RadioField label="Option 4" inputProps={{value: 'radio4', name: 'radio4'}} />
+import { RadioField } from '@zopauk/react-components';
+
+<RadioField label="I'm checked by default" inputProps={{ value: 'radio4', name: 'radio4', defaultChecked: true }} />;
 ```
 
-#### Disabled + defaultChecked
+#### disabled and pre-selected
 
 ```jsx
-  <RadioField label="Option 5" inputProps={{value: 'radio5', name: 'radio5', disabled: true, defaultChecked: true }}/>
-  <RadioField label="Option 6" inputProps={{value: 'radio6', name: 'radio5', disabled: true}} />
+import { RadioField } from '@zopauk/react-components';
+
+<RadioField
+  label="I'm disabled and checked"
+  inputProps={{ value: 'radio5', name: 'radio5', disabled: true, defaultChecked: true }}
+/>;
 ```
 
-#### Disabled + defaultChecked + isValid
+#### disabled, valid and pre-selected
 
 ```jsx
-  <RadioField label="Option 5" isValid={true} inputProps={{value: 'radio5', name: 'radio6', disabled: true, defaultChecked: true }}/>
-  <RadioField label="Option 6" isValid={true} inputProps={{value: 'radio6', name: 'radio6', disabled: true}} />
+import { RadioField } from '@zopauk/react-components';
+
+<RadioField
+  label="I'm disabled, valid and checked"
+  isValid={true}
+  inputProps={{ value: 'radio6', name: 'radio6', disabled: true, defaultChecked: true }}
+/>;
 ```
 
-## Long list
+#### multiple choices
 
 ```jsx
-<div style={{ margin: '24px 0px', maxHeight: '150px', overflow: 'auto' }}>
-  <RadioField label="Option 1" inputProps={{ value: 'radio 1', name: 'radio7' }} />
-  <RadioField label="Option 2" inputProps={{ value: 'radio 2', name: 'radio7' }} />
-  <RadioField label="Option 3" inputProps={{ value: 'radio 3', name: 'radio7' }} />
-  <RadioField label="Option 4" inputProps={{ value: 'radio 4', name: 'radio7' }} />
-  <RadioField label="Option 5" inputProps={{ value: 'radio 5', name: 'radio7' }} />
-  <RadioField label="Option 6" inputProps={{ value: 'radio 6', name: 'radio7' }} />
-  <RadioField label="Option 7" inputProps={{ value: 'radio 7', name: 'radio7' }} />
-  <RadioField label="Option 8" inputProps={{ value: 'radio 8', name: 'radio7' }} />
-  <RadioField label="Option 9" inputProps={{ value: 'radio 9', name: 'radio7' }} />
-  <RadioField label="Option 10" inputProps={{ value: 'radio 10', name: 'radio7' }} />
-  <RadioField label="Option 11" inputProps={{ value: 'radio 11', name: 'radio7' }} />
-  <RadioField label="Option 12" inputProps={{ value: 'radio 12', name: 'radio7' }} />
-  <RadioField label="Option 13" inputProps={{ value: 'radio 13', name: 'radio7' }} />
-  <RadioField label="Option 14" inputProps={{ value: 'radio 14', name: 'radio7' }} />
-  <RadioField label="Option 15" inputProps={{ value: 'radio 15', name: 'radio7' }} />
-  <RadioField label="Option 16" inputProps={{ value: 'radio 16', name: 'radio7' }} />
-  <RadioField label="Option 17" inputProps={{ value: 'radio 17', name: 'radio7' }} />
-  <RadioField label="Option 18" inputProps={{ value: 'radio 18', name: 'radio7' }} />
-  <RadioField label="Option 20" inputProps={{ value: 'radio 20', name: 'radio7' }} />
-  <RadioField label="Option 21" inputProps={{ value: 'radio 21', name: 'radio7' }} />
-</div>
+import { RadioField } from '@zopauk/react-components';
+
+<>
+  <RadioField label="Apple 🍏" inputProps={{ value: 'apple', name: 'apple-choice' }} />
+  <RadioField label="Avocado 🥑" inputProps={{ value: 'avocado', name: 'avocado-choice' }} />
+  <RadioField label="Chilly 🌶" inputProps={{ value: 'chilly', name: 'chilly-choice' }} />
+  <RadioField label="Sweet Potato 🍠" inputProps={{ value: 'potato', name: 'potato-choice' }} />
+  <RadioField label="Kiwi 🥝" inputProps={{ value: 'kiwi', name: 'kiwi-choice' }} />
+  <RadioField label="Watermelon 🍉" inputProps={{ value: 'watermelon', name: 'watermelon-choice' }} />
+</>;
 ```

--- a/src/components/molecules/TextField/TextField.md
+++ b/src/components/molecules/TextField/TextField.md
@@ -1,57 +1,67 @@
-This is a wrapper of 4 different components:
+`<TextField /> is a wrapper composed of four different components:
 
-- SizedContainer: Div container with size prop.
-- InputText: Native input text.
-- InputLabel: Label text. Only rendered if the prop `label` is filled in.
-- HelpText: Addition information.
-- SizedContainer: Error message. Only rendered if the prop `errorMessage` is filled in.
+- `<SizedContainer />` ... ( _container with `size` prop_ )
+- `<InputText />` ... ( _native input text_ )
+- `<InputLabel />` ... ( _label text, only rendered if the prop `label` is provided_ )
+- `<HelpText />` ... ( _addition information_ )
+- `<SizedContainer />` ... ( _error message, only rendered if the prop `errorMessage` provided_ )
 
-`inputProps.name` must be set so it's used to automatically set:
+`name` must be provided to automatically set:
 
-- `htmlFor` in the `InputLabel` component.
-- `data-automation` in the `ErrorMessage`
-- `id` in `InputText` for automation test purposes.
+- `htmlFor` prop on `<InputLabel />`
+- `data-automation` prop on `<ErrorMessage />`
+- `id` prop on `<InputText />`
 
-All the designs follows the conventions specified in [Marvel](https://marvelapp.com/9hj9j4b/screen/48160210/handoff).
-
-#### Default
+#### default
 
 ```jsx
-<TextField inputProps={{ name: 'text1' }} />
+import { TextField } from '@zopauk/react-components';
+
+<TextField inputProps={{ name: 'text1' }} />;
 ```
 
-#### Specific size
+#### specific size
 
 ```jsx
-<TextField size="short" inputProps={{ name: 'text2' }} />
+import { TextField } from '@zopauk/react-components';
+
+<TextField size="short" inputProps={{ name: 'text2' }} />;
 ```
 
-#### With label
+#### with label
 
 ```jsx
-<TextField label="First name" inputProps={{ name: 'text3' }} />
+import { TextField } from '@zopauk/react-components';
+
+<TextField label="First name" inputProps={{ name: 'text3' }} />;
 ```
 
-#### With error message
+#### with error message
 
 ```jsx
-<TextField errorMessage="Oops ! Error !" inputProps={{ name: 'text4' }} />
+import { TextField } from '@zopauk/react-components';
+
+<TextField errorMessage="Oops ! Error !" inputProps={{ name: 'text4' }} />;
 ```
 
-#### isValid
+#### valid
 
 ```jsx
-<TextField isValid={true} inputProps={{ name: 'text5' }} />
+import { TextField } from '@zopauk/react-components';
+
+<TextField isValid={true} inputProps={{ name: 'text5' }} />;
 ```
 
-#### With label, helpText, errorMessage and size props
+#### with label, help text, error message and specific size
 
 ```jsx
+import { TextField } from '@zopauk/react-components';
+
 <TextField
   label="Label"
   helpText="Additional info"
   errorMessage="Not ok!"
   size="short"
   inputProps={{ name: 'text6' }}
-/>
+/>;
 ```

--- a/src/components/molecules/ZopaFooter/ZopaFooter.md
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.md
@@ -1,15 +1,19 @@
-ZopaFooter renders Zopa's standard footer with default links with the ability to provide custom links.
+ZopaFooter renders Zopa's standard footer with default links and the ability to provide custom links.
 
-#### Default
+#### default
 
 ```jsx
-<ZopaFooter />
+import { ZopaFooter } from '@zopauk/react-components';
+
+<ZopaFooter />;
 ```
 
-#### legalOnly flag
+#### only legal section
 
-You can also reduce the footer to just legal copy on pages where you need the user to focus on a specific task like form applications
+You can also reduce the footer to just the legal section on pages where you need the user to focus on a specific task like form applications.
 
 ```jsx
-<ZopaFooter legalOnly />
+import { ZopaFooter } from '@zopauk/react-components';
+
+<ZopaFooter legalOnly />;
 ```

--- a/src/components/organisms/Accordion/Accordion.md
+++ b/src/components/organisms/Accordion/Accordion.md
@@ -1,10 +1,10 @@
-Accordion doesn't render anything, it's just a namespace for `Accordion.Header` and `Accordion.Section` components. In order to create an accordion example,
-you should use these components along with `useAccordion` hook. It is done this way to allow for greater flexibility. See the example below for more details.
+Accordion doesn't render anything: it's just a namespace for `<Accordion.Header />` and `<Accordion.Section />` components.
 
-Basic example:
+In order to create an accordion, you should use these components along with the `useAccordion` hook.
+See the example below for more details.
 
 ```js
-import useAccordion from 'zopa-react-components/components/hooks/useAccordion/useAccordion';
+import { useAccordion } from '@zopauk/react-components';
 
 const AccordionExample = () => {
   const { getHeaderProps, getSectionProps, isActiveSection } = useAccordion();
@@ -25,6 +25,7 @@ const AccordionExample = () => {
       section: 'section three',
     },
   ];
+
   return (
     <div aria-label="accordion example">
       {items.map(({ id, header, section }, index) => (

--- a/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.md
+++ b/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.md
@@ -1,9 +1,9 @@
-This is a Accordion subcomponent and it is meant to be used along with other components such as `AccordionSection` and `useAccordion` hook. It is a button with a chevron icon that rotates according to the `isOpen` prop.
+This is a `Accordion` subcomponent and it is meant to be used along with other components such as `<AccordionSection />` and `useAccordion` hook. It is a button with a chevron icon that rotates according to the `isOpen` prop.
 
 Opened Accordion.Header
 
 ```js
-import Accordion from 'zopa-react-components/components/organisms/Accordion/Accordion';
+import { Accordion } from '@zopauk/react-components';
 
 <Accordion.Header isOpen={true}>opened accordion header</Accordion.Header>;
 ```
@@ -11,7 +11,7 @@ import Accordion from 'zopa-react-components/components/organisms/Accordion/Acco
 Closed Accordion.Header
 
 ```js
-import Accordion from 'zopa-react-components/components/organisms/Accordion/Accordion';
+import { Accordion } from '@zopauk/react-components';
 
 <Accordion.Header isOpen={false}>closed accordion header</Accordion.Header>;
 ```

--- a/src/components/organisms/Accordion/AccordionSection/AccordionSection.md
+++ b/src/components/organisms/Accordion/AccordionSection/AccordionSection.md
@@ -1,1 +1,5 @@
-This is a Accordion subcomponent and it is meant to be used along with other components such as `AccordionHeader` and `useAccordion` hook. It is a simple block element that passes down the ref to its content; this, in turn allows the section to be collapsible. Please refer to the `Accordion` documentation to see a working example.
+This is a subcomponent of `<Accordion />` and it is meant to be used along with other components such as `<Accordion.Header />` and the `useAccordion` hook.
+
+It is a simple block element that passes down the ref to its childs. This forwarding allows the section to be collapsible.
+
+Please refer to the `<Accordion />` documentation to see a working example.

--- a/src/components/organisms/Navbar/Navbar.md
+++ b/src/components/organisms/Navbar/Navbar.md
@@ -1,9 +1,7 @@
 Basic example:
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)" } } }
-import Link from 'zopa-react-components/components/atoms/Link/Link';
-import Hamburger from 'zopa-react-components/components/icons/Hamburger/Hamburger';
-import Profile from 'zopa-react-components/components/icons/Profile/Profile';
+import { Navbar, Link, HamburgerIcon, ProfileIcon } from '@zopauk/react-components';
 
 <Navbar.Layout
   backgroundColor="#00B9A7"
@@ -15,7 +13,7 @@ import Profile from 'zopa-react-components/components/icons/Profile/Profile';
       renderOpener={({ open, getOpenerProps }) => (
         <div style={{ padding: 8 }}>
           <Navbar.Link href="#" open={open} {...getOpenerProps()}>
-            <Hamburger size="30px" activeColor="#fff" inactiveColor="#fff" />
+            <HamburgerIcon size="30px" activeColor="#fff" inactiveColor="#fff" />
           </Navbar.Link>
         </div>
       )}
@@ -35,7 +33,7 @@ import Profile from 'zopa-react-components/components/icons/Profile/Profile';
         return (
           <div style={{ padding: 8 }}>
             <Navbar.Link color="#fff" href="#" open={open} {...getOpenerProps()}>
-              <Profile activeColor="#fff" inactiveColor="#fff" />
+              <ProfileIcon activeColor="#fff" inactiveColor="#fff" />
             </Navbar.Link>
           </div>
         );
@@ -53,9 +51,7 @@ import Profile from 'zopa-react-components/components/icons/Profile/Profile';
 Responsive Navbar example:
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)" } } }
-import Hamburger from 'zopa-react-components/components/icons/Hamburger/Hamburger';
-import Link from 'zopa-react-components/components/atoms/Link/Link';
-import FlexCol from 'zopa-react-components/components/layout/FlexCol/FlexCol';
+import { Navbar, Link, HamburgerIcon, FlexCol } from '@zopauk/react-components';
 
 class ResponsiveNavbar extends React.Component {
   constructor(props) {
@@ -75,7 +71,7 @@ class ResponsiveNavbar extends React.Component {
             renderOpener={({ open, getOpenerProps }) => (
               <div style={{ padding: 8 }}>
                 <Navbar.Link color="#fff" href="#" open={open} {...getOpenerProps()}>
-                  <Hamburger size="30px" activeColor="#fff" inactiveColor="#fff" />
+                  <HamburgerIcon size="30px" activeColor="#fff" inactiveColor="#fff" />
                 </Navbar.Link>
               </div>
             )}

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
@@ -3,7 +3,7 @@ This is a flexible Navbar subcomponent meant to be used with other components su
 Basic example:
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7" } } }
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Dropdown
   id="basic-example-id"
@@ -27,9 +27,7 @@ import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
 Example with custom components:
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7" } } }
-import Link from 'zopa-react-components/components/atoms/Link/Link';
-import Hamburger from 'zopa-react-components/components/icons/Hamburger/Hamburger';
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar, Link, HamburgerIcon } from '@zopauk/react-components';
 
 <Navbar.Dropdown
   id="custom-example-id"
@@ -38,7 +36,7 @@ import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
   renderOpener={({ open, getOpenerProps }) => (
     <div style={{ padding: 8 }}>
       <Link href="#" {...getOpenerProps()}>
-        <Hamburger size="30px" activeColor="#fff" inactiveColor="#fff" />
+        <HamburgerIcon size="30px" activeColor="#fff" inactiveColor="#fff" />
       </Link>
     </div>
   )}

--- a/src/components/organisms/Navbar/NavbarLayout/NavbarLayout.md
+++ b/src/components/organisms/Navbar/NavbarLayout/NavbarLayout.md
@@ -4,8 +4,7 @@ However, it can be used with other atoms and molecules as well (e.g Link). It im
 White Navbar.Layout component
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7" } } }
-import Link from 'zopa-react-components/components/atoms/Link/Link';
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar, Link } from '@zopauk/react-components';
 
 <Navbar.Layout left={<Link>left</Link>} center={<Link>center</Link>} right={<Link>right</Link>} />;
 ```
@@ -13,8 +12,7 @@ import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
 Teal Navbar.Layout component
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#fff" } } }
-import Link from 'zopa-react-components/components/atoms/Link/Link';
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar, Link } from '@zopauk/react-components';
 
 <Navbar.Layout backgroundColor="#00B9A7" left={<Link>left</Link>} right={<Link>right</Link>} />;
 ```

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.md
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.md
@@ -4,7 +4,7 @@ It is the same as Link component except for two extra props: active and withChev
 Default Navbar.Link component
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff">Navbar.Link</Navbar.Link>;
 ```
@@ -12,7 +12,7 @@ import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
 Active Navbar.Link component
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff" active>
   Navbar.Link
@@ -22,7 +22,7 @@ import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
 Navbar.Link withChevron down
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff" withChevron open={false}>
   Navbar.Link
@@ -32,7 +32,7 @@ import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
 Navbar.Link withChevron up
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
-import Navbar from 'zopa-react-components/components/organisms/Navbar/Navbar';
+import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff" withChevron open>
   Navbar.Link

--- a/src/components/typography/Caption/Caption.md
+++ b/src/components/typography/Caption/Caption.md
@@ -1,7 +1,11 @@
 ```js
-<Caption>Caption</Caption>
+import { Caption } from '@zopauk/react-components';
+
+<Caption>Caption</Caption>;
 ```
 
 ```js
-<Caption style={{ textAlign: 'center', color: 'salmon' }}>Caption</Caption>
+import { Caption } from '@zopauk/react-components';
+
+<Caption style={{ textAlign: 'center', color: 'salmon' }}>Caption</Caption>;
 ```

--- a/src/components/typography/Header1/Header1.md
+++ b/src/components/typography/Header1/Header1.md
@@ -1,7 +1,11 @@
 ```js
-<Header1>Header1</Header1>
+import { Header1 } from '@zopauk/react-components';
+
+<Header1>Header1</Header1>;
 ```
 
 ```js
-<Header1 style={{ textAlign: 'center', color: 'salmon' }}>Header1</Header1>
+import { Header1 } from '@zopauk/react-components';
+
+<Header1 style={{ textAlign: 'center', color: 'salmon' }}>Header1</Header1>;
 ```

--- a/src/components/typography/Header2/Header2.md
+++ b/src/components/typography/Header2/Header2.md
@@ -1,7 +1,11 @@
 ```js
-<Header2>Header2</Header2>
+import { Header2 } from '@zopauk/react-components';
+
+<Header2>Header2</Header2>;
 ```
 
 ```js
-<Header2 style={{ textAlign: 'center', color: 'salmon' }}>Header2</Header2>
+import { Header2 } from '@zopauk/react-components';
+
+<Header2 style={{ textAlign: 'center', color: 'salmon' }}>Header2</Header2>;
 ```

--- a/src/components/typography/Header3/Header3.md
+++ b/src/components/typography/Header3/Header3.md
@@ -1,7 +1,11 @@
 ```js
-<Header3>Header3</Header3>
+import { Header3 } from '@zopauk/react-components';
+
+<Header3>Header3</Header3>;
 ```
 
 ```js
-<Header3 style={{ textAlign: 'center', color: 'salmon' }}>Header3</Header3>
+import { Header3 } from '@zopauk/react-components';
+
+<Header3 style={{ textAlign: 'center', color: 'salmon' }}>Header3</Header3>;
 ```

--- a/src/components/typography/Lead/Lead.md
+++ b/src/components/typography/Lead/Lead.md
@@ -1,7 +1,11 @@
 ```js
-<Lead>Lead</Lead>
+import { Lead } from '@zopauk/react-components';
+
+<Lead>Lead</Lead>;
 ```
 
 ```js
-<Lead style={{ textAlign: 'center', color: 'salmon' }}>Lead</Lead>
+import { Lead } from '@zopauk/react-components';
+
+<Lead style={{ textAlign: 'center', color: 'salmon' }}>Lead</Lead>;
 ```

--- a/src/components/typography/Subhead/Subhead.md
+++ b/src/components/typography/Subhead/Subhead.md
@@ -1,7 +1,11 @@
 ```js
-<Subhead>Subhead</Subhead>
+import { Subhead } from '@zopauk/react-components';
+
+<Subhead>Subhead</Subhead>;
 ```
 
 ```js
-<Subhead style={{ textAlign: 'center', color: 'salmon' }}>Subhead</Subhead>
+import { Subhead } from '@zopauk/react-components';
+
+<Subhead style={{ textAlign: 'center', color: 'salmon' }}>Subhead</Subhead>;
 ```

--- a/src/components/typography/Text/Text.md
+++ b/src/components/typography/Text/Text.md
@@ -3,55 +3,71 @@ Text component
 ### Text sizes
 
 ```jsx
-<div>
-  <Text size="xl">Extra large</Text>
-</div>
-<div>
-  <Text size="l">Large</Text>
-</div>
-<div>
-  <Text size="m">Medium (default)</Text>
-</div>
-<div>
-  <Text size="s">Small</Text>
-</div>
-<div>
-  <Text size="xs">Extra small</Text>
-</div>
+import { Text } from '@zopauk/react-components';
+
+<>
+  <div>
+    <Text size="xl">Extra large</Text>
+  </div>
+  <div>
+    <Text size="l">Large</Text>
+  </div>
+  <div>
+    <Text size="m">Medium (default)</Text>
+  </div>
+  <div>
+    <Text size="s">Small</Text>
+  </div>
+  <div>
+    <Text size="xs">Extra small</Text>
+  </div>
+</>;
 ```
 
 ### Text font weights
 
 ```jsx
-<div>
-  <Text fw="normal">Normal (default)</Text>
-</div>
-<div>
-  <Text fw="bold">Bold</Text>
-</div>
+import { Text } from '@zopauk/react-components';
+
+<>
+  <div>
+    <Text fw="normal">Normal (default)</Text>
+  </div>
+  <div>
+    <Text fw="bold">Bold</Text>
+  </div>
+</>;
 ```
 
 ### Text custom colors
 
 ```jsx
-<div>
-  <Text>Default</Text>
-</div>
-<div>
-  <Text color="#00B9A7">Teal</Text>
-</div>
-<div>
-  <Text color="#5E35B1">Indigo</Text>
-</div>
+import { Text } from '@zopauk/react-components';
+
+<>
+  <div>
+    <Text>Default</Text>
+  </div>
+  <div>
+    <Text color="#00B9A7">Teal</Text>
+  </div>
+  <div>
+    <Text color="#5E35B1">Indigo</Text>
+  </div>
+</>;
 ```
 
 ### Text as different html elements
 
 ```jsx
-<div>
-  <Text as="span">Text as span tag (default)</Text>
-</div>
-<div>
-  <Text as="p">Text as p tag</Text>
-</div>
+import { Text } from '@zopauk/react-components';
+
+<>
+  <div>
+    <Text as="span">Text as span tag (default)</Text>
+  </div>
+  <div>
+    <Text as="p">Text as p tag</Text>
+  </div>
+</>;
 ```

--- a/src/components/typography/Title1/Title1.md
+++ b/src/components/typography/Title1/Title1.md
@@ -1,7 +1,11 @@
 ```js
-<Title1>Title1</Title1>
+import { Title1 } from '@zopauk/react-components';
+
+<Title1>Title1</Title1>;
 ```
 
 ```js
-<Title1 style={{ textAlign: 'center', color: 'salmon' }}>Title1</Title1>
+import { Title1 } from '@zopauk/react-components';
+
+<Title1 style={{ textAlign: 'center', color: 'salmon' }}>Title1</Title1>;
 ```

--- a/src/components/typography/Title2/Title2.md
+++ b/src/components/typography/Title2/Title2.md
@@ -1,7 +1,11 @@
 ```js
-<Title2>Title2</Title2>
+import { Title2 } from '@zopauk/react-components';
+
+<Title2>Title2</Title2>;
 ```
 
 ```js
-<Title2 style={{ textAlign: 'center', color: 'salmon' }}>Title2</Title2>
+import { Title2 } from '@zopauk/react-components';
+
+<Title2 style={{ textAlign: 'center', color: 'salmon' }}>Title2</Title2>;
 ```

--- a/src/components/typography/Title3/Title3.md
+++ b/src/components/typography/Title3/Title3.md
@@ -1,7 +1,11 @@
 ```js
-<Title3>Title3</Title3>
+import { Title3 } from '@zopauk/react-components';
+
+<Title3>Title3</Title3>;
 ```
 
 ```js
-<Title3 style={{ textAlign: 'center', color: 'salmon' }}>Title3</Title3>
+import { Title3 } from '@zopauk/react-components';
+
+<Title3 style={{ textAlign: 'center', color: 'salmon' }}>Title3</Title3>;
 ```

--- a/src/content/Colors/Colors.md
+++ b/src/content/Colors/Colors.md
@@ -5,7 +5,7 @@ In the library we have access to the color constants as follows:
 ### Usage
 
 ```js static
-import { colors } from 'zopa-react-components';
+import { colors } from '@zopauk/react-components';
 
 const whiteColor = colors.base.white; // #fff
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,12 @@ export { default as FlexCol } from './components/layout/FlexCol/FlexCol';
 export { default as SizedContainer } from './components/layout/SizedContainer/SizedContainer';
 
 // Icons
+export { default as Arrow } from './components/icons/Arrow/Arrow';
 export { default as Alert } from './components/icons/Alert/Alert';
 export { default as CheckMark } from './components/icons/CheckMark/CheckMark';
+export { default as Chevron } from './components/icons/Chevron/Chevron';
+export { default as Facebook } from './components/icons/Facebook/Facebook';
+export { default as Twitter } from './components/icons/Twitter/Twitter';
 export { default as ZopaLogo } from './components/icons/ZopaLogo/ZopaLogo';
 export { default as HamburgerIcon } from './components/icons/Hamburger/Hamburger';
 export { default as ProfileIcon } from './components/icons/Profile/Profile';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -151,7 +151,7 @@ module.exports = {
     colors: path.resolve(__dirname, './src/constants/colors'),
   },
   moduleAliases: {
-    'zopa-react-components': path.resolve(__dirname, 'src'),
+    '@zopauk/react-components': path.resolve(__dirname, 'src'),
   },
   printServerInstructions,
   ribbon: {


### PR DESCRIPTION
## Summary 🍉

An attempt to fix #16 and #15 along the way 💕

It's opinionated refactor of the **code examples** of the living documentation.

Now, every code example will have the following shape:
```jsx
import { Button } from '@zopauk/react-components'

<Buttom /> // Example usage
``` 
We're **explictly importing** the relevant components from what's pusblished in NPM.  

I see the following benefits:
- when a component is not available through NPM, they won't work ( prevents #16 )
- forces to use the [exposed component name](https://github.com/zopaUK/react-components/blob/master/src/index.ts#L61) in the examples
- it's explicit on how to use this library ( _beginner friendly_ )

In this way, we also don't rely on **Styleguidst** adding the components to `window` properly?

### Other fixes 🔧

#### 1
Whenever we use a colour on the examples, use the colours exposed by the library rather than random ones:
```jsx
<Button styling="contrastPrimary" contrastColor="#141E64" />
// vs
<Button styling="contrastPrimary" contrastColor={colors.primary.navy800} />
```

#### 2
Prevent the usage of inline styles in the examples as much as possible 👌🏻

#### 3
Prevent styling example code block through `<div />`, use **Styleguidst** powers instead.
```jsx
<div style={{ backgroundColor: '#293272' }} />
// vs
jsx { "props": { "style": { "backgroundColor": "#293272" } } }
```

#### 4
Re-word the documentation of some components to be more clear 💬

