### PR TITLE
Improve documentation styles 🎨 🖌 👨🏻‍🎨

### DIFF
--- a/src/components/atoms/Button/Button.md
+++ b/src/components/atoms/Button/Button.md
@@ -111,9 +111,9 @@ import { Button } from '@zopauk/react-components';
 Can be used with arrows, among other icons.
 
 ```jsx
-import { Alert, Button } from '@zopauk/react-components';
+import { AlertIcon, Button } from '@zopauk/react-components';
 
-<Button rightIcon={<Alert fillColor="#fff" />}>Learn more</Button>;
+<Button rightIcon={<AlertIcon fillColor="#fff" />}>Learn more</Button>;
 ```
 
 ### Left icon
@@ -121,9 +121,9 @@ import { Alert, Button } from '@zopauk/react-components';
 For when the icon conveys the meaning faster than text.
 
 ```jsx
-import { Alert, Button } from '@zopauk/react-components';
+import { AlertIcon, Button } from '@zopauk/react-components';
 
-<Button leftIcon={<Alert fillColor="#fff" />}>Smash now</Button>;
+<Button leftIcon={<AlertIcon fillColor="#fff" />}>Smash now</Button>;
 ```
 
 ### Full width
@@ -140,7 +140,7 @@ import { Button } from '@zopauk/react-components';
 
 Note that the text colour is the same as the background (always!)
 
-```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "2px solid #efefef" } } }
 import { Button, colors } from '@zopauk/react-components';
 
 <Button styling="contrastPrimary" contrastColor={colors.primary.navy800}>
@@ -152,7 +152,7 @@ import { Button, colors } from '@zopauk/react-components';
 
 The border should be the colour's shade in 50 or close to that.
 
-```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "2px solid #efefef" } } }
 import { Button, colors } from '@zopauk/react-components';
 
 <Button styling="contrastSecondary" contrastColor={colors.extended.blue25}>
@@ -164,7 +164,7 @@ import { Button, colors } from '@zopauk/react-components';
 
 See above.
 
-```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "2px solid #efefef" } } }
 import { Button } from '@zopauk/react-components';
 
 <Button styling="contrastLink">Link smash</Button>;

--- a/src/components/atoms/Card/Card.md
+++ b/src/components/atoms/Card/Card.md
@@ -4,7 +4,7 @@ The design team has agreed on three types of cards depending on the context.
 
 A standard or default card, which we'll assume if the type property has been omitted or set explicitly to card. As of this writing, cards of this type are non-interactable and have a border radius of 4px.
 
-```js { "props": { "style": { "backgroundColor": "#141E64" } } }
+```js { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { Card } from '@zopauk/react-components';
 
 <Card type="card">
@@ -18,7 +18,7 @@ A card that is meant to be clickable and respond to user interactions (hover eff
 
 Cards of type `"linkCard"` are meant to be used to build components that interact with user actions.
 
-```js { "props": { "style": { "backgroundColor": "#141E64" } } }
+```js { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { Card, Header3 } from '@zopauk/react-components';
 
 <div onClick={() => alert("You're a winner!")}>

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -19,7 +19,7 @@ const Option: React.FunctionComponent<IOption> = styled.option``;
 const Dropdown: React.FunctionComponent<IDropdownProps> = styled.select<IDropdownProps>`
   appearance: none;
 
-  background: ${colors.base.white} url(${chevronDown}) no-repeat calc(100% - 13px) center;
+  background: transparent url(${chevronDown}) no-repeat calc(100% - 13px) center;
   background-size: 13px;
 
   border: 2px solid ${({ hasError }) => (hasError ? statusColors.error : DEFAULT_COLOR)};

--- a/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Dropdown /> renders the Dropdown with one option 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: #fff url(chevron-down.svg) no-repeat calc(100% - 13px) center;
+  background: transparent url(chevron-down.svg) no-repeat calc(100% - 13px) center;
   background-size: 13px;
   border: 2px solid #D6D7DE;
   border-radius: 4px;
@@ -39,7 +39,7 @@ exports[`<Dropdown /> renders the Dropdown with options 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: #fff url(chevron-down.svg) no-repeat calc(100% - 13px) center;
+  background: transparent url(chevron-down.svg) no-repeat calc(100% - 13px) center;
   background-size: 13px;
   border: 2px solid #D6D7DE;
   border-radius: 4px;
@@ -79,7 +79,7 @@ exports[`<Dropdown /> renders the Dropdown with options and a default selected v
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: #fff url(chevron-down.svg) no-repeat calc(100% - 13px) center;
+  background: transparent url(chevron-down.svg) no-repeat calc(100% - 13px) center;
   background-size: 13px;
   border: 2px solid #D6D7DE;
   border-radius: 4px;
@@ -120,7 +120,7 @@ exports[`<Dropdown /> renders the Dropdown with options passed through an array.
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: #fff url(chevron-down.svg) no-repeat calc(100% - 13px) center;
+  background: transparent url(chevron-down.svg) no-repeat calc(100% - 13px) center;
   background-size: 13px;
   border: 2px solid #D6D7DE;
   border-radius: 4px;

--- a/src/components/atoms/SidekickCard/SidekickCard.md
+++ b/src/components/atoms/SidekickCard/SidekickCard.md
@@ -10,7 +10,7 @@ There are 3 types of SidekickCards:
 
 For success messages. It shows a green left border and a green check mark.
 
-```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { SidekickCard } from '@zopauk/react-components';
 
 <SidekickCard type="triumph">
@@ -23,7 +23,7 @@ import { SidekickCard } from '@zopauk/react-components';
 
 For verification messages. It shows a green left border and a green squiggly circle check mark.
 
-```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { SidekickCard } from '@zopauk/react-components';
 
 <SidekickCard type="verified">
@@ -36,7 +36,7 @@ import { SidekickCard } from '@zopauk/react-components';
 
 For alert/warning messages. It shows a yellow left border and a yellow warning icon.
 
-```jsx { "props": { "style": { "backgroundColor": "#141E64" } } }
+```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { SidekickCard } from '@zopauk/react-components';
 
 <SidekickCard type="alert">

--- a/src/components/organisms/Navbar/Navbar.md
+++ b/src/components/organisms/Navbar/Navbar.md
@@ -1,6 +1,6 @@
 Basic example:
 
-```js { "props": { "style": { "transform": "translate3d(0, 0, 0)" } } }
+```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "border": "2px solid #efefef" } } }
 import { Navbar, Link, HamburgerIcon, ProfileIcon } from '@zopauk/react-components';
 
 <Navbar.Layout
@@ -50,7 +50,7 @@ import { Navbar, Link, HamburgerIcon, ProfileIcon } from '@zopauk/react-componen
 
 Responsive Navbar example:
 
-```js { "props": { "style": { "transform": "translate3d(0, 0, 0)" } } }
+```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "border": "2px solid #efefef" } } }
 import { Navbar, Link, HamburgerIcon, FlexCol } from '@zopauk/react-components';
 
 class ResponsiveNavbar extends React.Component {

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
@@ -2,7 +2,7 @@ This is a flexible Navbar subcomponent meant to be used with other components su
 
 Basic example:
 
-```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7", "border": "2px solid #efefef"} } }
 import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Dropdown
@@ -26,7 +26,7 @@ import { Navbar } from '@zopauk/react-components';
 
 Example with custom components:
 
-```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7", "border": "2px solid #efefef" } } }
 import { Navbar, Link, HamburgerIcon } from '@zopauk/react-components';
 
 <Navbar.Dropdown

--- a/src/components/organisms/Navbar/NavbarLayout/NavbarLayout.md
+++ b/src/components/organisms/Navbar/NavbarLayout/NavbarLayout.md
@@ -3,7 +3,7 @@ However, it can be used with other atoms and molecules as well (e.g Link). It im
 
 White Navbar.Layout component
 
-```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7", "border": "2px solid #efefef" } } }
 import { Navbar, Link } from '@zopauk/react-components';
 
 <Navbar.Layout left={<Link>left</Link>} center={<Link>center</Link>} right={<Link>right</Link>} />;
@@ -11,7 +11,7 @@ import { Navbar, Link } from '@zopauk/react-components';
 
 Teal Navbar.Layout component
 
-```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#fff" } } }
+```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#fff", "border": "2px solid #efefef" } } }
 import { Navbar, Link } from '@zopauk/react-components';
 
 <Navbar.Layout backgroundColor="#00B9A7" left={<Link>left</Link>} right={<Link>right</Link>} />;

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.md
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.md
@@ -3,7 +3,7 @@ It is the same as Link component except for two extra props: active and withChev
 
 Default Navbar.Link component
 
-```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff">Navbar.Link</Navbar.Link>;
@@ -11,7 +11,7 @@ import { Navbar } from '@zopauk/react-components';
 
 Active Navbar.Link component
 
-```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff" active>
@@ -21,7 +21,7 @@ import { Navbar } from '@zopauk/react-components';
 
 Navbar.Link withChevron down
 
-```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff" withChevron open={false}>
@@ -31,7 +31,7 @@ import { Navbar } from '@zopauk/react-components';
 
 Navbar.Link withChevron up
 
-```js { "props": { "style": { "backgroundColor": "#00B9A7" } } }
+```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Link color="#fff" withChevron open>

--- a/src/styleguide-components/Heading.js
+++ b/src/styleguide-components/Heading.js
@@ -7,8 +7,7 @@ const styles = ({ color, fontSize }) => ({
   heading: {
     margin: '1em 0',
     color: color.base,
-    fontFamily: 'Alverata',
-    fontWeight: 'normal',
+    fontWeight: 900,
   },
   heading1: {
     fontSize: fontSize.h1,

--- a/src/styleguide-components/StyleGuide.js
+++ b/src/styleguide-components/StyleGuide.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { createGlobalStyle } from 'styled-components';
 import Logo from 'rsg-components/Logo';
 import Markdown from 'rsg-components/Markdown';
 import Styled from 'rsg-components/Styled';
@@ -9,6 +10,13 @@ import Version from 'rsg-components/Version';
 
 import GlobalStyles from '../components/styles/GlobalStyles';
 import Fonts from '../components/styles/Fonts';
+
+const GlobalStyleGuideStyles = createGlobalStyle`
+  /* System Fonts as used by GitHub */
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  }
+`;
 
 const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth }) => ({
   root: {
@@ -70,6 +78,7 @@ export function StyleGuideRenderer({ classes, title, version, homepageUrl, child
   return (
     <div className={cx(classes.root, hasSidebar && classes.hasSidebar)}>
       <GlobalStyles />
+      <GlobalStyleGuideStyles />
       <Fonts />
       <main className={classes.content}>
         {children}

--- a/src/styleguide-components/Table.js
+++ b/src/styleguide-components/Table.js
@@ -9,9 +9,6 @@ export const styles = ({ space, color, fontFamily, fontSize }) => ({
     marginBottom: space[4],
     tableLayout: 'auto',
   },
-  tableHead: {
-    borderBottom: [[1, color.border, 'solid']],
-  },
   cellHeading: {
     color: color.base,
     paddingRight: space[1],
@@ -19,8 +16,12 @@ export const styles = ({ space, color, fontFamily, fontSize }) => ({
     textAlign: 'left',
     fontFamily: fontFamily.base,
     fontWeight: 'bold',
-    fontSize: fontSize.small,
+    fontSize: '14px',
     whiteSpace: 'nowrap',
+    textTransform: 'unset',
+    backgroundColor: '#efefef',
+    border: '1px solid #efefef',
+    padding: 10,
   },
   cell: {
     color: color.base,
@@ -30,6 +31,8 @@ export const styles = ({ space, color, fontFamily, fontSize }) => ({
     verticalAlign: 'top',
     fontFamily: fontFamily.base,
     fontSize: fontSize.small,
+    border: '1px solid #efefef',
+    padding: 10,
     '&:last-child': {
       isolate: false,
       paddingRight: 0,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -52,7 +52,7 @@ module.exports = {
       ignore: 'src/content/**/*constants.{js,jsx,ts,tsx}',
     },
     {
-      sectionDepth: 1,
+      sectionDepth: 2,
       name: 'Components',
       content: 'src/components/README.md',
       components: 'src/components/*/*.{js,jsx,ts,tsx}',
@@ -115,9 +115,10 @@ module.exports = {
     maxWidth: '100%',
     color: {
       sidebarBackground: '#1C2139',
+      codeBackground: '#F5F5F5',
     },
     fontFamily: {
-      base: '"Open Sans", sans-serif',
+      monospace: 'Monaco, Menlo, Courier, monospace',
     },
     fontSize: {
       base: 14,
@@ -129,6 +130,32 @@ module.exports = {
       h4: 18,
       h5: 16,
       h6: 16,
+    },
+  },
+  styles: {
+    TableOfContents: {
+      input: {
+        backgroundColor: '#80808000',
+        color: 'white',
+        borderColor: '#595959',
+      },
+    },
+    StyleGuide: {
+      logo: {
+        borderBottom: 'none',
+      },
+    },
+    Playground: {
+      preview: {
+        border: '3px #dcdcdc dashed',
+      },
+    },
+    TabButton: {
+      button: {
+        color: '#afafaf',
+        textTransform: 'unset',
+        border: 'none !important',
+      },
     },
   },
   // Override Styleguidist components


### PR DESCRIPTION
## Background 

When working on the [re-brand updates](https://github.com/zopaUK/react-components/pull/54) I noticed that when removing **Alverata** our docs headings looked a bit _oopsie_:

<img src="https://user-images.githubusercontent.com/5938217/63340166-b860f600-c346-11e9-87a5-a5e5e429efc9.png" width="550" />


<img src="https://media.giphy.com/media/26xBD8jb96cfiUEbS/giphy.gif" width="300" />

While updating the header styles... I found myself on the journey of customising our **Docs UI** with the goal of...

> Making the docs UI distinct from our components UI

Here are the updates:

- Use **system font-stack** for our docs typography
- Nicer props table ( looking like an actual table 😝 )
- Clear border to highlight properly the **component preview**
- Cleaning the sidebar to have a proper **dark theme** 🦇

Here's the result... 🥁

### New

![Screenshot 2019-08-20 at 12 12 33](https://user-images.githubusercontent.com/5938217/63339798-f873a900-c345-11e9-8f24-533b9655c87d.png)

### OId

![Screenshot 2019-08-20 at 12 29 23](https://user-images.githubusercontent.com/5938217/63339897-2e189200-c346-11e9-8c96-1cdce06c7788.png)

## Disclaimer

I understand this is a pretty stubborn change from my side, so happy not to get it merged if it not seen as an improvement 👍🏻
