### PR TITLE
Add column swapping to grid

### DIFF
--- a/src/components/layout/FlexCol/FlexCol.md
+++ b/src/components/layout/FlexCol/FlexCol.md
@@ -71,6 +71,23 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
+Layout with a column order swapped on small screen:
+
+```jsx
+import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
+
+<FlexContainer>
+  <FlexRow direction="row-reverse">
+    <FlexCol xs={12} m={6}>
+      <div style={{ backgroundColor: '#73E1D6' }}>second column</div>
+    </FlexCol>
+    <FlexCol xs={12} m={6}>
+      <div style={{ backgroundColor: '#73E1D6' }}>first column</div>
+    </FlexCol>
+  </FlexRow>
+</FlexContainer>;
+```
+
 Grid aligned vertically:
 
 ```jsx

--- a/src/components/layout/FlexRow/FlexRow.tsx
+++ b/src/components/layout/FlexRow/FlexRow.tsx
@@ -4,11 +4,14 @@ import grid from '../../../constants/grid';
 
 export type TFlexValues = 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly';
 
+export type TFlexDirection = 'row' | 'row-reverse';
+
 export interface IFlexRowProps {
   align?: TFlexValues;
   cols?: number;
   gutter?: number;
   justify?: TFlexValues;
+  direction?: TFlexDirection;
 }
 
 export interface IFlexRow extends React.HTMLAttributes<HTMLDivElement>, IFlexRowProps {}
@@ -18,11 +21,13 @@ const defaultProps: Partial<IFlexRow> = {
   cols: grid.cols,
   gutter: grid.gutter,
   justify: 'flex-start',
+  direction: 'row',
 };
 
 const StyledFlexRow = styled.div<IFlexRow>`
   display: flex;
   flex-wrap: wrap;
+  flex-direction: ${props => props.direction};
   margin-right: -${props => props.gutter}px;
   margin-left: -${props => props.gutter}px;
   justify-content: ${props => props.justify};

--- a/src/components/layout/FlexRow/__snapshots__/FlexRow.test.tsx.snap
+++ b/src/components/layout/FlexRow/__snapshots__/FlexRow.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`<FlexRow /> renders a FlexRow component 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin-right: -16px;
   margin-left: -16px;
   -webkit-box-pack: start;
@@ -24,5 +27,6 @@ exports[`<FlexRow /> renders a FlexRow component 1`] = `
 <div
   class="c0"
   cols="12"
+  direction="row"
 />
 `;

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -47,6 +47,9 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin-right: -16px;
   margin-left: -16px;
   -webkit-box-pack: start;
@@ -146,6 +149,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
     <div
       class="c2"
       cols="12"
+      direction="row"
     >
       <div
         class="c3"
@@ -161,6 +165,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
     <div
       class="c2"
       cols="12"
+      direction="row"
     >
       <div
         class="c5"

--- a/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
@@ -31,6 +31,9 @@ exports[`<Links /> renders the component 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin-right: -16px;
   margin-left: -16px;
   -webkit-box-pack: start;
@@ -149,6 +152,7 @@ exports[`<Links /> renders the component 1`] = `
 <div
   class="c0"
   cols="12"
+  direction="row"
 >
   <div
     class="c1"

--- a/src/components/molecules/ZopaFooter/MiscLinks/__snapshots__/MiscLinks.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/MiscLinks/__snapshots__/MiscLinks.test.tsx.snap
@@ -20,6 +20,9 @@ exports[`<MiscLinks /> renders the component 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin-right: -16px;
   margin-left: -16px;
   -webkit-box-pack: start;
@@ -65,6 +68,7 @@ exports[`<MiscLinks /> renders the component 1`] = `
 <div
   class="c0"
   cols="12"
+  direction="row"
 >
   <div
     class="c1"

--- a/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
@@ -20,6 +20,9 @@ exports[`<SocialLinks /> renders the component 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin-right: -16px;
   margin-left: -16px;
   -webkit-box-pack: start;
@@ -61,6 +64,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 <div
   class="c0"
   cols="12"
+  direction="row"
 >
   <div
     class="c1"

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -158,6 +158,9 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   margin-right: -16px;
   margin-left: -16px;
   -webkit-box-pack: start;
@@ -333,6 +336,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
     <div
       class="c2"
       cols="12"
+      direction="row"
     >
       <div
         class="c3"
@@ -561,6 +565,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       <div
         class="c2"
         cols="12"
+        direction="row"
       >
         <div
           class="c12"
@@ -621,6 +626,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       <div
         class="c2"
         cols="12"
+        direction="row"
       >
         <div
           class="c12"


### PR DESCRIPTION
Added `direction` prop to `<FlexRow>` to control order in which the columns collapse