### PR TITLE
<DropdownField /> molecule

### DIFF
--- a/src/components/molecules/DropdownField/DropdownField.md
+++ b/src/components/molecules/DropdownField/DropdownField.md
@@ -1,0 +1,11 @@
+`<DropdownField />` has exactly the same behaviour as `<TextField />`, the only difference being that it renders a `<Dropdown />` instead of `<InputText />`.
+
+```jsx
+import { DropdownField } from '@zopauk/react-components';
+
+<DropdownField label="Your cool dropdown ❤" errorMessage="You need to choose something!" size="short" name="foo">
+  <option value="first">First value</option>
+  <option value="second">Second value</option>
+  <option value="third">Third value</option>
+</DropdownField>;
+```

--- a/src/components/molecules/DropdownField/DropdownField.test.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import DropdownField from './DropdownField';
+
+describe('<DropdownField />', () => {
+  it('renders the component with props with no a11y violations', async () => {
+    const { container } = render(
+      <DropdownField
+        label="Your cool dropdown ❤"
+        errorMessage="You need to choose something!"
+        size="short"
+        name="dropdown-field-default"
+      >
+        <option value="first" key="first">
+          First value
+        </option>
+        <option value="second" key="second">
+          Second value
+        </option>
+        <option value="third" key="third">
+          Third value
+        </option>
+      </DropdownField>,
+    );
+
+    const results = await axe(container.innerHTML);
+
+    expect(container.firstChild).toMatchSnapshot();
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -1,0 +1,48 @@
+import React, { InputHTMLAttributes } from 'react';
+import styled from 'styled-components';
+import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
+import HelpText from '../../atoms/HelpText/HelpText';
+import InputLabel from '../../atoms/InputLabel/InputLabel';
+import Dropdown from '../../atoms/Dropdown/Dropdown';
+import SizedContainer from '../../layout/SizedContainer/SizedContainer';
+import { IField } from '../../types';
+
+interface IDropdownFieldProps
+  extends Omit<IField, 'isValid' | 'inputProps'>,
+    Omit<InputHTMLAttributes<HTMLSelectElement>, 'size'> {
+  /**
+   * Size attribute for the rendered HTML `<select>` element
+   */
+  htmlSelectSize?: InputHTMLAttributes<HTMLSelectElement>['size'];
+}
+
+const FieldError = styled(ErrorMessage)`
+  margin-top: 5px;
+`;
+
+const Label = styled(InputLabel)`
+  margin-bottom: 5px;
+`;
+
+function DropdownField(props: IDropdownFieldProps) {
+  const { label, errorMessage, size, helpText, htmlSelectSize, name, ...rest } = props;
+
+  if (!name) {
+    throw Error("You didn't supply a name for the dropdown. Check the docs.");
+  }
+
+  const input = (
+    <Dropdown id={`text-id-${name}`} aria-label={label ? undefined : name} {...rest} size={htmlSelectSize} />
+  );
+
+  return (
+    <>
+      {label && <Label htmlFor={`text-id-${name}`}>{label}</Label>}
+      {helpText && <HelpText>{helpText}</HelpText>}
+      <SizedContainer size={size}>{input}</SizedContainer>
+      {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
+    </>
+  );
+}
+
+export default DropdownField;

--- a/src/components/molecules/DropdownField/__snapshots__/DropdownField.test.tsx.snap
+++ b/src/components/molecules/DropdownField/__snapshots__/DropdownField.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DropdownField /> renders the component with props with no a11y violations 1`] = `
+.c1 {
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 24px;
+  width: 100%;
+  color: #1C2139;
+  display: block;
+}
+
+.c0 {
+  margin-bottom: 5px;
+}
+
+<label
+  class="c0 c1"
+  for="text-id-dropdown-field-default"
+>
+  Your cool dropdown ❤
+</label>
+`;

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import HelpText from '../../atoms/HelpText/HelpText';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
@@ -8,7 +8,7 @@ import { IField } from '../../types';
 import styled from 'styled-components';
 import { colors } from '../../..';
 
-export interface ITextFieldProps extends IField {
+export interface ITextFieldProps extends IField, HTMLAttributes<HTMLInputElement> {
   prefix?: string;
 }
 
@@ -16,12 +16,14 @@ const TextFieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const TextField = (props: IField) => {
-  const { label, errorMessage, isValid, inputProps, size, helpText, prefix, ...rest } = props;
+const TextField = (props: ITextFieldProps) => {
+  const { label, errorMessage, isValid, inputProps, size, helpText, prefix } = props;
   const { name } = inputProps;
+
   if (!name) {
     throw Error('Name must be set in inputProps. Check the docs.');
   }
+
   if (prefix && prefix.length > 1) {
     throw Error('Prefixes can only have one character');
   }
@@ -36,13 +38,12 @@ const TextField = (props: IField) => {
       {...inputProps}
     />
   );
+
   return (
     <>
       {label && <InputLabel htmlFor={`text-id-${name}`}>{label}</InputLabel>}
       {helpText && <HelpText>{helpText}</HelpText>}
-      <SizedContainer size={size} {...rest}>
-        {prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}
-      </SizedContainer>
+      <SizedContainer size={size}>{prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}</SizedContainer>
       {errorMessage && <TextFieldError data-automation={`ZA.error-${name}`}>{errorMessage}</TextFieldError>}
     </>
   );

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes, InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes } from 'react';
 
 /**
  * GLOBAL TYPES ACROSS COMPONENTS
@@ -18,14 +18,14 @@ export interface IInputStatus {
   hasError?: boolean;
 }
 
-export interface IInput extends IInputStatus, InputHTMLAttributes<HTMLInputElement> {
+export interface IInput extends IInputStatus, InputHTMLAttributes<HTMLInputElement | HTMLSelectElement> {
   /**
    * Attribute used for testing porpuses
    */
   'data-automation'?: string;
 }
 
-export interface IField extends HTMLAttributes<HTMLDivElement> {
+export interface IField {
   /**
    * The text to be shown on the label. If this is not set it doesn't render the label.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export { default as Help } from './components/molecules/Help/Help';
 export { default as CheckboxField } from './components/molecules/CheckboxField/CheckboxField';
 export { default as RadioField } from './components/molecules/RadioField/RadioField';
 export { default as TextField } from './components/molecules/TextField/TextField';
+export { default as DropdownField } from './components/molecules/DropdownField/DropdownField';
 
 // Organisms
 export { default as Navbar } from './components/organisms/Navbar/Navbar';


### PR DESCRIPTION
![Screenshot 2019-07-31 at 18 22 14](https://user-images.githubusercontent.com/5938217/62229538-235e8300-b3c0-11e9-9ea0-f903a35ba304.png)


Adds a new `<DropddownField />` molecule to complete the group of **"form molecules"** we have:

- `<TextField />`
- `<RadioField />`
- `<ChecboxField />`

It's a convenience so that you can use a dropdown that is stateful ( _error and help text_ ) and accessible ( _with label_ ) instead of building your own 💅🏻

## Note 💬

I had to wrangle a bit with the types, as the native `<select>` element had already a `size` attribute which was conflicting with the `size` to customise `<SizedContainer />`.