### PR TITLE
Fix <HamburgerIcon /> example 

### DIFF
--- a/src/components/icons/Hamburger/Hamburger.md
+++ b/src/components/icons/Hamburger/Hamburger.md
@@ -1,7 +1,7 @@
 This component is a wrapper around the svg code for Hamburger's icon.
 
 ```jsx
-import { Hamburger as HamburgerIcon } from '@zopauk/react-components';
+import { HamburgerIcon } from '@zopauk/react-components';
 
 <HamburgerIcon active size="30px" activeColor="blue" inactiveColor="gray" />;
 ```


### PR DESCRIPTION
Following #31, I imported `<HamburgerIcon />` wrongly on its example 👍🏻

![Screenshot 2019-06-07 at 12 06 40](https://user-images.githubusercontent.com/5938217/59097055-d3fa5a00-891c-11e9-890b-b06e43b3e6fc.png)