### PR TITLE
docs(colors): improve styling

### DIFF
--- a/src/content/Colors/Colors.md
+++ b/src/content/Colors/Colors.md
@@ -14,20 +14,30 @@ You can modify the Colors component with a js object of colors. See props & meth
 
 ### Base Colors
 
-    <Colors defaultSection='base' />
+```js noeditor
+<Colors defaultSection="base" />
+```
 
 ### Primary Colors
 
-    <Colors defaultSection='primary' />
+```js noeditor
+<Colors defaultSection="primary" />
+```
 
 ### Extended Colors
 
-    <Colors defaultSection='extended' />
+```js noeditor
+<Colors defaultSection="extended" />
+```
 
 ### Neutral Colors
 
-    <Colors defaultSection='neutral' />
+```js noeditor
+<Colors defaultSection="neutral" />
+```
 
 ### Alert Colors
 
-    <Colors defaultSection='alert' />
+```js noeditor
+<Colors defaultSection="alert" />
+```

--- a/src/content/Colors/Colors.tsx
+++ b/src/content/Colors/Colors.tsx
@@ -35,11 +35,15 @@ export interface IColorsProps {
    * Object with the colors for testing purposes.
    * The key must be the name of the color and the value the color itself as in css. (e.g: { red: '#ff0000' }).
    * @default defaultColors of Zopa
+   * @ignore
    */
   colors?: {
     [colorName: string]: string;
   };
-  /** section of the default colors */
+  /**
+   * section of the default colors
+   * @ignore
+   */
   defaultSection: 'base' | 'primary' | 'extended' | 'neutral' | 'alert';
 }
 


### PR DESCRIPTION

Basically, I removed all the marked parts to make things less confusing as Colors is a wrapper component just for presentational purposes.

Removed in Colors:

- Code Editor
- Props

![React_components](https://user-images.githubusercontent.com/7198934/59914535-e2676c00-941a-11e9-8849-4ecde6f7f44c.png)

