### PR TITLE
fix(footer): fix car loans link and copyright year

### DIFF
--- a/src/components/molecules/ZopaFooter/Legal/Legal.test.tsx
+++ b/src/components/molecules/ZopaFooter/Legal/Legal.test.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Legal from './Legal';
+import { mockDate, IMockDate } from '../../../../helpers/test/date';
+
+const fixedDate = new Date('2016-02-28T09:39:59');
 
 describe('<Legal />', () => {
+  let date: IMockDate;
+
+  beforeEach(() => {
+    date = mockDate(new Date(fixedDate));
+    date.startMocking();
+  });
+  afterEach(() => {
+    date.finishMocking();
+  });
+
   it('renders the component', async () => {
     const { container } = render(<Legal />);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/molecules/ZopaFooter/Legal/Legal.tsx
+++ b/src/components/molecules/ZopaFooter/Legal/Legal.tsx
@@ -12,26 +12,28 @@ const StyledParagraph = styled.p`
   margin: 0;
 `;
 
-const content = {
-  about: `Zopa Limited is incorporated in England & Wales (registration number 05197592), with its registered office at 1st Floor, Cottons Centre, Tooley Street, 
-London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
-and entered on the Financial Services Register under firm registration number 718925.`,
+const Legal = () => {
+  const { about, rightsReserved } = {
+    about: `Zopa Limited is incorporated in England & Wales (registration number 05197592), with its registered office at 1st Floor, Cottons Centre, Tooley Street, 
+    London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
+    and entered on the Financial Services Register under firm registration number 718925.`,
 
-  rightsReserved: `© Zopa Limited ${new Date().getFullYear()} All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
-Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
-and we are registered with the Office of the Information Commissioner (No. Z8797078).`,
+    rightsReserved: `© Zopa Limited ${new Date().getFullYear()} All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+    Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
+    and we are registered with the Office of the Information Commissioner (No. Z8797078).`,
+  };
+
+  return (
+    <>
+      <Wrapper>
+        <StyledParagraph>{about}</StyledParagraph>
+      </Wrapper>
+      <Separator />
+      <Wrapper>
+        <StyledParagraph>{rightsReserved}</StyledParagraph>
+      </Wrapper>
+    </>
+  );
 };
-
-const Legal = () => (
-  <>
-    <Wrapper>
-      <StyledParagraph>{content.about}</StyledParagraph>
-    </Wrapper>
-    <Separator />
-    <Wrapper>
-      <StyledParagraph>{content.rightsReserved}</StyledParagraph>
-    </Wrapper>
-  </>
-);
 
 export default Legal;

--- a/src/components/molecules/ZopaFooter/Legal/Legal.tsx
+++ b/src/components/molecules/ZopaFooter/Legal/Legal.tsx
@@ -17,7 +17,7 @@ const content = {
 London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
 and entered on the Financial Services Register under firm registration number 718925.`,
 
-  rightsReserved: `© Zopa Limited 2018 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+  rightsReserved: `© Zopa Limited ${new Date().getFullYear()} All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
 Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
 and we are registered with the Office of the Information Commissioner (No. Z8797078).`,
 };

--- a/src/components/molecules/ZopaFooter/Legal/__snapshots__/Legal.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Legal/__snapshots__/Legal.test.tsx.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Legal /> renders the component 1`] = `
+.c2 {
+  background-color: #282F52;
+  height: 1px;
+}
+
 .c0 {
   padding: 18px 0;
 }
@@ -12,15 +17,31 @@ exports[`<Legal /> renders the component 1`] = `
   margin: 0;
 }
 
-<div
-  class="c0"
->
-  <p
-    class="c1"
+<div>
+  <div
+    class="c0"
   >
-    Zopa Limited is incorporated in England & Wales (registration number 05197592), with its registered office at 1st Floor, Cottons Centre, Tooley Street, 
-London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
-and entered on the Financial Services Register under firm registration number 718925.
-  </p>
+    <p
+      class="c1"
+    >
+      Zopa Limited is incorporated in England & Wales (registration number 05197592), with its registered office at 1st Floor, Cottons Centre, Tooley Street, 
+    London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
+    and entered on the Financial Services Register under firm registration number 718925.
+    </p>
+  </div>
+  <div
+    class="c2"
+  />
+  <div
+    class="c0"
+  >
+    <p
+      class="c1"
+    >
+      © Zopa Limited 2016 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+    Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
+    and we are registered with the Office of the Information Commissioner (No. Z8797078).
+    </p>
+  </div>
 </div>
 `;

--- a/src/components/molecules/ZopaFooter/Links/Links.tsx
+++ b/src/components/molecules/ZopaFooter/Links/Links.tsx
@@ -74,8 +74,8 @@ const linkGroups = [
         label: 'Home improvements',
       },
       {
-        href: 'https://zopa.com/loans/car-finance',
-        label: 'Car finance',
+        href: 'https://zopa.com/loans/car-loans',
+        label: 'Car loans',
       },
       {
         href: 'https://zopa.com/loans/faq',

--- a/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
@@ -265,9 +265,9 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6"
-            href="https://zopa.com/loans/car-finance"
+            href="https://zopa.com/loans/car-loans"
           >
-            Car finance
+            Car loans
           </a>
         </li>
         <li

--- a/src/components/molecules/ZopaFooter/ZopaFooter.test.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.test.tsx
@@ -2,8 +2,21 @@ import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
 import ZopaFooter from './ZopaFooter';
+import { mockDate, IMockDate } from '../../../helpers/test/date';
+
+const fixedDate = new Date('2025-02-28T09:39:59');
 
 describe('<ZopaFooter />', () => {
+  let date: IMockDate;
+
+  beforeEach(() => {
+    date = mockDate(new Date(fixedDate));
+    date.startMocking();
+  });
+  afterEach(() => {
+    date.finishMocking();
+  });
+
   it('renders the component with default props', async () => {
     const { container } = render(<ZopaFooter />);
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -69,8 +69,8 @@ exports[`<ZopaFooter /> renders the component with a legalOnly prop 1`] = `
         class="c3"
       >
         Zopa Limited is incorporated in England & Wales (registration number 05197592), with its registered office at 1st Floor, Cottons Centre, Tooley Street, 
-London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
-and entered on the Financial Services Register under firm registration number 718925.
+    London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
+    and entered on the Financial Services Register under firm registration number 718925.
       </p>
     </div>
     <div
@@ -82,9 +82,9 @@ and entered on the Financial Services Register under firm registration number 71
       <p
         class="c3"
       >
-        © Zopa Limited 2019 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
-Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
-and we are registered with the Office of the Information Commissioner (No. Z8797078).
+        © Zopa Limited 2025 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+    Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
+    and we are registered with the Office of the Information Commissioner (No. Z8797078).
       </p>
     </div>
   </div>
@@ -537,8 +537,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
         class="c11"
       >
         Zopa Limited is incorporated in England & Wales (registration number 05197592), with its registered office at 1st Floor, Cottons Centre, Tooley Street, 
-London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
-and entered on the Financial Services Register under firm registration number 718925.
+    London, SE1 2QG. Zopa Limited is authorised and regulated by the Financial Conduct Authority, 
+    and entered on the Financial Services Register under firm registration number 718925.
       </p>
     </div>
     <div
@@ -550,9 +550,9 @@ and entered on the Financial Services Register under firm registration number 71
       <p
         class="c11"
       >
-        © Zopa Limited 2019 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
-Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
-and we are registered with the Office of the Information Commissioner (No. Z8797078).
+        © Zopa Limited 2025 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+    Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
+    and we are registered with the Office of the Information Commissioner (No. Z8797078).
       </p>
     </div>
     <div

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -82,7 +82,7 @@ and entered on the Financial Services Register under firm registration number 71
       <p
         class="c3"
       >
-        © Zopa Limited 2018 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+        © Zopa Limited 2019 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
 Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
 and we are registered with the Office of the Information Commissioner (No. Z8797078).
       </p>
@@ -449,9 +449,9 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
             >
               <a
                 class="c8"
-                href="https://zopa.com/loans/car-finance"
+                href="https://zopa.com/loans/car-loans"
               >
-                Car finance
+                Car loans
               </a>
             </li>
             <li
@@ -550,7 +550,7 @@ and entered on the Financial Services Register under firm registration number 71
       <p
         class="c11"
       >
-        © Zopa Limited 2018 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
+        © Zopa Limited 2019 All rights reserved. 'Zopa' and the Zopa logo are trade marks of Zopa Limited. 
 Zopa is a member of CIFAS – the UK's leading anti-fraud association, 
 and we are registered with the Office of the Information Commissioner (No. Z8797078).
       </p>

--- a/src/helpers/test/date.ts
+++ b/src/helpers/test/date.ts
@@ -1,0 +1,20 @@
+export interface IMockDate {
+  startMocking(): void;
+  finishMocking(): void;
+}
+
+export function mockDate(date: Date): IMockDate {
+  const RealDate = Date;
+
+  return {
+    startMocking() {
+      global.Date = jest.fn(() => date) as any;
+      global.Date.UTC = RealDate.UTC;
+      global.Date.parse = RealDate.parse;
+      global.Date.now = RealDate.now;
+    },
+    finishMocking() {
+      global.Date = RealDate;
+    },
+  };
+}


### PR DESCRIPTION
Changed the car finance link  to car loans and changed to dynamic copyright year in the legal text to show actual year