### PR TITLE
Rename icons 💬

### DIFF
--- a/src/components/icons/Alert/Alert.md
+++ b/src/components/icons/Alert/Alert.md
@@ -1,7 +1,7 @@
 An Alert icon
 
 ```js
-import { Alert as AlertIcon } from '@zopauk/react-components';
+import { AlertIcon } from '@zopauk/react-components';
 
 <AlertIcon size="24px" fillColor="rebeccaPurple" />;
 ```

--- a/src/components/icons/Arrow/Arrow.md
+++ b/src/components/icons/Arrow/Arrow.md
@@ -4,7 +4,7 @@ Allowed directions are: `down` | `up` | `left` | `right` | `number` | `string`
 
 ```jsx
 import { Fragment } from 'react';
-import { Arrow as ArrowIcon } from '@zopauk/react-components';
+import { ArrowIcon } from '@zopauk/react-components';
 
 <Fragment>
   <ArrowIcon color="blue" direction="down" />

--- a/src/components/icons/CheckMark/CheckMark.md
+++ b/src/components/icons/CheckMark/CheckMark.md
@@ -1,7 +1,7 @@
 Wrapper around svg code for a checkmark icon.
 
 ```jsx
-import { CheckMark as CheckMarkIcon } from '@zopauk/react-components';
+import { CheckMarkIcon } from '@zopauk/react-components';
 
 <CheckMarkIcon />;
 ```

--- a/src/components/icons/Chevron/Chevron.md
+++ b/src/components/icons/Chevron/Chevron.md
@@ -4,7 +4,7 @@ Allowed directions are 'down' | 'up' | 'left' | 'right' | number | string
 
 ```jsx
 import { Fragment } from 'react';
-import { Chevron as ChevronIcon } from '@zopauk/react-components';
+import { ChevronIcon } from '@zopauk/react-components';
 
 <Fragment>
   <ChevronIcon color="blue" direction="down" />

--- a/src/components/icons/ZopaLogo/ZopaLogo.md
+++ b/src/components/icons/ZopaLogo/ZopaLogo.md
@@ -1,7 +1,7 @@
 This component is a wrapper around the svg code for Zopa's logo.
 
 ```jsx
-import { ZopaLogo as ZopaLogoIcon } from '@zopauk/react-components';
+import { ZopaIcon } from '@zopauk/react-components';
 
-<ZopaLogoIcon width="70px" height="50px" color="red" />;
+<ZopaIcon width="70px" height="50px" color="red" />;
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,13 +55,13 @@ export { default as FlexCol } from './components/layout/FlexCol/FlexCol';
 export { default as SizedContainer } from './components/layout/SizedContainer/SizedContainer';
 
 // Icons
-export { default as Arrow } from './components/icons/Arrow/Arrow';
-export { default as Alert } from './components/icons/Alert/Alert';
-export { default as CheckMark } from './components/icons/CheckMark/CheckMark';
-export { default as Chevron } from './components/icons/Chevron/Chevron';
+export { default as ArrowIcon } from './components/icons/Arrow/Arrow';
+export { default as AlertIcon } from './components/icons/Alert/Alert';
+export { default as CheckMarkIcon } from './components/icons/CheckMark/CheckMark';
+export { default as ChevronIcon } from './components/icons/Chevron/Chevron';
 export { default as Facebook } from './components/icons/Facebook/Facebook';
 export { default as Twitter } from './components/icons/Twitter/Twitter';
-export { default as ZopaLogo } from './components/icons/ZopaLogo/ZopaLogo';
+export { default as ZopaIcon } from './components/icons/ZopaLogo/ZopaLogo';
 export { default as HamburgerIcon } from './components/icons/Hamburger/Hamburger';
 export { default as ProfileIcon } from './components/icons/Profile/Profile';
 


### PR DESCRIPTION
## Summary

Rename our **icon components** so that they contain the word `Icon` on their name.

In this way, whenever importing one of those components is explicit that their responsibility is to render an icon 💅🏻

It is marked as a **breaking change**.

## Issue
- #20