### PR TITLE
"color" prop for text components 🎨

### DIFF
--- a/src/components/atoms/Badge/Badge.tsx
+++ b/src/components/atoms/Badge/Badge.tsx
@@ -37,8 +37,8 @@ const fontColors: IFontColors = {
 };
 
 const StyledBadge = styled(Text)<IStyledBadgeProps>`
-  color: ${({ styling }) => styling && fontColors[styling]};
-  background-color: ${({ styling }) => styling && backgroundColors[styling]};
+  color: ${({ styling = 'default' }) => styling && fontColors[styling]};
+  background-color: ${({ styling = 'default' }) => styling && backgroundColors[styling]};
   display: inline-block;
   padding: 3px 8px;
   white-space: nowrap;

--- a/src/components/atoms/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/atoms/Badge/__snapshots__/Badge.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<Badge /> renders with no a11y violations 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -37,6 +38,7 @@ exports[`<Badge /> renders with specific size: "large" 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -67,6 +69,7 @@ exports[`<Badge /> renders with specific size: "medium" 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -97,6 +100,7 @@ exports[`<Badge /> renders with specific size: "small" 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -127,6 +131,7 @@ exports[`<Badge /> renders with specific style 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -187,6 +192,7 @@ exports[`<Badge /> renders without crashing 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;

--- a/src/components/atoms/ErrorMessage/__snapshots__/ErrorMessage.test.tsx.snap
+++ b/src/components/atoms/ErrorMessage/__snapshots__/ErrorMessage.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<ErrorMessage /> renders the component with props with no a11y violatio
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/components/atoms/Heading/Heading.md
+++ b/src/components/atoms/Heading/Heading.md
@@ -18,7 +18,9 @@ import { Heading } from '@zopauk/react-components';
   <Heading as="h1">Heading level 1</Heading>
   <Heading as="h2">Heading level 2</Heading>
   <Heading as="h3">Heading level 3</Heading>
-  <Heading as="h4">Heading level 4</Heading>
+  <Heading as="h4" mb={false}>
+    Heading level 4
+  </Heading>
 </Fragment>;
 ```
 
@@ -35,6 +37,20 @@ import { Heading } from '@zopauk/react-components';
   </Heading>
   <Heading as="h3" mb={false}>
     Without bottom white-space
+  </Heading>
+</Fragment>;
+```
+
+```jsx { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
+import { Fragment } from 'react';
+import { Heading, colors } from '@zopauk/react-components';
+
+<Fragment>
+  <Heading as="h4" color={colors.neutral.white}>
+    White
+  </Heading>
+  <Heading as="h4" color={colors.neutral.dark} mb={false}>
+    Dark
   </Heading>
 </Fragment>;
 ```

--- a/src/components/atoms/Heading/Heading.md
+++ b/src/components/atoms/Heading/Heading.md
@@ -41,6 +41,8 @@ import { Heading } from '@zopauk/react-components';
 </Fragment>;
 ```
 
+- Colors
+
 ```jsx { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
 import { Fragment } from 'react';
 import { Heading, colors } from '@zopauk/react-components';

--- a/src/components/atoms/Heading/Heading.test.tsx
+++ b/src/components/atoms/Heading/Heading.test.tsx
@@ -1,6 +1,7 @@
 import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { colors } from '../../../constants/colors';
 import Heading from './Heading';
 
 describe('<Heading />', () => {
@@ -19,7 +20,30 @@ describe('<Heading />', () => {
     ${'h3'}
     ${'h4'}
   `('it can render with a different HTML tag: $tag', ({ tag }: { tag: 'h1' | 'h2' | 'h3' | 'h4' }) => {
-    const { container } = render(<Heading as={tag}>Text</Heading>);
+    const { container } = render(<Heading as={tag}>Header</Heading>);
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it.each`
+    hex                     | name
+    ${colors.neutral.white} | ${'White'}
+    ${colors.neutral.dark}  | ${'Dark'}
+  `('can render in different colors: $name – $hex', ({ hex }) => {
+    const { container } = render(
+      <Heading as="h2" color={hex}>
+        Text
+      </Heading>,
+    );
+    expect(container.firstChild).toHaveStyleRule('color', hex);
+  });
+
+  it('can render without margin bottom', () => {
+    const { container } = render(
+      <Heading as="h1" mb={false}>
+        Header
+      </Heading>,
+    );
+
+    expect(container.firstChild).toHaveStyleRule('margin', '0');
   });
 });

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -2,6 +2,7 @@ import React, { FC, HTMLAttributes } from 'react';
 import styled from 'styled-components';
 import Text from '../Text/Text';
 import { typography } from '../../../constants/typography';
+import { colors, THeadingHexColors } from '../../../constants/colors';
 
 const {
   sizes: { heading: headingSizes },
@@ -14,12 +15,16 @@ interface IStyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   as: 'h1' | 'h2' | 'h3' | 'h4';
   /**
    * Whether to add some margin below the rendered heading or not. Applied by default.
-   * @default false
    */
   mb?: boolean;
+  /**
+   * Accepts a subset of the Zopa brand colors. Same as the ones accepted by `<Text />`.
+   */
+  color?: THeadingHexColors;
 }
 
 const StyledHeading = styled(Text)<IStyledHeadingProps>`
+  color: ${({ color = colors.neutral.dark }) => color};
   font-size: ${({ as }) => headingSizes[as]};
   font-family: ${typography.primary};
   font-weight: ${typography.weights.bold};

--- a/src/components/atoms/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/atoms/Heading/__snapshots__/Heading.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Heading /> it can render with a different HTML tag: "h1" 1`] = `
 .c0 {
+  color: #0D0A38;
   font-size: 48px;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;
@@ -17,12 +18,13 @@ exports[`<Heading /> it can render with a different HTML tag: "h1" 1`] = `
 <h1
   class="c0"
 >
-  Text
+  Header
 </h1>
 `;
 
 exports[`<Heading /> it can render with a different HTML tag: "h2" 1`] = `
 .c0 {
+  color: #0D0A38;
   font-size: 28px;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;
@@ -38,12 +40,13 @@ exports[`<Heading /> it can render with a different HTML tag: "h2" 1`] = `
 <h2
   class="c0"
 >
-  Text
+  Header
 </h2>
 `;
 
 exports[`<Heading /> it can render with a different HTML tag: "h3" 1`] = `
 .c0 {
+  color: #0D0A38;
   font-size: 24px;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;
@@ -59,12 +62,13 @@ exports[`<Heading /> it can render with a different HTML tag: "h3" 1`] = `
 <h3
   class="c0"
 >
-  Text
+  Header
 </h3>
 `;
 
 exports[`<Heading /> it can render with a different HTML tag: "h4" 1`] = `
 .c0 {
+  color: #0D0A38;
   font-size: 20px;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;
@@ -80,12 +84,13 @@ exports[`<Heading /> it can render with a different HTML tag: "h4" 1`] = `
 <h4
   class="c0"
 >
-  Text
+  Header
 </h4>
 `;
 
 exports[`<Heading /> renders without  a11y violations 1`] = `
 .c0 {
+  color: #0D0A38;
   font-size: 48px;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;

--- a/src/components/atoms/InputLabel/InputLabel.tsx
+++ b/src/components/atoms/InputLabel/InputLabel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Text from '../Text/Text';
+import { colors } from '../../../constants/colors';
 
 export interface IInputLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
 
@@ -9,7 +10,7 @@ const StyledLabel = styled(Text)`
 `;
 
 const InputLabel = (props: IInputLabelProps) => (
-  <StyledLabel {...props} weight="semibold" forwardedAs="label" size="large" />
+  <StyledLabel {...props} weight="semibold" forwardedAs="label" size="large" color={colors.neutral.dark} />
 );
 
 export default InputLabel;

--- a/src/components/atoms/InputLabel/__snapshots__/InputLabel.test.tsx.snap
+++ b/src/components/atoms/InputLabel/__snapshots__/InputLabel.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<InputLabel /> renders the component with props 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -19,6 +20,7 @@ exports[`<InputLabel /> renders the component with props 1`] = `
 
 <label
   class="c0 c1"
+  color="#0D0A38"
   for="username"
 >
   Username:

--- a/src/components/atoms/Link/Link.md
+++ b/src/components/atoms/Link/Link.md
@@ -14,6 +14,37 @@ Use `<Link />` to create hyperlinks to other web pages, files, locations within 
 
 ### Examples
 
+- Normal link
+
+```js
+import { Text, Link } from '@zopauk/react-components';
+
+<Text size="large" as="p">
+  Some text with
+  <Link target="_blank" href="http://duckduckgo.com" onClick={() => alert('Link clicked!')}>
+    a link
+  </Link>
+</Text>;
+```
+
+- Negative link
+
+```js { "props": { "style": { "backgroundColor": "#00B9A7", "border": "none" } } }
+import { Text, Link, colors } from '@zopauk/react-components';
+
+<Text size="large" as="p" color={colors.neutral.white}>
+  Some text with
+  <Link
+    color={colors.neutral.white}
+    target="_blank"
+    href="http://duckduckgo.com"
+    onClick={() => alert('Link clicked!')}
+  >
+    a link
+  </Link>
+</Text>;
+```
+
 - With `target="_blank"`
 
 ```js

--- a/src/components/atoms/Link/Link.test.tsx
+++ b/src/components/atoms/Link/Link.test.tsx
@@ -1,21 +1,38 @@
 import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { colors } from '../../../constants/colors';
 import Link from './Link';
 
 describe('<Link />', () => {
   it('renders the link with default values and the svg is hidden with no a11y violations', async () => {
     const { container } = render(<Link href="http://duckduckgo.com">text</Link>);
     expect(container.firstChild).toMatchSnapshot();
+
     const results = await axe(container.innerHTML);
     expect(results).toHaveNoViolations();
   });
+
   it('renders the link with target _blank with the svg visible', () => {
     const { container } = render(
       <Link href="http://duckduckgo.com" target="_blank">
         text
       </Link>,
     );
+
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it.each`
+    hex                      | name
+    ${colors.base.secondary} | ${'Blue'}
+    ${colors.neutral.white}  | ${'White'}
+  `('can render in different colors: $name – $hex', ({ hex }) => {
+    const { container } = render(
+      <Link href="http://duckduckgo.com" color={hex}>
+        text
+      </Link>,
+    );
+    expect(container.firstChild).toHaveStyleRule('color', hex);
   });
 });

--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -1,21 +1,20 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
-import Text from '../Text/Text';
-import { colors } from '../../../constants/colors';
+import { colors, TLinkHexColors } from '../../../constants/colors';
 
 export interface ILinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  color?: string;
+  color?: TLinkHexColors;
 }
 
 export interface ITargetIconProps extends React.SVGProps<SVGSVGElement> {}
 
-const SLink = styled(Text)`
+const SLink = styled.a`
   cursor: pointer;
   text-decoration: none;
   user-select: none;
   appearance: none;
 
-  color: ${({ color }) => color || colors.base.secondary};
+  color: ${({ color = colors.base.secondary }) => color};
 
   &:hover {
     opacity: 0.88;
@@ -46,7 +45,7 @@ const TargetIcon = (props: ITargetIconProps) => {
 const Link: FC<ILinkProps> = React.forwardRef<HTMLAnchorElement, ILinkProps>((props, ref) => {
   const { children, ...rest } = props;
   return (
-    <SLink ref={ref} weight="bold" forwardedAs="a" {...rest}>
+    <SLink ref={ref} {...rest}>
       {children}
       {rest.target === '_blank' && <TargetIcon color={rest.color} />}
     </SLink>

--- a/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Link /> renders the link with default values and the svg is hidden with no a11y violations 1`] = `
-.c1 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 700;
-  font-size: 14px;
-}
-
 .c0 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -36,7 +24,7 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
 }
 
 <a
-  class="c0 c1"
+  class="c0"
   href="http://duckduckgo.com"
 >
   text
@@ -44,18 +32,6 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
 `;
 
 exports[`<Link /> renders the link with target _blank with the svg visible 1`] = `
-.c1 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 700;
-  font-size: 14px;
-}
-
 .c0 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -78,20 +54,20 @@ exports[`<Link /> renders the link with target _blank with the svg visible 1`] =
   opacity: 0.72;
 }
 
-.c2 {
+.c1 {
   margin-left: 6px;
   top: 2px;
   position: relative;
 }
 
 <a
-  class="c0 c1"
+  class="c0"
   href="http://duckduckgo.com"
   target="_blank"
 >
   text
   <svg
-    class="c2"
+    class="c1"
     height="15"
     width="15"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/atoms/Text/Text.md
+++ b/src/components/atoms/Text/Text.md
@@ -1,9 +1,10 @@
 ### Summary
 
-1. Whenever you want to render text on any UI at Zopa, use the `<Text />` component
-2. Its size, weight, white-space and semantics can be customised according to context
-3. If you need to render long text, render it within `<p />` tag, otherwise use the defautl `<span />` tag
+1. Whenever you want to render text on any UI at Zopa, use the `<Text />` component 🙏🏻
+2. Its size, weight, white-space, semantics and colour can be customised
+3. If you need to render long text, render it within `<p />` tag, otherwise use the defautl `<span />` tag 👮🏻‍♂️
 4. Don't use `semibold` for now as we don't have clear specs on when to use it over `bold`
+5. Use the colours mindfully 🎨
 
 ### Examples
 
@@ -64,5 +65,28 @@ import { Text } from '@zopauk/react-components';
   <Text weight="bold" mb>
     Bold weight
   </Text>
+</Fragment>;
+```
+
+- Colors
+
+```jsx { "props": { "style": { "backgroundColor": "rgb(244, 248, 246)", "border": "none" } } }
+import { Fragment } from 'react';
+import { Text, colors } from '@zopauk/react-components';
+
+<Fragment>
+  <Text color={colors.neutral.white} mb>
+    White
+  </Text>
+  <Text color={colors.neutral.medium} mb>
+    Medium
+  </Text>
+  <Text color={colors.neutral.dark} mb>
+    Dark
+  </Text>
+  <Text color={colors.semantic.success} mb>
+    Success
+  </Text>
+  <Text color={colors.semantic.error}>Error</Text>
 </Fragment>;
 ```

--- a/src/components/atoms/Text/Text.test.tsx
+++ b/src/components/atoms/Text/Text.test.tsx
@@ -2,6 +2,7 @@ import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
 import Text from './Text';
+import { colors } from '../../../constants/colors';
 
 describe('<Text />', () => {
   it('renders without  a11y violations', async () => {
@@ -10,6 +11,16 @@ describe('<Text />', () => {
 
     expect(results).toHaveNoViolations();
     expect(container).toMatchSnapshot();
+  });
+
+  it('can render with bottom white-space', () => {
+    const { container } = render(
+      <Text as="p" mb>
+        Long paragraph with some bottom white-space to prevent text next to it colliding.
+      </Text>,
+    );
+
+    expect(container.firstChild).toHaveStyleRule('margin', '0');
   });
 
   it.each`
@@ -24,20 +35,32 @@ describe('<Text />', () => {
   it.each`
     size        | pixels
     ${'large'}  | ${'16px'}
-    ${'medium'} | ${'14px (default)'}
+    ${'medium'} | ${'14px'}
     ${'small'}  | ${'12px'}
-  `('can render at different sizes:  $size – $pixels', ({ size }) => {
+  `('can render at different sizes:  $size – $pixels', ({ size, pixels }) => {
     const { container } = render(<Text size={size}>Text</Text>);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container.firstChild).toHaveStyleRule('font-size', pixels);
   });
 
   it.each`
-    weight
-    ${'regular'}
-    ${'semibold'}
-    ${'bold'}
-  `('can render at different weights:  $weight', ({ weight }) => {
-    const { container } = render(<Text weight={weight}>Text</Text>);
-    expect(container.firstChild).toMatchSnapshot();
+    name          | weight
+    ${'regular'}  | ${'400'}
+    ${'semibold'} | ${'600'}
+    ${'bold'}     | ${'700'}
+  `('can render at different weights:  $name', ({ name, weight }) => {
+    const { container } = render(<Text weight={name}>Text</Text>);
+    expect(container.firstChild).toHaveStyleRule('font-weight', weight);
+  });
+
+  it.each`
+    hex                        | name
+    ${colors.neutral.white}    | ${'White'}
+    ${colors.neutral.medium}   | ${'Medium'}
+    ${colors.neutral.dark}     | ${'Dark'}
+    ${colors.semantic.success} | ${'Success'}
+    ${colors.semantic.error}   | ${'Error'}
+  `('can render in different colors: $name – $hex', ({ hex }) => {
+    const { container } = render(<Text color={hex}>Text</Text>);
+    expect(container.firstChild).toHaveStyleRule('color', hex);
   });
 });

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -2,33 +2,35 @@ import React from 'react';
 import { HTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { typography } from '../../../constants/typography';
+import { colors, TTextHexColors } from '../../../constants/colors';
 
 export interface ITextProps extends HTMLAttributes<HTMLSpanElement | HTMLParagraphElement> {
   /**
    * The weight of the rendered text. Avoid the use of `semibold` as for now.
-   * @default 400
    */
   weight?: keyof typeof typography.weights;
   /**
    * The size you want to render your text at, currently only `12px` | `14px` | `16px` supported.
-   * @default 'medium'
    */
   size?: keyof typeof typography.sizes.text;
   /**
    * The HTML5 tag you want to render your text on, currently only `<span>` and `<p>` are supported.
-   * @default span
    */
   as?: 'span' | 'p' | 'label';
   /**
    * Whether to add some margin below the rendered text or not. Use it to give meaningful white-space.
-   * @default false
    */
   mb?: boolean;
+  /**
+   * Accepts a subset of the Zopa brand colors. Same as the ones accepted by `<Heading />`.
+   */
+  color?: TTextHexColors;
 }
 
 const Text = styled.span<ITextProps>`
   margin: 0;
   letter-spacing: 0;
+  color: ${({ color = colors.neutral.dark }) => color};
 
   ${({ mb = false }) =>
     mb &&
@@ -46,5 +48,9 @@ const Text = styled.span<ITextProps>`
 `;
 
 const TextWrap: React.FunctionComponent<ITextProps> = props => <Text {...props} />;
+
+TextWrap.defaultProps = {
+  as: 'span',
+};
 
 export default TextWrap;

--- a/src/components/atoms/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/atoms/Text/__snapshots__/Text.test.tsx.snap
@@ -1,125 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Text /> can render at different sizes:  "large" – "16px" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 16px;
-}
-
-<span
-  class="c0"
->
-  Text
-</span>
-`;
-
-exports[`<Text /> can render at different sizes:  "medium" – "14px (default)" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 14px;
-}
-
-<span
-  class="c0"
->
-  Text
-</span>
-`;
-
-exports[`<Text /> can render at different sizes:  "small" – "12px" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 12px;
-}
-
-<span
-  class="c0"
->
-  Text
-</span>
-`;
-
-exports[`<Text /> can render at different weights:  "bold" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 700;
-  font-size: 14px;
-}
-
-<span
-  class="c0"
->
-  Text
-</span>
-`;
-
-exports[`<Text /> can render at different weights:  "regular" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 14px;
-}
-
-<span
-  class="c0"
->
-  Text
-</span>
-`;
-
-exports[`<Text /> can render at different weights:  "semibold" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
-  font-size: 14px;
-}
-
-<span
-  class="c0"
->
-  Text
-</span>
-`;
-
 exports[`<Text /> it can render as an HTML "p" tag 1`] = `
 .c0 {
   margin: 0;
@@ -127,6 +7,7 @@ exports[`<Text /> it can render as an HTML "p" tag 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -147,6 +28,7 @@ exports[`<Text /> it can render as an HTML "span" tag 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
@@ -167,6 +49,7 @@ exports[`<Text /> renders without  a11y violations 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;

--- a/src/components/molecules/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/molecules/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<CheckboxField /> renders the component with props with no a11y violati
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -109,6 +110,7 @@ exports[`<CheckboxField /> renders the component with props with no a11y violati
   />
   <label
     class="c2 c3 c4"
+    color="#0D0A38"
     for="checkbox-id-test1"
   >
     hello

--- a/src/components/molecules/DropdownField/__snapshots__/DropdownField.test.tsx.snap
+++ b/src/components/molecules/DropdownField/__snapshots__/DropdownField.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<DropdownField /> renders the component with props with no a11y violati
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -23,6 +24,7 @@ exports[`<DropdownField /> renders the component with props with no a11y violati
 
 <label
   class="c0 c1 c2"
+  color="#0D0A38"
   for="text-id-dropdown-field-default"
 >
   Your cool dropdown ❤

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -90,6 +91,7 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
   >
     <label
       class="c1 c2"
+      color="#0D0A38"
       for="text-id-test"
       id="downshift-0-label"
     >

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -1,56 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Help /> renders the default Help component with no a11y violations 1`] = `
-.c6 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  display: block;
-  margin-bottom: 24px;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 16px;
-}
-
-.c8 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 700;
-  font-size: 14px;
-}
-
-.c9 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 16px;
-}
-
-.c11 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 12px;
-}
-
 .c7 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -73,7 +23,49 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   opacity: 0.72;
 }
 
+.c6 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  display: block;
+  margin-bottom: 24px;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 16px;
+}
+
+.c8 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 16px;
+}
+
+.c10 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 12px;
+}
+
 .c4 {
+  color: #0D0A38;
   font-size: 24px;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;
@@ -142,7 +134,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   max-width: 900px;
 }
 
-.c10 {
+.c9 {
   max-width: 350px;
 }
 
@@ -211,7 +203,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           class="c6"
         >
           <a
-            class="c7 c8"
+            class="c7"
             href="mailto:savings@zopa.com"
           >
             savings@zopa.com
@@ -221,7 +213,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           class="c6"
         >
           <a
-            class="c7 c8"
+            class="c7"
             href="tel:020 7580 6060"
           >
             020 7580 6060 
@@ -229,10 +221,10 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           for loans
         </span>
         <span
-          class="c9"
+          class="c8"
         >
           <a
-            class="c7 c8"
+            class="c7"
             href="tel:020 7291 8331"
           >
             020 7291 8331 
@@ -245,16 +237,16 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
         cols="12"
       >
         <div
-          class="c10"
+          class="c9"
         >
           <p
-            class="c9"
+            class="c8"
           >
             Monday to Thursday (8am to 8pm), and Friday (8am to 5pm)
           </p>
         </div>
         <p
-          class="c11"
+          class="c10"
         >
           We can't take applications over the phone. UK residents only. Calls may be monitored.
         </p>

--- a/src/components/molecules/Progress/__snapshots__/Progress.test.tsx.snap
+++ b/src/components/molecules/Progress/__snapshots__/Progress.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<Progress /> renders the component with props with no a11y violations 1
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;

--- a/src/components/molecules/RadioField/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/molecules/RadioField/__snapshots__/RadioField.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<RadioField /> renders the component with props with no a11y violations
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -126,6 +127,7 @@ exports[`<RadioField /> renders the component with props with no a11y violations
   />
   <label
     class="c3 c4 c5"
+    color="#0D0A38"
     for="radio-id-1"
   >
     hello

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`<TextField /> renders the component with error and label and size 1`] =
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -128,6 +129,7 @@ exports[`<TextField /> renders the component with label 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`<TextField /> renders the component with error and label and size 1`] =
 
 <label
   class="c0 c1"
+  color="#0D0A38"
   for="text-id-test1"
 >
   yes!
@@ -142,6 +143,7 @@ exports[`<TextField /> renders the component with label 1`] = `
 
 <label
   class="c0 c1"
+  color="#0D0A38"
   for="text-id-test1"
 >
   Username

--- a/src/components/molecules/ZopaFooter/FooterLink/__snapshots__/FooterLink.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/FooterLink/__snapshots__/FooterLink.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FooterLink /> renders the component with a small size 1`] = `
-.c2 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
-  font-size: 12px;
-}
-
 .c1 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -46,22 +34,11 @@ exports[`<FooterLink /> renders the component with a small size 1`] = `
 }
 
 <a
-  class="c0 c1 c2"
+  class="c0 c1"
 />
 `;
 
 exports[`<FooterLink /> renders the component with default props 1`] = `
-.c2 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
-}
-
 .c1 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -95,6 +72,6 @@ exports[`<FooterLink /> renders the component with default props 1`] = `
 }
 
 <a
-  class="c0 c1 c2"
+  class="c0 c1"
 />
 `;

--- a/src/components/molecules/ZopaFooter/Legal/__snapshots__/Legal.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Legal/__snapshots__/Legal.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<Legal /> renders the component 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
@@ -35,17 +35,6 @@ exports[`<Links /> renders the component 1`] = `
   align-items: flex-start;
 }
 
-.c8 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
-}
-
 .c7 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -161,7 +150,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/loans/car-loans"
           >
             Car loans
@@ -171,7 +160,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/loans/debt-consolidation"
           >
             Debt consolidation loans
@@ -181,7 +170,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/loans/home-improvement"
           >
             Home improvement loans
@@ -191,7 +180,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/loans/wedding"
           >
             Wedding loans
@@ -201,7 +190,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/invest"
           >
             Peer-to-peer investments
@@ -211,7 +200,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/invest/isa"
           >
             Innovative Finance ISA
@@ -239,7 +228,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about"
           >
             About Us
@@ -249,7 +238,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about/our-story"
           >
             Our story
@@ -259,7 +248,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about/board"
           >
             Meet the board
@@ -269,7 +258,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about/leadership"
           >
             Meet the leadership team
@@ -279,7 +268,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about/awards"
           >
             Awards
@@ -289,7 +278,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about/careers"
           >
             Careers
@@ -299,7 +288,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/about/press"
           >
             Press team
@@ -309,7 +298,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/feelgood"
           >
             New products
@@ -337,7 +326,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/cookie-policy"
           >
             Cookie policy
@@ -347,7 +336,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/conflicts-policy"
           >
             Conflicts policy
@@ -357,7 +346,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/modern-slavery"
           >
             Modern slavery
@@ -367,7 +356,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/website-terms"
           >
             Website terms
@@ -395,7 +384,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/contact"
           >
             Support
@@ -405,7 +394,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/support/faqs"
           >
             Common Questions
@@ -415,7 +404,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7 c8"
+            class="c6 c7"
             href="https://zopa.com/sitemap"
           >
             Sitemap

--- a/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   align-self: auto;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -46,7 +46,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   align-items: flex-start;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,17 +67,6 @@ exports[`<SocialLinks /> renders the component 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.c4 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
 }
 
 .c3 {
@@ -112,7 +101,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   color: #6F748B;
 }
 
-.c6 {
+.c5 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -120,7 +109,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   margin-top: 32px;
 }
 
-.c8 {
+.c7 {
   color: #A9ACBA;
   -webkit-transition: color 0.2s ease;
   transition: color 0.2s ease;
@@ -128,7 +117,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   margin-right: 8px;
 }
 
-.c8:hover {
+.c7:hover {
   color: #6F748B;
 }
 
@@ -173,7 +162,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:0px) {
-  .c5 {
+  .c4 {
     display: block;
     -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
@@ -183,7 +172,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:576px) {
-  .c5 {
+  .c4 {
     display: block;
     -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
@@ -193,7 +182,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c4 {
     display: block;
     -webkit-flex: 0 0 33.33333333333333%;
     -ms-flex: 0 0 33.33333333333333%;
@@ -203,7 +192,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:992px) {
-  .c5 {
+  .c4 {
     display: block;
     -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
@@ -213,13 +202,13 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:576px) {
-  .c6 {
+  .c5 {
     margin-top: 0;
   }
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c5 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -237,7 +226,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
     cols="12"
   >
     <a
-      class="c2 c3 c4"
+      class="c2 c3"
       href="https://www.zopa.com"
     >
       <svg
@@ -263,17 +252,17 @@ exports[`<SocialLinks /> renders the component 1`] = `
     </a>
   </div>
   <div
-    class="c5"
+    class="c4"
     cols="12"
   >
     <div
-      class="c6 c7"
+      class="c5 c6"
       cols="12"
       direction="row"
     >
       <a
         aria-label="instagram"
-        class="c8 c3 c4"
+        class="c7 c3"
         cols="12"
         href="https://www.instagram.com/Zopamoney/"
       >
@@ -301,7 +290,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
       </a>
       <a
         aria-label="facebook"
-        class="c8 c3 c4"
+        class="c7 c3"
         cols="12"
         href="https://facebook.com/zopa"
       >
@@ -323,7 +312,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
       </a>
       <a
         aria-label="twitter"
-        class="c8 c3 c4"
+        class="c7 c3"
         cols="12"
         href="https://twitter.com/zopa"
       >

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<ZopaFooter /> renders the component with a legalOnly prop 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -102,23 +103,13 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-right: auto;
 }
 
-.c7 {
+.c16 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
-}
-
-.c17 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -129,7 +120,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   padding: 18px 0;
 }
 
-.c16 {
+.c15 {
   color: #A9ACBA;
   margin: 0 0 24px 0;
 }
@@ -145,7 +136,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   align-self: auto;
 }
 
-.c8 {
+.c7 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -179,7 +170,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   align-items: flex-start;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -234,27 +225,27 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   color: #6F748B;
 }
 
-.c12 {
+.c11 {
   color: #FFFFFF;
 }
 
-.c13 {
+.c12 {
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
 
-.c14 {
+.c13 {
   margin: 0 0 5px 0;
   padding: 0;
 }
 
-.c15 {
+.c14 {
   background-color: #282F52;
   height: 1px;
 }
 
-.c9 {
+.c8 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -262,7 +253,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-top: 32px;
 }
 
-.c11 {
+.c10 {
   color: #A9ACBA;
   -webkit-transition: color 0.2s ease;
   transition: color 0.2s ease;
@@ -270,7 +261,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-right: 8px;
 }
 
-.c11:hover {
+.c10:hover {
   color: #6F748B;
 }
 
@@ -344,7 +335,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:0px) {
-  .c8 {
+  .c7 {
     display: block;
     -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
@@ -354,7 +345,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:576px) {
-  .c8 {
+  .c7 {
     display: block;
     -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
@@ -364,7 +355,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:768px) {
-  .c8 {
+  .c7 {
     display: block;
     -webkit-flex: 0 0 33.33333333333333%;
     -ms-flex: 0 0 33.33333333333333%;
@@ -374,7 +365,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:992px) {
-  .c8 {
+  .c7 {
     display: block;
     -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
@@ -384,13 +375,13 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:576px) {
-  .c9 {
+  .c8 {
     margin-top: 0;
   }
 }
 
 @media (min-width:768px) {
-  .c9 {
+  .c8 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -418,7 +409,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           cols="12"
         >
           <a
-            class="c5 c6 c7"
+            class="c5 c6"
             href="https://www.zopa.com"
           >
             <svg
@@ -444,17 +435,17 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </a>
         </div>
         <div
-          class="c8"
+          class="c7"
           cols="12"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
             cols="12"
             direction="row"
           >
             <a
               aria-label="instagram"
-              class="c11 c6 c7"
+              class="c10 c6"
               cols="12"
               href="https://www.instagram.com/Zopamoney/"
             >
@@ -482,7 +473,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
             </a>
             <a
               aria-label="facebook"
-              class="c11 c6 c7"
+              class="c10 c6"
               cols="12"
               href="https://facebook.com/zopa"
             >
@@ -504,7 +495,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
             </a>
             <a
               aria-label="twitter"
-              class="c11 c6 c7"
+              class="c10 c6"
               cols="12"
               href="https://twitter.com/zopa"
             >
@@ -530,80 +521,80 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       class="c2"
     >
       <div
-        class="c10"
+        class="c9"
         cols="12"
         direction="row"
       >
         <div
-          class="c8"
+          class="c7"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c12"
+              class="c11"
             >
               What we do
             </h3>
             <ul
-              class="c13"
+              class="c12"
             >
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/loans/car-loans"
                 >
                   Car loans
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/loans/debt-consolidation"
                 >
                   Debt consolidation loans
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/loans/home-improvement"
                 >
                   Home improvement loans
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/loans/wedding"
                 >
                   Wedding loans
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/invest"
                 >
                   Peer-to-peer investments
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/invest/isa"
                 >
                   Innovative Finance ISA
@@ -613,95 +604,95 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c12"
+              class="c11"
             >
               About Zopa
             </h3>
             <ul
-              class="c13"
+              class="c12"
             >
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about"
                 >
                   About Us
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about/our-story"
                 >
                   Our story
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about/board"
                 >
                   Meet the board
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about/leadership"
                 >
                   Meet the leadership team
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about/awards"
                 >
                   Awards
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about/careers"
                 >
                   Careers
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/about/press"
                 >
                   Press team
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/feelgood"
                 >
                   New products
@@ -711,55 +702,55 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c12"
+              class="c11"
             >
               Legal
             </h3>
             <ul
-              class="c13"
+              class="c12"
             >
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/cookie-policy"
                 >
                   Cookie policy
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/conflicts-policy"
                 >
                   Conflicts policy
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/modern-slavery"
                 >
                   Modern slavery
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/website-terms"
                 >
                   Website terms
@@ -769,45 +760,45 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c12"
+              class="c11"
             >
               Navigation
             </h3>
             <ul
-              class="c13"
+              class="c12"
             >
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/contact"
                 >
                   Support
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/support/faqs"
                 >
                   Common Questions
                 </a>
               </li>
               <li
-                class="c14"
+                class="c13"
               >
                 <a
-                  class="c5 c6 c7"
+                  class="c5 c6"
                   href="https://zopa.com/sitemap"
                 >
                   Sitemap
@@ -819,23 +810,23 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       </div>
     </div>
     <div
-      class="c15"
+      class="c14"
     />
     <div
       class="c2"
     >
       <p
-        class="c16 c17"
+        class="c15 c16"
       >
         Zopa Limited is authorised and regulated by the Financial Conduct Authority, and entered on the Financial Services Register (718925). Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services Register (800542). Zopa Limited (05197592) and Zopa Bank Limited (10627575) are both incorporated in England & Wales and have their registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
       </p>
       <p
-        class="c16 c17"
+        class="c15 c16"
       >
         © Zopa Bank Limited 2025 All rights reserved. 'Zopa' is a trademark of Zopa Bank Limited.
       </p>
       <p
-        class="c16 c17"
+        class="c15 c16"
       >
         Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the Office of the Information Commissioner (ZA275984, Z8797078).
 

--- a/src/components/organisms/Accordion/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/src/components/organisms/Accordion/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<AccordionHeader /> renders the component with no a11y violations 1`] =
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
+  color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 700;

--- a/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Navbar.Link /> should render component with default props 1`] = `
-.c2 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 700;
-  font-size: 14px;
-}
-
 .c1 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -53,31 +41,19 @@ exports[`<Navbar.Link /> should render component with default props 1`] = `
 }
 
 <a
-  class="c0 c1 c2"
+  class="c0 c1"
   color="#4A3EDE"
 />
 `;
 
 exports[`<Navbar.Link /> should render component with specific props 1`] = `
-.c4 {
+.c3 {
   -webkit-transition: -webkit-transform 0.2s;
   -webkit-transition: transform 0.2s;
   transition: transform 0.2s;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
   transform: rotate(0deg);
-}
-
-.c2 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 700;
-  font-size: 14px;
 }
 
 .c1 {
@@ -119,7 +95,7 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
   opacity: 1;
 }
 
-.c3 {
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -138,15 +114,15 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
 }
 
 <a
-  class="c0 c1 c2"
+  class="c0 c1"
   color="#4A3EDE"
 >
   <span
-    class="c3"
+    class="c2"
     open=""
   >
     <svg
-      class="c4"
+      class="c3"
       direction="down"
       height="18px"
       viewBox="0 0 416 416"

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,3 +1,7 @@
+export type TTextHexColors = '#FFFFFF' | '#C5C6CD' | '#0D0A38' | '#1EC06A' | '#EE0505';
+export type THeadingHexColors = '#FFFFFF' | '#0D0A38';
+export type TLinkHexColors = '#FFFFFF' | '#0D0A38';
+
 export const colors = {
   base: {
     primary: '#00B9A7',


### PR DESCRIPTION
## Summary 🍿

New `color` prop for `<Text />` , `<Heading />` and `<Link />`.

### `<Text />`

Accepts **five colour variants** through the `color` prop.
```js
/* Grey variants */
colors.neutral.white
colors.neutral.grey
colors.neutral.dark // ( default)

/* Semantic variants */
colors.semantic.success
colors.semantic.error
```

<img src="https://user-images.githubusercontent.com/5938217/63781388-fd0e0380-c8e9-11e9-8e07-74ac069952a4.png" width="300" />

### `<Heading />`


Accepts **two colour variants** through the `color` prop.
```js
colors.neutral.dark // ( default)
colors.neutral.white // on top of dark backgrounds
```

<img src="https://user-images.githubusercontent.com/5938217/63781394-0008f400-c8ea-11e9-9da2-a12a761a4ff8.png" width="300" />

### `<Link />`


Accepts **two colour variants** through the `color` prop.
```js
colors.primary.secondary // ( violet, default)
colors.neutral.white // on top of dark backgrounds
```

<img src="https://user-images.githubusercontent.com/5938217/63781401-026b4e00-c8ea-11e9-88cd-4c9b8136018f.png" width="300" />
