### PR TITLE
Cleanup <Link /> 🛀 

### DIFF
--- a/src/components/atoms/Link/Link.md
+++ b/src/components/atoms/Link/Link.md
@@ -21,7 +21,7 @@ import { Text, Link } from '@zopauk/react-components';
 
 <Text size="large" as="p">
   Some text with
-  <Link target="_blank" href="http://duckduckgo.com" onClick={() => alert('Link clicked!')}>
+  <Link target="_blank" href="http://duckduckgo.com" onClick={() => alert('Link clicked!')} size="large">
     a link
   </Link>
 </Text>;
@@ -39,6 +39,7 @@ import { Text, Link, colors } from '@zopauk/react-components';
     target="_blank"
     href="http://duckduckgo.com"
     onClick={() => alert('Link clicked!')}
+    size="large"
   >
     a link
   </Link>
@@ -52,7 +53,7 @@ import { Text, Link } from '@zopauk/react-components';
 
 <Text size="large" as="p">
   Some text with
-  <Link target="_blank" href="http://duckduckgo.com" onClick={() => alert('Link clicked!')}>
+  <Link target="_blank" href="http://duckduckgo.com" onClick={() => alert('Link clicked!')} size="large">
     a link
   </Link>
 </Text>;
@@ -65,7 +66,7 @@ import { Text, Link } from '@zopauk/react-components';
 
 <Text size="large" as="p">
   Some text with
-  <Link href="http://duckduckgo.com" onClick={() => alert('Link clicked!')}>
+  <Link href="http://duckduckgo.com" onClick={() => alert('Link clicked!')} size="large">
     a link
   </Link>
 </Text>;

--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import { colors, TLinkHexColors } from '../../../constants/colors';
+import Text from '../../atoms/Text/Text';
 
 export interface ILinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   color?: TLinkHexColors;
@@ -8,13 +9,11 @@ export interface ILinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement
 
 export interface ITargetIconProps extends React.SVGProps<SVGSVGElement> {}
 
-const SLink = styled.a`
+const SLink = styled(Text)`
   cursor: pointer;
   text-decoration: none;
   user-select: none;
   appearance: none;
-
-  color: ${({ color = colors.base.secondary }) => color};
 
   &:hover {
     opacity: 0.88;
@@ -43,11 +42,11 @@ const TargetIcon = (props: ITargetIconProps) => {
 };
 
 const Link: FC<ILinkProps> = React.forwardRef<HTMLAnchorElement, ILinkProps>((props, ref) => {
-  const { children, ...rest } = props;
+  const { children, color, ...rest } = props;
   return (
-    <SLink ref={ref} {...rest}>
+    <SLink ref={ref} {...rest} weight="semibold" color={color} forwardedAs="a">
       {children}
-      {rest.target === '_blank' && <TargetIcon color={rest.color} />}
+      {rest.target === '_blank' && <TargetIcon color={color} />}
     </SLink>
   );
 });

--- a/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Link /> renders the link with default values and the svg is hidden with no a11y violations 1`] = `
+.c1 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+  font-size: 14px;
+}
+
 .c0 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -12,7 +25,6 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c0:hover {
@@ -24,7 +36,7 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
 }
 
 <a
-  class="c0"
+  class="c0 c1"
   href="http://duckduckgo.com"
 >
   text
@@ -32,6 +44,19 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
 `;
 
 exports[`<Link /> renders the link with target _blank with the svg visible 1`] = `
+.c1 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+  font-size: 14px;
+}
+
 .c0 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -43,7 +68,6 @@ exports[`<Link /> renders the link with target _blank with the svg visible 1`] =
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c0:hover {
@@ -54,20 +78,20 @@ exports[`<Link /> renders the link with target _blank with the svg visible 1`] =
   opacity: 0.72;
 }
 
-.c1 {
+.c2 {
   margin-left: 6px;
   top: 2px;
   position: relative;
 }
 
 <a
-  class="c0"
+  class="c0 c1"
   href="http://duckduckgo.com"
   target="_blank"
 >
   text
   <svg
-    class="c1"
+    class="c2"
     height="15"
     width="15"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -1,28 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Help /> renders the default Help component with no a11y violations 1`] = `
-.c7 {
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  color: #4A3EDE;
-}
-
-.c7:hover {
-  opacity: 0.88;
-}
-
-.c7:active {
-  opacity: 0.72;
-}
-
 .c6 {
   margin: 0;
   -webkit-letter-spacing: 0;
@@ -47,11 +25,24 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   color: #0D0A38;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.c9 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
   font-size: 16px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -62,6 +53,27 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
   font-size: 12px;
+}
+
+.c7 {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c7:hover {
+  opacity: 0.88;
+}
+
+.c7:active {
+  opacity: 0.72;
 }
 
 .c4 {
@@ -134,7 +146,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   max-width: 900px;
 }
 
-.c9 {
+.c10 {
   max-width: 350px;
 }
 
@@ -203,7 +215,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           class="c6"
         >
           <a
-            class="c7"
+            class="c7 c8"
             href="mailto:savings@zopa.com"
           >
             savings@zopa.com
@@ -213,7 +225,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           class="c6"
         >
           <a
-            class="c7"
+            class="c7 c8"
             href="tel:020 7580 6060"
           >
             020 7580 6060 
@@ -221,10 +233,10 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
           for loans
         </span>
         <span
-          class="c8"
+          class="c9"
         >
           <a
-            class="c7"
+            class="c7 c8"
             href="tel:020 7291 8331"
           >
             020 7291 8331 
@@ -237,16 +249,16 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
         cols="12"
       >
         <div
-          class="c9"
+          class="c10"
         >
           <p
-            class="c8"
+            class="c9"
           >
             Monday to Thursday (8am to 8pm), and Friday (8am to 5pm)
           </p>
         </div>
         <p
-          class="c10"
+          class="c11"
         >
           We can't take applications over the phone. UK residents only. Calls may be monitored.
         </p>

--- a/src/components/molecules/ZopaFooter/FooterLink/__snapshots__/FooterLink.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/FooterLink/__snapshots__/FooterLink.test.tsx.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FooterLink /> renders the component with a small size 1`] = `
+.c2 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+  font-size: 12px;
+}
+
 .c1 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -12,7 +25,6 @@ exports[`<FooterLink /> renders the component with a small size 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c1:hover {
@@ -34,11 +46,23 @@ exports[`<FooterLink /> renders the component with a small size 1`] = `
 }
 
 <a
-  class="c0 c1"
+  class="c0 c1 c2"
 />
 `;
 
 exports[`<FooterLink /> renders the component with default props 1`] = `
+.c2 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+}
+
 .c1 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -50,7 +74,6 @@ exports[`<FooterLink /> renders the component with default props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c1:hover {
@@ -72,6 +95,6 @@ exports[`<FooterLink /> renders the component with default props 1`] = `
 }
 
 <a
-  class="c0 c1"
+  class="c0 c1 c2"
 />
 `;

--- a/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
@@ -35,6 +35,18 @@ exports[`<Links /> renders the component 1`] = `
   align-items: flex-start;
 }
 
+.c8 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+}
+
 .c7 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -46,7 +58,6 @@ exports[`<Links /> renders the component 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c7:hover {
@@ -150,7 +161,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/loans/car-loans"
           >
             Car loans
@@ -160,7 +171,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/loans/debt-consolidation"
           >
             Debt consolidation loans
@@ -170,7 +181,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/loans/home-improvement"
           >
             Home improvement loans
@@ -180,7 +191,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/loans/wedding"
           >
             Wedding loans
@@ -190,7 +201,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/invest"
           >
             Peer-to-peer investments
@@ -200,7 +211,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/invest/isa"
           >
             Innovative Finance ISA
@@ -228,7 +239,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about"
           >
             About Us
@@ -238,7 +249,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about/our-story"
           >
             Our story
@@ -248,7 +259,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about/board"
           >
             Meet the board
@@ -258,7 +269,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about/leadership"
           >
             Meet the leadership team
@@ -268,7 +279,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about/awards"
           >
             Awards
@@ -278,7 +289,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about/careers"
           >
             Careers
@@ -288,7 +299,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/about/press"
           >
             Press team
@@ -298,7 +309,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/feelgood"
           >
             New products
@@ -326,7 +337,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/cookie-policy"
           >
             Cookie policy
@@ -336,7 +347,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/conflicts-policy"
           >
             Conflicts policy
@@ -346,7 +357,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/modern-slavery"
           >
             Modern slavery
@@ -356,7 +367,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/website-terms"
           >
             Website terms
@@ -384,7 +395,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/contact"
           >
             Support
@@ -394,7 +405,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/support/faqs"
           >
             Common Questions
@@ -404,7 +415,7 @@ exports[`<Links /> renders the component 1`] = `
           class="c5"
         >
           <a
-            class="c6 c7"
+            class="c6 c7 c8"
             href="https://zopa.com/sitemap"
           >
             Sitemap

--- a/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   align-self: auto;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -46,7 +46,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   align-items: flex-start;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -69,6 +69,18 @@ exports[`<SocialLinks /> renders the component 1`] = `
   align-items: flex-start;
 }
 
+.c4 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+}
+
 .c3 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -80,7 +92,6 @@ exports[`<SocialLinks /> renders the component 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c3:hover {
@@ -101,7 +112,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   color: #6F748B;
 }
 
-.c5 {
+.c6 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -109,7 +120,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   margin-top: 32px;
 }
 
-.c7 {
+.c8 {
   color: #A9ACBA;
   -webkit-transition: color 0.2s ease;
   transition: color 0.2s ease;
@@ -117,7 +128,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
   margin-right: 8px;
 }
 
-.c7:hover {
+.c8:hover {
   color: #6F748B;
 }
 
@@ -162,7 +173,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:0px) {
-  .c4 {
+  .c5 {
     display: block;
     -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
@@ -172,7 +183,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:576px) {
-  .c4 {
+  .c5 {
     display: block;
     -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
@@ -182,7 +193,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c5 {
     display: block;
     -webkit-flex: 0 0 33.33333333333333%;
     -ms-flex: 0 0 33.33333333333333%;
@@ -192,7 +203,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:992px) {
-  .c4 {
+  .c5 {
     display: block;
     -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
@@ -202,13 +213,13 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 @media (min-width:576px) {
-  .c5 {
+  .c6 {
     margin-top: 0;
   }
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c6 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -226,7 +237,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
     cols="12"
   >
     <a
-      class="c2 c3"
+      class="c2 c3 c4"
       href="https://www.zopa.com"
     >
       <svg
@@ -252,17 +263,17 @@ exports[`<SocialLinks /> renders the component 1`] = `
     </a>
   </div>
   <div
-    class="c4"
+    class="c5"
     cols="12"
   >
     <div
-      class="c5 c6"
+      class="c6 c7"
       cols="12"
       direction="row"
     >
       <a
         aria-label="instagram"
-        class="c7 c3"
+        class="c8 c3 c4"
         cols="12"
         href="https://www.instagram.com/Zopamoney/"
       >
@@ -290,7 +301,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
       </a>
       <a
         aria-label="facebook"
-        class="c7 c3"
+        class="c8 c3 c4"
         cols="12"
         href="https://facebook.com/zopa"
       >
@@ -312,7 +323,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
       </a>
       <a
         aria-label="twitter"
-        class="c7 c3"
+        class="c8 c3 c4"
         cols="12"
         href="https://twitter.com/zopa"
       >

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -103,7 +103,19 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-right: auto;
 }
 
-.c16 {
+.c7 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+}
+
+.c17 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -120,7 +132,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   padding: 18px 0;
 }
 
-.c15 {
+.c16 {
   color: #A9ACBA;
   margin: 0 0 24px 0;
 }
@@ -136,7 +148,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   align-self: auto;
 }
 
-.c7 {
+.c8 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -170,7 +182,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   align-items: flex-start;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -204,7 +216,6 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c6:hover {
@@ -225,27 +236,27 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   color: #6F748B;
 }
 
-.c11 {
+.c12 {
   color: #FFFFFF;
 }
 
-.c12 {
+.c13 {
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
 
-.c13 {
+.c14 {
   margin: 0 0 5px 0;
   padding: 0;
 }
 
-.c14 {
+.c15 {
   background-color: #282F52;
   height: 1px;
 }
 
-.c8 {
+.c9 {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -253,7 +264,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-top: 32px;
 }
 
-.c10 {
+.c11 {
   color: #A9ACBA;
   -webkit-transition: color 0.2s ease;
   transition: color 0.2s ease;
@@ -261,7 +272,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-right: 8px;
 }
 
-.c10:hover {
+.c11:hover {
   color: #6F748B;
 }
 
@@ -335,7 +346,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:0px) {
-  .c7 {
+  .c8 {
     display: block;
     -webkit-flex: 0 0 100%;
     -ms-flex: 0 0 100%;
@@ -345,7 +356,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:576px) {
-  .c7 {
+  .c8 {
     display: block;
     -webkit-flex: 0 0 50%;
     -ms-flex: 0 0 50%;
@@ -355,7 +366,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c8 {
     display: block;
     -webkit-flex: 0 0 33.33333333333333%;
     -ms-flex: 0 0 33.33333333333333%;
@@ -365,7 +376,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:992px) {
-  .c7 {
+  .c8 {
     display: block;
     -webkit-flex: 0 0 25%;
     -ms-flex: 0 0 25%;
@@ -375,13 +386,13 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 @media (min-width:576px) {
-  .c8 {
+  .c9 {
     margin-top: 0;
   }
 }
 
 @media (min-width:768px) {
-  .c8 {
+  .c9 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -409,7 +420,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           cols="12"
         >
           <a
-            class="c5 c6"
+            class="c5 c6 c7"
             href="https://www.zopa.com"
           >
             <svg
@@ -435,17 +446,17 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </a>
         </div>
         <div
-          class="c7"
+          class="c8"
           cols="12"
         >
           <div
-            class="c8 c9"
+            class="c9 c10"
             cols="12"
             direction="row"
           >
             <a
               aria-label="instagram"
-              class="c10 c6"
+              class="c11 c6 c7"
               cols="12"
               href="https://www.instagram.com/Zopamoney/"
             >
@@ -473,7 +484,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
             </a>
             <a
               aria-label="facebook"
-              class="c10 c6"
+              class="c11 c6 c7"
               cols="12"
               href="https://facebook.com/zopa"
             >
@@ -495,7 +506,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
             </a>
             <a
               aria-label="twitter"
-              class="c10 c6"
+              class="c11 c6 c7"
               cols="12"
               href="https://twitter.com/zopa"
             >
@@ -521,80 +532,80 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       class="c2"
     >
       <div
-        class="c9"
+        class="c10"
         cols="12"
         direction="row"
       >
         <div
-          class="c7"
+          class="c8"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c11"
+              class="c12"
             >
               What we do
             </h3>
             <ul
-              class="c12"
+              class="c13"
             >
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/loans/car-loans"
                 >
                   Car loans
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/loans/debt-consolidation"
                 >
                   Debt consolidation loans
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/loans/home-improvement"
                 >
                   Home improvement loans
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/loans/wedding"
                 >
                   Wedding loans
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/invest"
                 >
                   Peer-to-peer investments
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/invest/isa"
                 >
                   Innovative Finance ISA
@@ -604,95 +615,95 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </div>
         </div>
         <div
-          class="c7"
+          class="c8"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c11"
+              class="c12"
             >
               About Zopa
             </h3>
             <ul
-              class="c12"
+              class="c13"
             >
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about"
                 >
                   About Us
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about/our-story"
                 >
                   Our story
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about/board"
                 >
                   Meet the board
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about/leadership"
                 >
                   Meet the leadership team
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about/awards"
                 >
                   Awards
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about/careers"
                 >
                   Careers
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/about/press"
                 >
                   Press team
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/feelgood"
                 >
                   New products
@@ -702,55 +713,55 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </div>
         </div>
         <div
-          class="c7"
+          class="c8"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c11"
+              class="c12"
             >
               Legal
             </h3>
             <ul
-              class="c12"
+              class="c13"
             >
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/cookie-policy"
                 >
                   Cookie policy
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/conflicts-policy"
                 >
                   Conflicts policy
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/modern-slavery"
                 >
                   Modern slavery
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/website-terms"
                 >
                   Website terms
@@ -760,45 +771,45 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
           </div>
         </div>
         <div
-          class="c7"
+          class="c8"
           cols="12"
         >
           <div
             class="c2"
           >
             <h3
-              class="c11"
+              class="c12"
             >
               Navigation
             </h3>
             <ul
-              class="c12"
+              class="c13"
             >
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/contact"
                 >
                   Support
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/support/faqs"
                 >
                   Common Questions
                 </a>
               </li>
               <li
-                class="c13"
+                class="c14"
               >
                 <a
-                  class="c5 c6"
+                  class="c5 c6 c7"
                   href="https://zopa.com/sitemap"
                 >
                   Sitemap
@@ -810,23 +821,23 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       </div>
     </div>
     <div
-      class="c14"
+      class="c15"
     />
     <div
       class="c2"
     >
       <p
-        class="c15 c16"
+        class="c16 c17"
       >
         Zopa Limited is authorised and regulated by the Financial Conduct Authority, and entered on the Financial Services Register (718925). Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services Register (800542). Zopa Limited (05197592) and Zopa Bank Limited (10627575) are both incorporated in England & Wales and have their registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
       </p>
       <p
-        class="c15 c16"
+        class="c16 c17"
       >
         © Zopa Bank Limited 2025 All rights reserved. 'Zopa' is a trademark of Zopa Bank Limited.
       </p>
       <p
-        class="c15 c16"
+        class="c16 c17"
       >
         Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the Office of the Information Commissioner (ZA275984, Z8797078).
 

--- a/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Navbar.Link /> should render component with default props 1`] = `
+.c2 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #4A3EDE;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+  font-size: 14px;
+}
+
 .c1 {
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -12,7 +25,6 @@ exports[`<Navbar.Link /> should render component with default props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c1:hover {
@@ -41,19 +53,32 @@ exports[`<Navbar.Link /> should render component with default props 1`] = `
 }
 
 <a
-  class="c0 c1"
+  class="c0 c1 c2"
   color="#4A3EDE"
 />
 `;
 
 exports[`<Navbar.Link /> should render component with specific props 1`] = `
-.c3 {
+.c4 {
   -webkit-transition: -webkit-transform 0.2s;
   -webkit-transition: transform 0.2s;
   transition: transform 0.2s;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
   transform: rotate(0deg);
+}
+
+.c2 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #4A3EDE;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 600;
+  font-size: 14px;
 }
 
 .c1 {
@@ -67,7 +92,6 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  color: #4A3EDE;
 }
 
 .c1:hover {
@@ -95,7 +119,7 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
   opacity: 1;
 }
 
-.c2 {
+.c3 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -114,15 +138,15 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
 }
 
 <a
-  class="c0 c1"
+  class="c0 c1 c2"
   color="#4A3EDE"
 >
   <span
-    class="c2"
+    class="c3"
     open=""
   >
     <svg
-      class="c3"
+      class="c4"
       direction="down"
       height="18px"
       viewBox="0 0 416 416"


### PR DESCRIPTION
## Summary

A bit of cleanup on `<Link />` ...

- make it same size as its wrapping `<Text />` on the examples
- use `<Text />` instead of `a` as the **styled-components** base
- prevent it's `weight` being customisable ( _always "semibold"_ )

