### PR TITLE
Heading level 1 size on 📱

### DIFF
--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Text from '../Text/Text';
 import { typography } from '../../../constants/typography';
 import { colors, THeadingHexColors } from '../../../constants/colors';
+import { maxMedia } from '../../../helpers/responsiveness';
 
 const {
   sizes: { heading: headingSizes },
@@ -25,7 +26,10 @@ interface IStyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
 
 const StyledHeading = styled(Text)<IStyledHeadingProps>`
   color: ${({ color = colors.neutral.dark }) => color};
+  
   font-size: ${({ as }) => headingSizes[as]};
+  ${({ as }) => (as === 'h1' ? maxMedia.phone`font-size: 36px;` : null)}
+  
   font-family: ${typography.primary};
   font-weight: ${typography.weights.semibold};
   line-height: ${typography.lineHeights.heading};

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -28,7 +28,7 @@ const StyledHeading = styled(Text)<IStyledHeadingProps>`
   color: ${({ color = colors.neutral.dark }) => color};
   
   font-size: ${({ as }) => headingSizes[as]};
-  ${({ as }) => (as === 'h1' ? maxMedia.phone`font-size: 36px;` : null)}
+  ${({ as }) => as === 'h1' && maxMedia.phone`font-size: 36px;`}
   
   font-family: ${typography.primary};
   font-weight: ${typography.weights.semibold};

--- a/src/components/atoms/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/atoms/Heading/__snapshots__/Heading.test.tsx.snap
@@ -15,6 +15,12 @@ exports[`<Heading /> it can render with a different HTML tag: "h1" 1`] = `
   margin-bottom: 24px;
 }
 
+@media (max-width:600px) {
+  .c0 {
+    font-size: 36px;
+  }
+}
+
 <h1
   class="c0"
 >
@@ -101,6 +107,12 @@ exports[`<Heading /> renders without  a11y violations 1`] = `
   letter-spacing: -0.5px;
   margin: 0;
   margin-bottom: 24px;
+}
+
+@media (max-width:600px) {
+  .c0 {
+    font-size: 36px;
+  }
 }
 
 <div>


### PR DESCRIPTION
## Challenge 🍿 

<img src="https://user-images.githubusercontent.com/5938217/63935857-aa098d00-ca5e-11e9-9399-f5a16a7daaa1.png" width="250px" />

Our **level 1** size in `<Heading />` ( currently `48px` ) is too big on narrow viewports.

As you can see &nbsp; ☝🏻 👀 on most mobile devices at that size, you can only fit at most *two words per line* which affects readability.

## Workaround 🤓

Decrease manually the font size of our `h1` to `36px` on narrow viewports:

<img src="https://user-images.githubusercontent.com/5938217/63936071-403db300-ca5f-11e9-981e-2ec199372fdc.png" width="250px" />

## Notes 💭

There's a spec on the works by the **design team** on responsive font sizes ...

Related to #51 