### PR TITLE
Control applied `z-index` in `<Modal />` 👔

### DIFF
--- a/src/components/molecules/Modal/Modal.md
+++ b/src/components/molecules/Modal/Modal.md
@@ -6,6 +6,8 @@ All the props are being passed down to `react-modal` so if you want to customize
 
 **Notes ⚠️**:
 
+- You can control the CSS `z-index` value applied on the rendered modal through the `layer` prop on `<Modal.Styles />` ( 👀 example below )
+
 - In order to use it, you have to call `Modal.setAppElement('#rootElementId')` in the root component. You'll also need to include `<Modal.Styles>` component (preferably in the top level component) that contains the global styles from the modal.
 
 - Note that in order to make `<Modal />` to close when the user clicks on the overlay, you'll need to do so in a handler supplied to the `onRequestClose` prop. See [`react-modal` documentation](http://reactcommunity.org/react-modal/examples/on_request_close.html) for more background about this.
@@ -37,7 +39,7 @@ function ModalDemo() {
 }
 
 <>
-  <Modal.Styles />
+  <Modal.Styles layer={100} />
   <ModalDemo />
 </>;
 ```

--- a/src/components/molecules/Modal/Modal.md
+++ b/src/components/molecules/Modal/Modal.md
@@ -6,7 +6,7 @@ All the props are being passed down to `react-modal` so if you want to customize
 
 **Notes ⚠️**:
 
-- You can control the CSS `z-index` value applied on the rendered modal through the `layer` prop on `<Modal.Styles />` ( 👀 example below )
+- You can control the CSS `z-index` value applied on the rendered modal through the `zIndex` prop on `<Modal.Styles />` ( 👀 example below )
 
 - In order to use it, you have to call `Modal.setAppElement('#rootElementId')` in the root component. You'll also need to include `<Modal.Styles>` component (preferably in the top level component) that contains the global styles from the modal.
 
@@ -39,7 +39,7 @@ function ModalDemo() {
 }
 
 <>
-  <Modal.Styles layer={100} />
+  <Modal.Styles zIndex={100} />
   <ModalDemo />
 </>;
 ```

--- a/src/components/molecules/Modal/Modal.test.tsx
+++ b/src/components/molecules/Modal/Modal.test.tsx
@@ -3,10 +3,39 @@ import { render, waitForElement } from 'react-testing-library';
 import Modal from './Modal';
 
 describe('<Modal />', () => {
-  it('render the opened Modal', async () => {
+  it('can render un-opened', async () => {
+    Modal.setAppElement('body');
+    const { queryByText } = render(<Modal isOpen={false}>text</Modal>);
+
+    expect(queryByText('text')).toBe(null);
+  });
+
+  it('can render opened', async () => {
     Modal.setAppElement('body');
     const { getByText } = render(<Modal isOpen>text</Modal>);
+
     const modal = await waitForElement(() => getByText('text'));
     expect(modal).toMatchSnapshot();
   });
+
+  it('allows to set global styles', () => {
+    render(<Modal.Styles />);
+
+    const [globalModalStyles] = getGlobalStyleTags();
+    expect(globalModalStyles).toMatchSnapshot();
+  });
+
+  it('allows to set the `z-index` for the modal portal', () => {
+    const expectedZIndex = 100;
+    render(<Modal.Styles zIndex={expectedZIndex} />);
+
+    const [globalModalStyles] = getGlobalStyleTags();
+    expect(globalModalStyles).toContain(`z-index:${expectedZIndex}`);
+  });
 });
+
+function getGlobalStyleTags() {
+  return Array.from(document.querySelectorAll('style')).map(styleTag =>
+    styleTag.innerHTML.trim().replace(/\s+/gm, ' '),
+  );
+}

--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -2,22 +2,25 @@ import React from 'react';
 import ReactModal from 'react-modal';
 import ModalStyles from './ModalStyles/ModalStyles';
 
-class Modal extends React.Component<ReactModal.Props> {
+class Modal extends React.PureComponent<ReactModal.Props> {
   public static Styles = ModalStyles;
   public static setAppElement = ReactModal.setAppElement;
 
   public render() {
     const { children, ...rest } = this.props;
+
     const classNames = {
       afterOpen: 'zopa-modal--after-open',
       base: 'zopa-modal',
       beforeClose: 'zopa-modal--before-close',
     };
+
     const overlayClassNames = {
       afterOpen: 'zopa-modal-overlay--after-open',
       base: 'zopa-modal-overlay',
       beforeClose: 'zopa-modal-overlay--before-close',
     };
+
     return (
       <ReactModal
         bodyOpenClassName="zopa-modal-body--open"

--- a/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
+++ b/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
@@ -2,14 +2,22 @@ import { createGlobalStyle } from 'styled-components';
 
 import * as colors from '../../../../constants/colors';
 
-const ModalStyles = createGlobalStyle`
+interface IModalStylesPrsop {
+  /**
+   * The CSS `z-index` value to be applied on the rendered modal.
+   * @default 2
+   */
+  layer?: number;
+}
+
+const ModalStyles = createGlobalStyle<IModalStylesPrsop>`
   .zopa-modal-body--open {
     overflow: hidden;
   }
 
   .zopa-modal-portal {
     position: relative;
-    z-index: 2;
+    z-index: ${({ layer = 2 }) => layer};
   }
 
   .zopa-modal-overlay {

--- a/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
+++ b/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
@@ -2,7 +2,7 @@ import { createGlobalStyle } from 'styled-components';
 
 import * as colors from '../../../../constants/colors';
 
-interface IModalStylesPrsop {
+export interface IModalStylesProps {
   /**
    * The CSS `z-index` value to be applied on the rendered modal.
    * @default 2
@@ -10,7 +10,7 @@ interface IModalStylesPrsop {
   zIndex?: number;
 }
 
-const ModalStyles = createGlobalStyle<IModalStylesPrsop>`
+const ModalStyles = createGlobalStyle<IModalStylesProps>`
   .zopa-modal-body--open {
     overflow: hidden;
   }

--- a/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
+++ b/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
@@ -7,7 +7,7 @@ interface IModalStylesPrsop {
    * The CSS `z-index` value to be applied on the rendered modal.
    * @default 2
    */
-  layer?: number;
+  zIndex?: number;
 }
 
 const ModalStyles = createGlobalStyle<IModalStylesPrsop>`
@@ -17,7 +17,7 @@ const ModalStyles = createGlobalStyle<IModalStylesPrsop>`
 
   .zopa-modal-portal {
     position: relative;
-    z-index: ${({ layer = 2 }) => layer};
+    z-index: ${({ zIndex = 2 }) => zIndex};
   }
 
   .zopa-modal-overlay {

--- a/src/components/molecules/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/molecules/Modal/__snapshots__/Modal.test.tsx.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> render the opened Modal 1`] = `
+exports[`<Modal /> allows to set global styles 1`] = `"/* sc-component-id: sc-global-2055786734 */ .zopa-modal-body--open{overflow:hidden;} .zopa-modal-portal{position:relative;z-index:2;} .zopa-modal-overlay{position:fixed;top:0;bottom:0;left:0;right:0;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;background-color:#282F52;opacity:0;-webkit-transition:opacity 200ms ease-in-out;transition:opacity 200ms ease-in-out;} .zopa-modal-overlay--after-open{opacity:1;} .zopa-modal-overlay--before-close{opacity:0;} .zopa-modal{background-color:#fff;max-height:95%;overflow:auto;}"`;
+
+exports[`<Modal /> can render opened 1`] = `
 <div
   class="zopa-modal zopa-modal--after-open"
   role="dialog"


### PR DESCRIPTION
Addresses #36. 

Adding a `layer` prop to `<Modal.Styles />` to control the `z-index` applied on the rendered modal,
for example:
```jsx
<NavBar /> // this is fixed and internally applies a `z-index` value of `100`
<Modal.Styles layer={200} /> // ensures `<Modal />` will always render on top of `<NavBar />`  
```