### PR TITLE
Add a structure to our documentation ✍️ 💅🏻

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,39 +1,55 @@
 This project aims to have all the common styled react components as a library/documentation.
 
-## Installation
+### Installation
 
-- Install it from the repository:
+- Install it from NPM:
 
   ```bash
   yarn add '@zopauk/react-components'
   ```
 
-- ⚠️ **In order to use this UI you must import the `<GlobalStyles />` component and use it in the root of your project.**
+### Setup
 
-  ```js static
-  import { GlobalStyles } from '@zopauk/react-components';
+#### ... `<GlobalStyles />`
 
-  // root component
-  const App = () => (
-    <>
-      <GlobalStyles />
-      // rest of your top-level components
-    </>
-  );
-  ```
+⚠️ &nbsp;&nbsp;In order for the UI to render well, `<GlobalStyles />` needs to be imported and added to the top-most component of the project:
 
-- **Fonts** (_optional_): This is not added in the default module because there are better ways to do it in terms of performance.
+```js static
+import { GlobalStyles } from '@zopauk/react-components';
 
-  ```js static
-  import { Fonts } from '@zopauk/react-components';
+// root component
+const App = () => (
+  <>
+    <GlobalStyles />
+    // rest of your top-level components
+  </>
+);
+```
 
-  // root component
-  const App = () => (
-    <>
-      <Fonts />
-      // rest of your top-level components
-    </>
-  );
-  ```
+#### ... `<Fonts />`
 
-Another option is to use a custom rule on your favourite builder to inject the css.
+[Open Sans](https://fonts.google.com/specimen/Open+Sans) is the typography chosen for Zopa's brand.
+
+We currently use three weights:
+
+- 400 ( _regular_ )
+- 600 ( _semibold_ )
+- 700 ( _bold_ )
+
+As a convenience, you can import `<Fonts />` and add it on the top level of your app:
+
+```js static
+import { Fonts } from '@zopauk/react-components';
+
+// root component
+const App = () => (
+  <>
+    <Fonts />
+    // rest of your top-level components
+  </>
+);
+```
+
+It'll grab **Open Sans** from Google's CDN [through a CSS import](https://github.com/zopaUK/react-components/blob/master/src/components/styles/Fonts.tsx#L3-L5).
+
+You're free to use this technique or add the dependency manually to your base HTML `<head />`

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,15 +1,14 @@
-Components for the UI.
-
 Components are organized following the [atomic design](http://bradfrost.com/blog/post/atomic-web-design/) conventions.
-The only difference is that we focus on atoms and molecules, other more complex components (organisms, templates, pages, ...) are
-shown as code examples but are not exported as a single component itself to avoid extra complexity.
 
 ## Usage
 
-To use the components in your project simply import the desired component to your project as follows:
+To use them, simply import the desired component to your project as follows:
 
-```js static
-import { Button } from '@zopauk/react-components';
+```jsx static
+import { Button, Text, FlexCol } from '@zopauk/react-components';
+
+<SizeContainer size="short">
+  <Button>Click me</Button>
+  <Text>Hi!</Text>
+</SizeContainer>
 ```
-
-For complex components (organisms, templates, pages, ...) we can just click on "show code" and copy/paste the code to our project.

--- a/src/components/atoms/AlertBox/AlertBox.md
+++ b/src/components/atoms/AlertBox/AlertBox.md
@@ -1,4 +1,8 @@
-Styled AlertBox component
+### Summary
+
+`<Alertbox />` can be used to alert something important to the user within an interface. Its icon can be customised.
+
+### Example
 
 ```js
 import { AlertBox, Link, Text, SizedContainer } from '@zopauk/react-components';

--- a/src/components/atoms/Badge/Badge.md
+++ b/src/components/atoms/Badge/Badge.md
@@ -1,6 +1,12 @@
+### Summary
+
 Use the `<Badge />` component to label elements in the user interface.
 
-There's four different styles available:
+There's four variations available and accepts the same sizes as [`<Text />`](#/Components/Atoms/Text).
+
+### Examples
+
+- Variations
 
 ```js
 import { Fragment } from 'react';
@@ -28,7 +34,7 @@ import { Badge } from '@zopauk/react-components';
 </Fragment>;
 ```
 
-For sizing, you can supply the same `"size"` prop as for [`<Text />`](#/Components?id=text)
+- Sizes
 
 ```js
 import { Fragment } from 'react';

--- a/src/components/atoms/Button/Button.md
+++ b/src/components/atoms/Button/Button.md
@@ -1,24 +1,12 @@
-Styled button component
+### Summary
 
-- Primary
-- Secondary
-- Disabled
-- Link button
-- Warning
-- Alert
-- Large
-- Small
-- Compact
-- Right icon
-- Left icon
-- Full width
-- Primary contrast
-- Secondary contrast
-- Link contrast
+Use `<Button />` whenever you need to render a call to action within a **Zopa interface**.
 
-### Primary
+It comes in a lot of variations to suit different needs.
 
-Used for the main call to action. Should only appear once per screen.
+### Examples
+
+- Primary ( _used for the main call to action, should only appear once per screen._ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -26,9 +14,7 @@ import { Button } from '@zopauk/react-components';
 <Button styling="primary">Button smash</Button>;
 ```
 
-### Secondary
-
-Standard button for most actions.
+- Secondary ( _standard button for most actions_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -36,9 +22,7 @@ import { Button } from '@zopauk/react-components';
 <Button styling="secondary">Button smash</Button>;
 ```
 
-### Disabled
-
-For use when actions are disabled, both primary and secondary.
+- Disabled state ( _for use when actions are disabled, both primary and secondary_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -46,9 +30,7 @@ import { Button } from '@zopauk/react-components';
 <Button disabled={true}>Button smash</Button>;
 ```
 
-### Link button
-
-Used to navigate to other pages, always in current window unless external icon is present.
+- Text button ( _used to navigate to other pages, always in current window unless external icon is present_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -56,9 +38,7 @@ import { Button } from '@zopauk/react-components';
 <Button styling="link">Link smash</Button>;
 ```
 
-### Warning
-
-For potentially risky actions.
+- Warning state ( _for potentially risky actions_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -66,9 +46,7 @@ import { Button } from '@zopauk/react-components';
 <Button styling="warning">Proceed</Button>;
 ```
 
-### Alert
-
-For very dangerous actions!
+- Alert state ( _for very dangerous actions_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -76,9 +54,7 @@ import { Button } from '@zopauk/react-components';
 <Button styling="alert">Delete</Button>;
 ```
 
-### Large
-
-Rarely to be used, but it's here.
+- Large size ( _rarely to be used, but it's here_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -86,9 +62,7 @@ import { Button } from '@zopauk/react-components';
 <Button sizing="large">Big smash</Button>;
 ```
 
-### Small
-
-Mainly used when many actions are available in close proximity.
+- Small size ( _mainly used when many actions are available in close proximity_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -96,9 +70,7 @@ import { Button } from '@zopauk/react-components';
 <Button sizing="small">Little smash</Button>;
 ```
 
-### Compact
-
-For when the link style just won't work.
+- Compact size ( _for when the link style just won't work_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -106,9 +78,7 @@ import { Button } from '@zopauk/react-components';
 <Button sizing="compact">Tiny smash</Button>;
 ```
 
-### Right icon
-
-Can be used with arrows, among other icons.
+- With an icon on its right side ( _can be used with arrows, among other icons_ )
 
 ```jsx
 import { AlertIcon, Button } from '@zopauk/react-components';
@@ -116,9 +86,7 @@ import { AlertIcon, Button } from '@zopauk/react-components';
 <Button rightIcon={<AlertIcon fillColor="#fff" />}>Learn more</Button>;
 ```
 
-### Left icon
-
-For when the icon conveys the meaning faster than text.
+- With an icon on its left side ( _for when the icon conveys the meaning faster than text_ )
 
 ```jsx
 import { AlertIcon, Button } from '@zopauk/react-components';
@@ -126,9 +94,7 @@ import { AlertIcon, Button } from '@zopauk/react-components';
 <Button leftIcon={<AlertIcon fillColor="#fff" />}>Smash now</Button>;
 ```
 
-### Full width
-
-For when the button should stretch the entire width of the divider.
+- Full width ( _for when the button should stretch the entire width of the divider_ )
 
 ```jsx
 import { Button } from '@zopauk/react-components';
@@ -136,9 +102,7 @@ import { Button } from '@zopauk/react-components';
 <Button fullWidth={true}>Button smash</Button>;
 ```
 
-### Primary contrast
-
-Note that the text colour is the same as the background (always!)
+- Primary contrast ( _note that the text colour is the same as the background_ )
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "2px solid #efefef" } } }
 import { Button, colors } from '@zopauk/react-components';
@@ -148,9 +112,7 @@ import { Button, colors } from '@zopauk/react-components';
 </Button>;
 ```
 
-### Secondary contrast
-
-The border should be the colour's shade in 50 or close to that.
+- Secondary contrast ( _the border should be the colour's shade in 50 or close to that_ )
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "2px solid #efefef" } } }
 import { Button, colors } from '@zopauk/react-components';
@@ -160,9 +122,7 @@ import { Button, colors } from '@zopauk/react-components';
 </Button>;
 ```
 
-### Link contrast
-
-See above.
+- Text button contrast ( _see above_ )
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "2px solid #efefef" } } }
 import { Button } from '@zopauk/react-components';

--- a/src/components/atoms/Card/Card.md
+++ b/src/components/atoms/Card/Card.md
@@ -1,8 +1,12 @@
-The design team has agreed on two variations of cards depending on the context:
+### Summary
 
-#### Default variant
+`<Card />` can be used to highlight / categorise content within an interface.
 
-A standard or default card, which we'll assume if the type property has been omitted or set explicitly to card. As of this writing, cards of this type are non-interactable and have a border radius of 4px.
+It comes with two variations.
+
+### Examples
+
+- Default
 
 ```js { "props": { "style": { "backgroundColor": "#141E64", "border": "none"  } } }
 import { Card, Text } from '@zopauk/react-components';
@@ -12,9 +16,7 @@ import { Card, Text } from '@zopauk/react-components';
 </Card>;
 ```
 
-#### Link variant
-
-A card that is meant to be clickable and respond to user interactions (hover effects et al). Border radius of 8px. Note that any additional **styles and effects are meant to be added separately** by using this component as a base on which to build another with the desired effects.
+- Link variation
 
 Cards of type `"linkCard"` are meant to be used to build components that interact with user actions.
 

--- a/src/components/atoms/Dropdown/Dropdown.md
+++ b/src/components/atoms/Dropdown/Dropdown.md
@@ -1,9 +1,12 @@
-Styled Dropdown component.
+### Summary
 
-It consists of 2 components:
+`<Dropdown />` is a component extending the native HTML `<select />` element.
 
-- `<Dropdown />`: which extends from html `<select>` element
-- `<Option />`: which extends from html `<option>` element
+`<DropdownOption />` extemds the native HTML `<option />` element.
+
+### Examples
+
+- Standard
 
 ```jsx
 import { Dropdown, DropdownOption } from '@zopauk/react-components';
@@ -16,7 +19,7 @@ import { Dropdown, DropdownOption } from '@zopauk/react-components';
 </Dropdown>;
 ```
 
-#### hasError
+- With error
 
 ```jsx
 import { Dropdown, DropdownOption } from '@zopauk/react-components';

--- a/src/components/atoms/ErrorMessage/ErrorMessage.md
+++ b/src/components/atoms/ErrorMessage/ErrorMessage.md
@@ -1,6 +1,8 @@
-Error message for input Components. This component is meant to be used with an input.
+### Summary
 
-For a more complex component check `TextField`.
+Use `<ErrorMessage />` to render an error message, usually next to a form input.
+
+### Example
 
 ```jsx
 import { ErrorMessage } from '@zopauk/react-components';

--- a/src/components/atoms/Heading/Heading.md
+++ b/src/components/atoms/Heading/Heading.md
@@ -1,4 +1,4 @@
-### Guidelines ⚠️ 💯
+### Summary
 
 1. Whenever you want to render a heading on any UI at Zopa, use the `<Heading />` component
 2. Supply an `as` prop to specify which level to render: "h1" | "h2" | "h3" | "h4"
@@ -8,7 +8,7 @@
 
 ### Examples
 
-#### Variations
+- Variations
 
 ```jsx
 import { Fragment } from 'react';
@@ -22,7 +22,7 @@ import { Heading } from '@zopauk/react-components';
 </Fragment>;
 ```
 
-#### White-space
+- With white-space
 
 ```jsx
 import { Fragment } from 'react';

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -21,6 +21,7 @@ interface IStyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
 
 const StyledHeading = styled(Text)<IStyledHeadingProps>`
   font-size: ${({ as }) => headingSizes[as]};
+  font-family: ${typography.primary};
   line-height: ${typography.lineHeights.heading};
   letter-spacing: -0.5px;
   margin: 0;

--- a/src/components/atoms/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/atoms/Heading/__snapshots__/Heading.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Heading /> it can render with a different HTML tag: "h1" 1`] = `
 .c0 {
   font-size: 48px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   line-height: 1.2;
   -webkit-letter-spacing: -0.5px;
   -moz-letter-spacing: -0.5px;
@@ -22,6 +23,7 @@ exports[`<Heading /> it can render with a different HTML tag: "h1" 1`] = `
 exports[`<Heading /> it can render with a different HTML tag: "h2" 1`] = `
 .c0 {
   font-size: 28px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   line-height: 1.2;
   -webkit-letter-spacing: -0.5px;
   -moz-letter-spacing: -0.5px;
@@ -41,6 +43,7 @@ exports[`<Heading /> it can render with a different HTML tag: "h2" 1`] = `
 exports[`<Heading /> it can render with a different HTML tag: "h3" 1`] = `
 .c0 {
   font-size: 24px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   line-height: 1.2;
   -webkit-letter-spacing: -0.5px;
   -moz-letter-spacing: -0.5px;
@@ -60,6 +63,7 @@ exports[`<Heading /> it can render with a different HTML tag: "h3" 1`] = `
 exports[`<Heading /> it can render with a different HTML tag: "h4" 1`] = `
 .c0 {
   font-size: 20px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   line-height: 1.2;
   -webkit-letter-spacing: -0.5px;
   -moz-letter-spacing: -0.5px;
@@ -79,6 +83,7 @@ exports[`<Heading /> it can render with a different HTML tag: "h4" 1`] = `
 exports[`<Heading /> renders without  a11y violations 1`] = `
 .c0 {
   font-size: 48px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   line-height: 1.2;
   -webkit-letter-spacing: -0.5px;
   -moz-letter-spacing: -0.5px;

--- a/src/components/atoms/InputLabel/InputLabel.md
+++ b/src/components/atoms/InputLabel/InputLabel.md
@@ -1,6 +1,8 @@
-Label for input Components. This component is meant to be used with an input.
+### Summary
 
-For a more complex component check `TextField`.
+Use `<InputLabel />` to render a native HTML `<label />`.
+
+### Example
 
 ```jsx
 import { InputLabel } from '@zopauk/react-components';

--- a/src/components/atoms/InputText/InputText.md
+++ b/src/components/atoms/InputText/InputText.md
@@ -1,6 +1,12 @@
-Input native component. Simple component for input text, for more complex approach see `TextField` component``
+### Summary
 
-#### Default state
+Use `<TextInput />` to render a native HTML `<input />`.
+
+For a richer input see [`<TextField />`](/#/Components/Molecules/TextField).
+
+### Example
+
+- Default
 
 ```jsx
 import { InputText } from '@zopauk/react-components';
@@ -8,7 +14,7 @@ import { InputText } from '@zopauk/react-components';
 <InputText name="default" defaultValue="example of input" />;
 ```
 
-#### IsValid
+- Valid state
 
 ```jsx
 import { InputText } from '@zopauk/react-components';
@@ -16,7 +22,7 @@ import { InputText } from '@zopauk/react-components';
 <InputText name="isValid" isValid={true} />;
 ```
 
-#### hasError
+- With error
 
 ```jsx
 import { InputText } from '@zopauk/react-components';
@@ -24,7 +30,7 @@ import { InputText } from '@zopauk/react-components';
 <InputText name="error" hasError={true} />;
 ```
 
-#### Disabled
+- Disabled
 
 ```jsx
 import { InputText } from '@zopauk/react-components';

--- a/src/components/atoms/Link/Link.md
+++ b/src/components/atoms/Link/Link.md
@@ -1,39 +1,41 @@
-Creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL.
+### Summary
 
-**Before using read this carefully**
+Use `<Link />` to create hyperlinks to other web pages, files, locations within the same page, email addresses, or any other URL.
 
-- Links are never Headers.
+⚠️ &nbsp; Links are never headings
 
-- Choose the color using this table:
+⚠️ &nbsp; Choose the color according to the following table:
 
-  | Background color | Font Color                       |
-  | ---------------- | -------------------------------- |
-  | white or grey    | colors.primary.blue500 (default) |
-  | dark colored     | respective 0/25 (lightest)       |
-  | light colored    | respective 900 (darkest)         |
+| Background color | Font Color                       |
+| ---------------- | -------------------------------- |
+| white or grey    | colors.primary.blue500 (default) |
+| dark colored     | respective 0/25 (lightest)       |
+| light colored    | respective 900 (darkest)         |
 
-Component with `target="_blank"`:
+### Examples
+
+- With `target="_blank"`
 
 ```js
 import { Text, Link } from '@zopauk/react-components';
 
 <Text size="large" as="p">
-  A big paragraph with
+  Some text with
   <Link target="_blank" href="http://duckduckgo.com" onClick={() => alert('Link clicked!')}>
     a link
-  </Link>!
+  </Link>
 </Text>;
 ```
 
-Component without `target="_blank"` (notice that the square disappeared!)
+- Without `target="_blank"` ( _notice that the square icon disappeared_ )
 
 ```js
 import { Text, Link } from '@zopauk/react-components';
 
 <Text size="large" as="p">
-  A big paragraph with
+  Some text with
   <Link href="http://duckduckgo.com" onClick={() => alert('Link clicked!')}>
     a link
-  </Link>!
+  </Link>
 </Text>;
 ```

--- a/src/components/atoms/README.md
+++ b/src/components/atoms/README.md
@@ -1,9 +1,21 @@
-Atoms are simple components.
+Atoms are usually made with only one single HTML element.
 
-Usually made with only one html element.
+- [`<AlertBox />`](/#/Components/Atoms/AlertBox) 
+- [`<Badge />`](/#/Components/Atoms/Badge) 
+- [`<Button />`](/#/Components/Atoms/Button) 
+- [`<Card />`](/#/Components/Atoms/Card) 
+- [`<Doprdown />`](/#/Components/Atoms/Doprdown) 
+- [`<ErrorMessage />`](/#/Components/Atoms/ErrorMessage) 
+- [`<Heading />`](/#/Components/Atoms/Heading) 
+- [`<InputLabel />`](/#/Components/Atoms/InputLabel) 
+- [`<InputText />`](/#/Components/Atoms/InputText) 
+- [`<Link />`](/#/Components/Atoms/Link) 
+- [`<SidekickCard />`](/#/Components/Atoms/SidekickCard) 
+- [`<Spinner />`](/#/Components/Atoms/Spinner) 
+- [`<Text />`](/#/Components/Atoms/Text) 
 
-Atoms are extendable. That means the atom should be able to be used as a parameter in the function `extend()` of `styled-components`.
+### Tips
 
-These components can be used in molecules (more complex components than atoms).
-
-Every atom component must extend of it's native html element. For example the `Button` component extends from `React.ButtonHTMLAttributes<HTMLButtonElement>`.
+- You can create [molecules](/#/Components/Molecules) out of atoms
+- Every atom component must extend its native HTML element
+  - for example the `Button` component extends from `React.ButtonHTMLAttributes<HTMLButtonElement>`.

--- a/src/components/atoms/SidekickCard/SidekickCard.md
+++ b/src/components/atoms/SidekickCard/SidekickCard.md
@@ -1,14 +1,12 @@
-These Action Cards can be used in isolation or paired with Hero Action Cards to create urgency around certain
-events.
+### Summary
 
-They Give customers feedback for their actions, such as giving the all-clear when something goes right,
-alerting them when something goes wrong, or telling them something has changed.
+These Action Cards can be used to create urgency around certain events.
 
-There are 3 types of SidekickCards:
+They come in three variations.
 
-#### triumph type
+### Examples
 
-For success messages. It shows a green left border and a green check mark.
+- Triumph
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { SidekickCard, Text } from '@zopauk/react-components';
@@ -19,9 +17,7 @@ import { SidekickCard, Text } from '@zopauk/react-components';
 </SidekickCard>;
 ```
 
-#### verified type
-
-For verification messages. It shows a green left border and a green squiggly circle check mark.
+- Verified
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { SidekickCard, Text } from '@zopauk/react-components';
@@ -32,9 +28,7 @@ import { SidekickCard, Text } from '@zopauk/react-components';
 </SidekickCard>;
 ```
 
-#### alert type
-
-For alert/warning messages. It shows a yellow left border and a yellow warning icon.
+- Alert
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
 import { SidekickCard, Text } from '@zopauk/react-components';

--- a/src/components/atoms/Spinner/Spinner.md
+++ b/src/components/atoms/Spinner/Spinner.md
@@ -1,4 +1,10 @@
-Spinner component
+### Summary
+
+Use `<Spinner />` whenever we need to notify the user that something is loading.
+
+⚠️ &nbsp; We're working with the design team to settle on a single variation. When using it please don't customise it and stick to the styles and colors shown in the example.
+
+### Example
 
 ```js
 import { colors, Spinner } from '@zopauk/react-components';

--- a/src/components/atoms/Text/Text.md
+++ b/src/components/atoms/Text/Text.md
@@ -1,4 +1,4 @@
-### Guidelines ⚠️ 💯
+### Summary
 
 1. Whenever you want to render text on any UI at Zopa, use the `<Text />` component
 2. Its size, weight, white-space and semantics can be customised according to context
@@ -7,7 +7,7 @@
 
 ### Examples
 
-#### Variations
+- Variations
 
 ```jsx
 import { Fragment } from 'react';
@@ -23,7 +23,7 @@ import { Text } from '@zopauk/react-components';
 </Fragment>;
 ```
 
-#### White-space
+- With white-space
 
 ```jsx
 import { Fragment } from 'react';
@@ -35,7 +35,7 @@ import { Text } from '@zopauk/react-components';
 </Fragment>;
 ```
 
-#### Sizes
+- Sizes
 
 ```jsx
 import { Fragment } from 'react';
@@ -50,7 +50,7 @@ import { Text } from '@zopauk/react-components';
 </Fragment>;
 ```
 
-#### Weights
+- Weights
 
 ```jsx
 import { Fragment } from 'react';

--- a/src/components/icons/Alert/Alert.md
+++ b/src/components/icons/Alert/Alert.md
@@ -1,4 +1,8 @@
-An Alert icon
+### Summary
+
+Use it to render an alert icon.
+
+### Example
 
 ```js
 import { AlertIcon } from '@zopauk/react-components';

--- a/src/components/icons/Arrow/Arrow.md
+++ b/src/components/icons/Arrow/Arrow.md
@@ -1,6 +1,8 @@
-This component is a wrapper around the svg code for Arrow's icon.
+### Summary
 
-Allowed directions are: `down` | `up` | `left` | `right` | `number` | `string`
+Use it to render an arrow icon. You can specify the direction of the arrow through the `direction` prop.
+
+### Example
 
 ```jsx
 import { Fragment } from 'react';

--- a/src/components/icons/CheckMark/CheckMark.md
+++ b/src/components/icons/CheckMark/CheckMark.md
@@ -1,4 +1,8 @@
-Wrapper around svg code for a checkmark icon.
+### Summary
+
+Use it to render a checkmark icon.
+
+### Example
 
 ```jsx
 import { CheckMarkIcon } from '@zopauk/react-components';

--- a/src/components/icons/Chevron/Chevron.md
+++ b/src/components/icons/Chevron/Chevron.md
@@ -1,6 +1,8 @@
-This component is a wrapper around the svg code for Chevron's icon.
+### Summary
 
-Allowed directions are 'down' | 'up' | 'left' | 'right' | number | string
+Use it to render a chevron icon. You can specify the direction of the chevron through the `direction` prop.
+
+### Example
 
 ```jsx
 import { Fragment } from 'react';

--- a/src/components/icons/Hamburger/Hamburger.md
+++ b/src/components/icons/Hamburger/Hamburger.md
@@ -1,4 +1,8 @@
-This component is a wrapper around the svg code for Hamburger's icon.
+### Summary
+
+Use it to render an hamburger icon.
+
+### Example
 
 ```jsx
 import { HamburgerIcon } from '@zopauk/react-components';

--- a/src/components/icons/Profile/Profile.md
+++ b/src/components/icons/Profile/Profile.md
@@ -1,4 +1,8 @@
-This component is a wrapper around the svg code for Profile's icon.
+### Summary
+
+Use it to render a user profile icon.
+
+### Example
 
 ```jsx
 import { ProfileIcon } from '@zopauk/react-components';

--- a/src/components/icons/README.md
+++ b/src/components/icons/README.md
@@ -1,5 +1,17 @@
-Icons and logos of Zopa.
+Iconography related to Zopa's brand.
 
-SVGs are preferred. SVGs must be optimized with the tool: [SVGOMG](https://jakearchibald.github.io/svgomg/).
+- [`<AlertIcon />`](/#/Components/Icons/Alert)
+- [`<ArrowIcon />`](/#/Components/Icons/Arrow)
+- [`<CheckMarkIcon />`](/#/Components/Icons/CheckMark)
+- [`<ChevronIcon />`](/#/Components/Icons/Chevron)
+- [`<HamburgerIcon />`](/#/Components/Icons/Hamburger)
+- [`<ProfileIcon />`](/#/Components/Icons/Profile)
+- [`<ZopaIconIcon />`](/#/Components/Icons/ZopaIcon)
 
-Every SVG component in this folder must extend of `React.SVGProps<SVGSVGElement>`.
+### Tips
+
+- Note that every component has the word `"Icon"` on their name
+  - so that when importing we can easily understand it's meant to render an SVG icon.
+- We perfer to use SVG to ensure good display on any device resolution
+  - please compress them with [SVGOMG](https://jakearchibald.github.io/svgomg/).
+- Every component in this folder must extend of `React.SVGProps<SVGSVGElement>` for proper typing.

--- a/src/components/icons/ZopaLogo/ZopaLogo.md
+++ b/src/components/icons/ZopaLogo/ZopaLogo.md
@@ -1,4 +1,8 @@
-This component is a wrapper around the svg code for Zopa's logo.
+### Summary
+
+Use it to render Zopa's logo as an SVG.
+
+### Example
 
 ```jsx
 import { ZopaIcon } from '@zopauk/react-components';

--- a/src/components/layout/FlexCol/FlexCol.md
+++ b/src/components/layout/FlexCol/FlexCol.md
@@ -1,6 +1,10 @@
-The `FlexCol` component is meant to be used a child component of `FlexRow` as its padding is offset by `FlexRow`'s negative horizontal margins.
+### Summary
 
-Standard grid:
+`<FlexCol />` is meant to be used a child component of `<FlexRow />` ... its padding is offset by `<FlexRow />` _negative_ horizontal margin.
+
+### Examples
+
+- Standard layout
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -20,7 +24,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Content based grid (collapsing on mobile)
+- Content based layout ( _collapsing on mobile_ )
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -37,7 +41,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Flexbox responsive layouts:
+- Responsive layout
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -54,7 +58,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Layout with a column hidden on small screen:
+- Layout with a column hidden on small screens
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -71,7 +75,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Layout with a column order swapped on small screen:
+- Layout with column order swapped on small screens
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -88,7 +92,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Grid aligned vertically:
+- Layout aligned vertically
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -105,7 +109,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Each column with different vertical alignment
+- Each column with different vertical alignment
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -128,7 +132,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Grid with custom gutter (48px):
+- Layout with custom gutter ( `48px` )
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
@@ -148,7 +152,7 @@ import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';
 </FlexContainer>;
 ```
 
-Grid with custom number of column (5):
+- Layout with custom number of columns ( `5` )
 
 ```jsx
 import { FlexContainer, FlexRow, FlexCol } from '@zopauk/react-components';

--- a/src/components/layout/FlexContainer/FlexContainer.md
+++ b/src/components/layout/FlexContainer/FlexContainer.md
@@ -1,3 +1,6 @@
-`<FlexContainer />` component is meant to be used as a wrap `<FlexRow />` when building a grid.
+### Summary
 
-Its responsibility is to set the grid's `max-width`, `gutter` and making sure it's centred horizontally within the viewport.
+`<FlexContainer />` is meant to wrap `<FlexRow />`
+
+- Its main goal is to set the layout `max-width` and `gutter`; making sure the layout stays horizontally centred within the viewport 📐
+- See [`<FlexCol />`](/#/Components/Layout/FlexCol) docs for usage examples.

--- a/src/components/layout/FlexRow/FlexRow.md
+++ b/src/components/layout/FlexRow/FlexRow.md
@@ -1,5 +1,7 @@
+### Summary
+
 `<FlexRow />` is meant to be a child of `<FlexContainer />`.
 
-If your goal is to make a nested layout, then it can also be a child of a `<FlexCol />` or any JSX element.
-
-**Be mindful** that `<FlexCol />` should be his direct child.
+- If your goal is to make a nested layout, then it can also be a child of a `<FlexCol />` or any JSX element.
+- **Be mindful** that it needs to have `<FlexCol />` as its direct child.
+- See [`<FlexCol />`](/#/Components/Layout/FlexCol) docs for usage examples.

--- a/src/components/layout/README.md
+++ b/src/components/layout/README.md
@@ -1,2 +1,6 @@
-Responsive grid system based on [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
-for better support with Internet Explorer 11.
+Utilities to build a responsive layout based on [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) ( _note that we aim to support Internet Explorer 11_ )
+
+- [`<FlexCol />`](/#/Components/Layout/FlexCol)
+- [`<FlexContainer />`](/#/Components/Layout/FlexContainer)
+- [`<FlexRow />`](/#/Components/Layout/FlexRow)
+- [`<SizedContainer />`](/#/Components/Layout/SizedContainer)

--- a/src/components/layout/SizedContainer/SizedContainer.md
+++ b/src/components/layout/SizedContainer/SizedContainer.md
@@ -1,6 +1,10 @@
-Use `<SiedContainer />` to set a `max-width` around its children:
+### Summary
 
-#### Short size
+You can use `<SiedContainer />` to set a `max-width` around its children.
+
+### Examples
+
+- Short size
 
 ```jsx
 import { SizedContainer } from '@zopauk/react-components';
@@ -10,7 +14,7 @@ import { SizedContainer } from '@zopauk/react-components';
 </SizedContainer>;
 ```
 
-#### Medium size
+- Medium size
 
 ```jsx
 import { SizedContainer } from '@zopauk/react-components';
@@ -20,7 +24,7 @@ import { SizedContainer } from '@zopauk/react-components';
 </SizedContainer>;
 ```
 
-#### Long size
+- Long size
 
 ```jsx
 import { SizedContainer } from '@zopauk/react-components';
@@ -30,7 +34,7 @@ import { SizedContainer } from '@zopauk/react-components';
 </SizedContainer>;
 ```
 
-#### FullLength size
+- Fulll-length size
 
 ```jsx
 import { SizedContainer } from '@zopauk/react-components';

--- a/src/components/molecules/CheckboxField/CheckboxField.md
+++ b/src/components/molecules/CheckboxField/CheckboxField.md
@@ -1,17 +1,19 @@
-This is a wrapper of 2 different components:
+### Summary
 
-- Build-in custom checkbox input: This component is attached to the `label` so it's not possible to use standalone.
-- InputLabel: Only rendered if the prop `label` is filled in. This component has his own custom styles to show the
-  checkbox image (square), so it's not possible to use standalone.
-- ErrorMessage: Error message. Only rendered if the prop `errorMessage` is filled in.
+`<CheckboxField />` is a convenience wrapper around HTML `<input type="checkbox" />` and two **atoms**:
 
-`inputProps.name` must be set so it's used to automatically set:
+- [`<InputLabel />`](/#/Components/Atoms/InputLabel)
+- [`<ErrorMessage />`](/#/Components/Atoms/ErrorMessage)
 
-- `htmlFor` in the `InputLabel` component.
-- `data-automation` in the `ErrorMessage`
-- `id` in `InputCheckbox` for automation test purposes.
+⚠️ &nbsp;Note that a `name` prop **must be provided** to automatically set:
 
-#### Default state
+- `htmlFor` prop in `<InputLabel />`
+- `data-automation` prop in `<ErrorMessage />`
+- `id` prop in `<input type="checkbox" />` for accessibility and automation purposes
+
+### Examples
+
+- Default
 
 ```jsx
 import { CheckboxField } from '@zopauk/react-components';
@@ -19,7 +21,7 @@ import { CheckboxField } from '@zopauk/react-components';
 <CheckboxField inputProps={{ name: 'check1' }} />;
 ```
 
-#### Checked
+- Checked state
 
 ```jsx
 import { CheckboxField } from '@zopauk/react-components';
@@ -27,7 +29,7 @@ import { CheckboxField } from '@zopauk/react-components';
 <CheckboxField inputProps={{ name: 'text2', defaultChecked: true }} />;
 ```
 
-#### With label
+- With a label
 
 ```jsx
 import { CheckboxField } from '@zopauk/react-components';
@@ -39,7 +41,7 @@ import { CheckboxField } from '@zopauk/react-components';
 </>;
 ```
 
-#### With error
+- With an error
 
 ```jsx
 import { CheckboxField } from '@zopauk/react-components';

--- a/src/components/molecules/DropdownField/DropdownField.md
+++ b/src/components/molecules/DropdownField/DropdownField.md
@@ -1,4 +1,8 @@
-`<DropdownField />` has exactly the same behaviour as `<TextField />`, the only difference being that it renders a `<Dropdown />` instead of `<InputText />`.
+### Summary
+
+`<DropdownField />` has exactly the same behaviour as [`<TextField />`](/#/Components/Molecules/TextField), the only difference being that it renders with `<Dropdown />` instead of `<InputText />`.
+
+### Example
 
 ```jsx
 import { DropdownField } from '@zopauk/react-components';

--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.md
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.md
@@ -1,36 +1,38 @@
 ![BETA](https://img.shields.io/badge/BETA-0.0.4-yellow.svg)
 
-Styled Dropdown component with typing filter.
+### Summary
 
-This is a wrapper of 4 different components using [paypal/downshift](https://github.com/paypal/downshift):
+`<DropdownFiltered />` is a custom dropdown with a filter applied on typing.
 
-- SizedContainer: Div container with size prop.
-- InputText: Native input text.
-- InputLabel: Label text. Only rendered if the prop `label` is filled in.
-- SizedContainer: Error message. Only rendered if the prop `errorMessage` is filled in.
+It wrap four components:
 
-### TODO:
+- [`<SizedContainer />`](/#/Components/Layout/SizedContainer)
+- [`<InputText />`](/#/Components/Atoms/InputText)
+- [`<InputLabel />`](/#/Components/Atoms/InputLabel)
+- [`<ErrorMessage />`](/#/Components/Atoms/ErrorMessage)
 
-- Improve code readability
-- Add tests for filter
+And uses [paypal/downshift](https://github.com/paypal/downshift) internally.
 
-### Features:
+How it works:
 
-- Default value (see examples)
-- Close options on click over
-- Filter text: any case and any substring
-- Extendable: all props from [paypal/downshift](https://github.com/paypal/downshift) can also
-  be applied.
-
-### How it works
-
-Under the hood:
-
-- It uses [paypal/downshift](https://github.com/paypal/downshift).
 - The filtered text is always display in an input text.
 - The selected item is passed to the onChange function.
 
-Basic example:
+Also note that:
+
+- You can set a default value ( see the examples 👇🏻 )
+- Options lists closes when clicking outside of it
+- All props from [paypal/downshift](https://github.com/paypal/downshift) can be applied to it
+
+### Todos
+
+- Improve code readability
+- Simplify prop API 🤯
+- Test filter functionality
+
+### Examples
+
+- Standard
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';
@@ -49,7 +51,7 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 />;
 ```
 
-#### With default value
+- With default value
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';
@@ -69,7 +71,7 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 />;
 ```
 
-#### Long list and a optionsListMaxHeight
+- Long list with a `max-height` applied to it
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';
@@ -141,7 +143,7 @@ const items = [
 />;
 ```
 
-#### With errorMessage
+- With an error message
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';
@@ -161,7 +163,7 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 />;
 ```
 
-#### isValid
+- Valid state
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';
@@ -181,7 +183,7 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 />;
 ```
 
-#### disabled
+- Disabled
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';
@@ -202,7 +204,7 @@ const items = [{ value: 'apple' }, { value: 'pear' }, { value: 'orange' }, { val
 />;
 ```
 
-#### size is "short"
+- With a short size
 
 ```jsx
 import { DropdownFiltered } from '@zopauk/react-components';

--- a/src/components/molecules/Help/Help.md
+++ b/src/components/molecules/Help/Help.md
@@ -1,4 +1,10 @@
-This is a Help component that should sit ontop of the Footer to give the customer information about our opening hours and the phone numbers to call for specific products.
+### Summary
+
+If used, `<Help />` should sit ontop of [`<ZopaFooter />`](/#/Components/Molecules/ZopaFooter).
+
+Its aim is to give the customer information about Zopa's customer service opening hours and phone numbers to call about specific products.
+
+### Example
 
 ```jsx
 import { Help } from '@zopauk/react-components';

--- a/src/components/molecules/Help/Help.tsx
+++ b/src/components/molecules/Help/Help.tsx
@@ -35,10 +35,10 @@ const Help: React.FunctionComponent<IHelpProps> = ({ email }) => (
       </FlexRow>
       <FlexRow gutter={16}>
         <FlexCol xs={12} l={6}>
-          <Text size="large">
+          <Text size="large" mb>
             <Link href={`mailto:${email}`}>{email}</Link>
           </Text>
-          <Text size="large">
+          <Text size="large" mb>
             <Link href="tel:020 7580 6060">020 7580 6060 </Link>
             for loans
           </Text>

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -7,13 +7,27 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  display: block;
+  margin-bottom: 24px;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
   font-size: 16px;
 }
 
-.c9 {
+.c8 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 16px;
+}
+
+.c10 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -49,6 +63,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
 
 .c4 {
   font-size: 24px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   line-height: 1.2;
   -webkit-letter-spacing: -0.5px;
   -moz-letter-spacing: -0.5px;
@@ -114,7 +129,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   max-width: 900px;
 }
 
-.c8 {
+.c9 {
   max-width: 350px;
 }
 
@@ -201,7 +216,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           for loans
         </span>
         <span
-          class="c6"
+          class="c8"
         >
           <a
             class="c7"
@@ -217,16 +232,16 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
         cols="12"
       >
         <div
-          class="c8"
+          class="c9"
         >
           <p
-            class="c6"
+            class="c8"
           >
             Monday to Thursday (8am to 8pm), and Friday (8am to 5pm)
           </p>
         </div>
         <p
-          class="c9"
+          class="c10"
         >
           We can't take applications over the phone. UK residents only. Calls may be monitored.
         </p>

--- a/src/components/molecules/Modal/Modal.md
+++ b/src/components/molecules/Modal/Modal.md
@@ -1,18 +1,20 @@
-Modal is a flexible dialog prompt.
+### Summary
 
-It is just a simple wrapper around [`react-modal`](http://reactcommunity.org/react-modal/) with some default styling.
+`<Modal />` is a flexible dialog prompt wrapping [`react-modal`](http://reactcommunity.org/react-modal/) with some basic styles.
 
-All the props are being passed down to `react-modal` so if you want to customize it, please refer to its documentation.
+Props are passed down to `react-modal` so if you want to customize it, please refer to its documentation.
 
-**Notes ⚠️**:
+#### Requisites ⚠️
 
-- You can control the CSS `z-index` value applied on the rendered modal through the `zIndex` prop on `<Modal.Styles />` ( 👀 example below )
+- For the accessibility, call `Modal.setAppElement('#rootElementId')` in the root component before any of the modals are open.
+- Include `<Modal.Styles>` component (preferably in a top-most level component)
 
-- For the accessibility reasons, you should call `Modal.setAppElement('#rootElementId')` in the root component before any of the modals are open.
+#### Tips 💬
 
-- You'll also need to include `<Modal.Styles>` component (preferably in the top level component) that contains the global styles of the modal.
+- Control the CSS `z-index` value applied to the modal through the `zIndex` prop on `<Modal.Styles />`
+- Supply `onRequestClose` to close the modal when the user clicks on its overlay ( see [`react-modal` docs](http://reactcommunity.org/react-modal/examples/on_request_close.html) )
 
-- Note that in order to make `<Modal />` to close when the user clicks on the overlay, you'll need to do so in a handler supplied to the `onRequestClose` prop. See [`react-modal` documentation](http://reactcommunity.org/react-modal/examples/on_request_close.html) for more background about this.
+### Example
 
 ```jsx
 import { Modal, Button, Heading } from '@zopauk/react-components';

--- a/src/components/molecules/Progress/Progress.md
+++ b/src/components/molecules/Progress/Progress.md
@@ -1,4 +1,8 @@
-Progress bar to show the current step of a journey and its total steps.
+### Summary
+
+`<Progress />` is meant to show the current progress on a journey composed of multiple steps.
+
+### Example
 
 ```jsx { "props": { "style": { "padding": "20px 10px 30px" } } }
 import { colors, Progress } from '@zopauk/react-components';

--- a/src/components/molecules/README.md
+++ b/src/components/molecules/README.md
@@ -1,6 +1,11 @@
-Molecules are wrappers of multiple simple components.
+Molecules are a collection of **atoms** to build customised pieces of UI at Zopa.
 
-It’s only extendable with styled-component the top parent component. Other extensions will have his own prop (e.j.: inputProps).
-See `TextField` for a working example.
-
-Molecules are reusable in organisms (components more complex than molecules).
+- [`<CheckboxField />`](/#/Components/Molecules/CheckboxField)
+- [`<DropdownField />`](/#/Components/Molecules/DropdownField)
+- [`<DropdownFiltered />`](/#/Components/Molecules/DropdownFiltered)
+- [`<Help />`](/#/Components/Molecules/Help)
+- [`<Modal />`](/#/Components/Molecules/Modal)
+- [`<Progress />`](/#/Components/Molecules/Progress)
+- [`<RadioField />`](/#/Components/Molecules/RadioField)
+- [`<TextField />`](/#/Components/Molecules/TextField)
+- [`<ZopaFooter />`](/#/Components/Molecules/ZopaFooter)

--- a/src/components/molecules/RadioField/RadioField.md
+++ b/src/components/molecules/RadioField/RadioField.md
@@ -1,19 +1,19 @@
-`<RadioField />` is a single radio field element.
+### Summary
 
-Its error message is meant to be shown in a group of them.
+`<RadioField />` is a convenient wrapper that renders the following HTML elements:
 
-It's composed of three HTML elements:
-
-- `input`: input radio component, hidden for styling purposes\_
+- `input`: input radio component, hidden for styling purposes
 - `label`: text to show next to the radio field. It uses CSS `::after` and `::before` to draw the actual circles of the radio field
 - `div`: container to wrap the two previous elements.
 
-`value` must be provided so that it internally sets:
+⚠️ &nbsp;Note that a `value` prop **must be provided** to automatically set:
 
 - `htmlFor` prop on the `<InputLabel />` component.
 - `id` prop on `<InputRadio />` so that is easily to query (.i.e automated tests).
 
-#### default
+### Examples
+
+- Default
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';
@@ -21,7 +21,7 @@ import { RadioField } from '@zopauk/react-components';
 <RadioField label="option" inputProps={{ value: 'option', name: 'option' }} />;
 ```
 
-#### with error
+- With an error
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';
@@ -29,7 +29,7 @@ import { RadioField } from '@zopauk/react-components';
 <RadioField hasError={true} label="option" inputProps={{ value: 'radio2', name: 'radio2' }} />;
 ```
 
-#### valid
+- Valid state
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';
@@ -37,7 +37,7 @@ import { RadioField } from '@zopauk/react-components';
 <RadioField isValid={true} label="option" inputProps={{ value: 'radio3', name: 'radio3' }} />;
 ```
 
-#### pre-selected
+- Pre-selected
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';
@@ -45,7 +45,7 @@ import { RadioField } from '@zopauk/react-components';
 <RadioField label="I'm checked by default" inputProps={{ value: 'radio4', name: 'radio4', defaultChecked: true }} />;
 ```
 
-#### disabled and pre-selected
+- Disabled and pre-selected
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';
@@ -56,7 +56,7 @@ import { RadioField } from '@zopauk/react-components';
 />;
 ```
 
-#### disabled, valid and pre-selected
+- Disabled, valid and pre-selected
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';
@@ -68,7 +68,7 @@ import { RadioField } from '@zopauk/react-components';
 />;
 ```
 
-#### multiple choices
+- Multiple choices
 
 ```jsx
 import { RadioField } from '@zopauk/react-components';

--- a/src/components/molecules/TextField/TextField.md
+++ b/src/components/molecules/TextField/TextField.md
@@ -1,18 +1,21 @@
-`<TextField />` is a wrapper composed of four different components:
+### Summary
 
-- `<SizedContainer />` ... ( _container with `size` prop_ )
-- `<InputText />` ... ( _native input text_ )
-- `<InputLabel />` ... ( _label text, only rendered if the prop `label` is provided_ )
-- `<HelpText />` ... ( _addition information_ )
-- `<SizedContainer />` ... ( _error message, only rendered if the prop `errorMessage` provided_ )
+`<TextField />` is a convenient wrapper composed of four different components:
 
-`name` must be provided to automatically set:
+- [`<SizedContainer />`](/#/Components/Layout/SizedContainer)
+- [`<InputText />`](/#/Components/Atoms/InputText)
+- [`<InputLabel />`](/#/Components/Atoms/InputLabel)
+- [`<ErrorMessage />`](/#/Components/Atoms/ErrorMessage)
+
+⚠️ &nbsp;Note that a `name` prop **must be provided** to automatically set:
 
 - `htmlFor` prop on `<InputLabel />`
 - `data-automation` prop on `<ErrorMessage />`
 - `id` prop on `<InputText />`
 
-#### default
+### Examples
+
+- Default
 
 ```jsx
 import { TextField } from '@zopauk/react-components';
@@ -20,7 +23,7 @@ import { TextField } from '@zopauk/react-components';
 <TextField inputProps={{ name: 'text1' }} />;
 ```
 
-#### specific size
+- With a specific size
 
 ```jsx
 import { TextField } from '@zopauk/react-components';
@@ -28,7 +31,7 @@ import { TextField } from '@zopauk/react-components';
 <TextField size="short" inputProps={{ name: 'text2' }} />;
 ```
 
-#### with label
+- With a label
 
 ```jsx
 import { TextField } from '@zopauk/react-components';
@@ -36,7 +39,7 @@ import { TextField } from '@zopauk/react-components';
 <TextField label="First name" inputProps={{ name: 'text3' }} />;
 ```
 
-#### with error message
+- With error message
 
 ```jsx
 import { TextField } from '@zopauk/react-components';
@@ -44,7 +47,7 @@ import { TextField } from '@zopauk/react-components';
 <TextField errorMessage="Oops ! Error !" inputProps={{ name: 'text4' }} />;
 ```
 
-#### valid
+- Valid state
 
 ```jsx
 import { TextField } from '@zopauk/react-components';
@@ -52,7 +55,7 @@ import { TextField } from '@zopauk/react-components';
 <TextField isValid={true} inputProps={{ name: 'text5' }} />;
 ```
 
-#### with label, help text, error message and specific size
+- With all the previous configuration
 
 ```jsx
 import { TextField } from '@zopauk/react-components';
@@ -66,7 +69,7 @@ import { TextField } from '@zopauk/react-components';
 />;
 ```
 
-#### with prefix
+- With a custom text prefix
 
 ```jsx
 import { TextField } from '@zopauk/react-components';

--- a/src/components/molecules/ZopaFooter/ZopaFooter.md
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.md
@@ -1,6 +1,10 @@
-ZopaFooter renders Zopa's standard footer with default links and the ability to provide custom links.
+### Summary
 
-#### default
+Use `<ZopaFooter />` to render Zopa's standard footer in a **Zopa application**.
+
+### Examples
+
+- Standard
 
 ```jsx
 import { ZopaFooter } from '@zopauk/react-components';
@@ -8,9 +12,7 @@ import { ZopaFooter } from '@zopauk/react-components';
 <ZopaFooter />;
 ```
 
-#### only legal section
-
-You can also reduce the footer to just the legal section on pages where you need the user to focus on a specific task like form applications.
+- Only with legal section
 
 ```jsx
 import { ZopaFooter } from '@zopauk/react-components';

--- a/src/components/organisms/Accordion/Accordion.md
+++ b/src/components/organisms/Accordion/Accordion.md
@@ -1,7 +1,10 @@
-Accordion doesn't render anything: it's just a namespace for `<Accordion.Header />` and `<Accordion.Section />` components.
+### Summary
 
-In order to create an accordion, you should use these components along with the `useAccordion` hook.
-See the example below for more details.
+`<Accordion />` doesn't render anything: it's just a namespace for `<Accordion.Header />` and `<Accordion.Section />`.
+
+In order to create an accordion, you will need to use these two components along with the `useAccordion` hook.
+
+### Example
 
 ```js
 import { useAccordion, Text } from '@zopauk/react-components';

--- a/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.md
+++ b/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.md
@@ -1,6 +1,13 @@
-This is a `Accordion` subcomponent and it is meant to be used along with other components such as `<AccordionSection />` and `useAccordion` hook. It is a button with a chevron icon that rotates according to the `isOpen` prop.
+### Summary
 
-Opened Accordion.Header
+<Accordion.Header /> renders a button with a chevron icon that rotates according to the `boolean` `isOpen` prop.
+
+- It's meant to be used along `<Accordion.Section>` and `useAccordion`.
+- [`<Accordion />`](/#/Components/Organisms/Accordion) examples for how they're all meant to play together.
+
+### Examples
+
+- Expanded
 
 ```js
 import { Accordion } from '@zopauk/react-components';
@@ -8,7 +15,7 @@ import { Accordion } from '@zopauk/react-components';
 <Accordion.Header isOpen={true}>opened accordion header</Accordion.Header>;
 ```
 
-Closed Accordion.Header
+- Collapsed
 
 ```js
 import { Accordion } from '@zopauk/react-components';

--- a/src/components/organisms/Accordion/AccordionSection/AccordionSection.md
+++ b/src/components/organisms/Accordion/AccordionSection/AccordionSection.md
@@ -1,5 +1,7 @@
-This is a subcomponent of `<Accordion />` and it is meant to be used along with other components such as `<Accordion.Header />` and the `useAccordion` hook.
+### Summary
 
-It is a simple block element that passes down the ref to its childs. This forwarding allows the section to be collapsible.
+<Accordion.Section /> is a simple block element that passes down its `ref` to its children.
+In this way, we can allow the section to be collapsible.
 
-Please refer to the `<Accordion />` documentation to see a working example.
+- It's meant to be used along `<Accordion.Section>` and `useAccordion`.
+- [`<Accordion />`](/#/Components/Organisms/Accordion) examples for how they're all meant to play together.

--- a/src/components/organisms/Navbar/Navbar.md
+++ b/src/components/organisms/Navbar/Navbar.md
@@ -1,4 +1,12 @@
-Basic example:
+### Summary
+
+`<Navbar />` doesn't render anything: it's just a namespace for `<Navbar.Dropdwn />`, `<Navbar.Dropdown />` and `<Navbar.Link />`.
+
+In order to create a navigation bar to be used within a **Zopa application**, you will need to leverage these components together.
+
+### Examples
+
+- Static
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "border": "2px solid #efefef" } } }
 import { Navbar, Link, HamburgerIcon, ProfileIcon } from '@zopauk/react-components';
@@ -48,7 +56,7 @@ import { Navbar, Link, HamburgerIcon, ProfileIcon } from '@zopauk/react-componen
 />;
 ```
 
-Responsive Navbar example:
+- Responsive
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "border": "2px solid #efefef" } } }
 import { Navbar, Link, HamburgerIcon, FlexCol } from '@zopauk/react-components';

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
@@ -1,6 +1,17 @@
-This is a flexible Navbar subcomponent meant to be used with other components such as Navbar.Link and Navbar.Layout. However, it can be used with other atoms and molecules as well (e.g Link). It handles the visibility state and all the related accessibility attributes internally and passes them down through render props: renderOpener and renderItem. Also, it handles the positioning of the dropdown list for you. It's aligned to the right by default; however, if there's not enough room for the dropdown, it gets aligned to the left.
+### Summary
 
-Basic example:
+The purpose of `<Navbar.Dropdown />` is to handle the visibility state of a dropdwon within the main navigation bar.
+
+It also handles all the accessibility attributes internally and passes them down through render props:`renderOpener` and `renderItem`.
+
+The dropdown will be aligned to the right by default; however, if there's not enough room for the dropdown, it align to the left instead.
+
+- It's meant to be used at least along `<Navbar.Layout>`
+- The dropdown contents are up to you but we highly recommend to use `<Navbar.Link />` for brand consistency
+
+### Examples
+
+- Standard usage
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7", "border": "2px solid #efefef"} } }
 import { Navbar } from '@zopauk/react-components';
@@ -28,7 +39,7 @@ import { Navbar } from '@zopauk/react-components';
 />;
 ```
 
-Example with custom components:
+- With custom components
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7", "border": "2px solid #efefef" } } }
 import { Navbar, Link, HamburgerIcon } from '@zopauk/react-components';

--- a/src/components/organisms/Navbar/NavbarLayout/NavbarLayout.md
+++ b/src/components/organisms/Navbar/NavbarLayout/NavbarLayout.md
@@ -1,7 +1,12 @@
-This is a Navbar subcomponent meant to be used with other components such as Navbar.Link and Navbar.Dropdown.
-However, it can be used with other atoms and molecules as well (e.g Link). It implements a basic layout for the navbar creating slots where you can add whatever components you please.
+### Summary
 
-White Navbar.Layout component
+`<Navbar.Layout>` renders the base navigation bar layout, creating **right** and **left** to render the contents you like.
+
+It's meant to be used with other `<Navbar />` components like `<Navbar.Layout>`
+
+### Examples
+
+- White theme
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#00B9A7", "border": "2px solid #efefef" } } }
 import { Navbar, Link } from '@zopauk/react-components';
@@ -9,7 +14,7 @@ import { Navbar, Link } from '@zopauk/react-components';
 <Navbar.Layout left={<Link>left</Link>} center={<Link>center</Link>} right={<Link>right</Link>} />;
 ```
 
-Teal Navbar.Layout component
+- Teal theme
 
 ```js { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#fff", "border": "2px solid #efefef" } } }
 import { Navbar, Link } from '@zopauk/react-components';

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.md
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.md
@@ -1,7 +1,12 @@
-This is a Navbar subcomponent meant to be used with other components such as Navbar.Layout and Navbar.Dropdown.
-It is the same as Link component except for two extra props: active and withChevron.
+### Summary
 
-Default Navbar.Link component
+`<Navbar.Link />` is a wrap aroudn our [`<Link />`](/#/Components/Atoms/Link) atom, decorated with tow extra props: `active` and `withChevron`.
+
+It's meant to be used with other `<Navbar />` components like `<Navbar.Layout>`
+
+### Examples
+
+- Default
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
@@ -9,7 +14,7 @@ import { Navbar } from '@zopauk/react-components';
 <Navbar.Link color="#fff">Navbar.Link</Navbar.Link>;
 ```
 
-Active Navbar.Link component
+- Active
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
@@ -19,7 +24,7 @@ import { Navbar } from '@zopauk/react-components';
 </Navbar.Link>;
 ```
 
-Navbar.Link withChevron down
+- With chevron icon pointing down
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';
@@ -29,7 +34,7 @@ import { Navbar } from '@zopauk/react-components';
 </Navbar.Link>;
 ```
 
-Navbar.Link withChevron up
+- With chevron icon pointing up
 
 ```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Navbar } from '@zopauk/react-components';

--- a/src/components/organisms/README.md
+++ b/src/components/organisms/README.md
@@ -1,1 +1,4 @@
-Organisms are a collection of atoms, molecules, and it's own specific sub-components.
+Organisms are a collection of **atoms**, **molecules**, and it's own specific **sub-components** to build large pieces of UI at Zopa.
+
+- [`<Navbar />`](/#/Components/Organisms/Navbar)
+- [`<Accordion />`](/#/Components/Organisms/Accordion)

--- a/src/content/Colors/Colors.md
+++ b/src/content/Colors/Colors.md
@@ -1,16 +1,12 @@
-This component is **NOT available in the library**. It is used for presentation purposes only.
-
-In the library we have access to the color constants as follows:
-
 ### Usage
+
+⚠️ &nbsp; `<Color />` is **NOT available in the library**. It is used for presentation on this page only.
 
 ```js static
 import { colors } from '@zopauk/react-components';
 
 const whiteColor = colors.base.white; // #fff
 ```
-
-You can modify the Colors component with a js object of colors. See props & methods for more info.
 
 ### Base Colors
 


### PR DESCRIPTION
## Summary

I noticed that the structure of our **markdown files** for documenting components wasn't consistent. 

I took the time to go through each and structure with the following sections:

- Props table
- Summary
- Examples

To make documentation **visually consistent** across all components 🎨

<img src="https://user-images.githubusercontent.com/5938217/63423700-2a037780-c40d-11e9-9d2b-880457361f42.png" width="600" />

<img src="https://user-images.githubusercontent.com/5938217/63423751-443d5580-c40d-11e9-9964-773ad868aea4.png" width="600" />

<img src="https://user-images.githubusercontent.com/5938217/63423777-4ef7ea80-c40d-11e9-91c1-ee9145cdfefd.png" width="600" />

I also their content, extending or simplifying where I saw fit 🤓

## Disclaimer

Again very opinionated PR here, no hard feeling to not getting it merged 🤗
