### PR TITLE
Enable tree shacking in the consumer side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ styleguide/*
 !styleguide/styles/
 !styleguide/components
 
-dist
+/es
+/cjs
+/types
+
 coverage
 
 yarn-error.log

--- a/etc/rollup/config.js
+++ b/etc/rollup/config.js
@@ -17,16 +17,17 @@ export default {
   input: path.resolve('src/index.ts'),
   output: [
     {
-      file: pkg.main,
+      dir: 'cjs',
       format: 'cjs', // Universal Module Definition, works as amd, cjs and iife all in one
       sourcemap: true,
     },
     {
-      file: pkg.module,
+      dir: 'es',
       format: 'es',
       sourcemap: true,
     },
   ],
+  preserveModules: true,
   external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
   plugins: [
     customResolveOptions({ extensions }),
@@ -34,7 +35,7 @@ export default {
       presets: [['react-app', { flow: false, typescript: true }]],
       runtimeHelpers: true,
       extensions,
-      exclude: 'node_modules/**',
+      exclude: 'node_modules',
     }),
     commonjs({
       include: /node_modules/,

--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "version": "2.0.0-beta.10",
   "license": "MIT",
   "author": "Zopa Ltd <frontend-opensource@zopa.com> (https://zopa.com)",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
-  "types": "dist/index.d.ts",
+  "main": "cjs/src/index.js",
+  "module": "es/src/index.js",
+  "types": "types/index.d.ts",
   "files": [
-    "/dist"
+    "/es",
+    "/cjs",
+    "/types",
+    "/src"
   ],
   "scripts": {
     "commit": "git-cz",
@@ -17,7 +20,7 @@
     "build": "styleguidist build",
     "compile": "yarn compile:clean; yarn compile:types && yarn compile:code",
     "compile:code": "rollup --config ./etc/rollup/config.js",
-    "compile:clean": "rm -rf ./dist; mkdir ./dist",
+    "compile:clean": "rm -rf es cjs types",
     "compile:types": "tsc --p ./tsconfig.types.json",
     "test": "react-scripts test",
     "format": "prettier -l --ignore-path ./prettierignore --write \"**/*.{ts,tsx,js,jsx,json,less,css,md}\"",
@@ -75,7 +78,7 @@
     "react-scripts": "2.1.1",
     "react-styleguidist": "^9.0.4",
     "react-test-renderer": "^16.8.6",
-    "rollup": "^1.20.2",
+    "rollup": "^1.21.4",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDeclarationOnly": true,
     "declaration": true,
-    "declarationDir": "./dist",
+    "declarationDir": "./types",
     "lib": ["es2018", "dom"],
     "module": "esnext",
     "target": "es5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,15 +1403,20 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@^12.7.5":
-  version "12.7.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
-  integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
+"@types/node@*":
+  version "12.0.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
+  integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
 
 "@types/node@^10.12.18":
   version "10.14.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.18.tgz#b7d45fc950e6ffd7edc685e890d13aa7b8535dce"
   integrity sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==
+
+"@types/node@^12.7.5":
+  version "12.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
+  integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4220,7 +4225,7 @@ debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6826,7 +6831,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -8722,11 +8727,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -8735,32 +8735,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -8821,11 +8799,6 @@ lodash.merge@4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
   integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -12789,7 +12762,7 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.20.2:
+rollup@^1.21.4:
   version "1.21.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.21.4.tgz#00a41a30f90095db890301b226cbe2918e4cf54d"
   integrity sha512-Pl512XVCmVzgcBz5h/3Li4oTaoDcmpuFZ+kdhS/wLreALz//WuDAMfomD3QEYl84NkDu6Z6wV9twlcREb4qQsw==


### PR DESCRIPTION
## Context

With the incorporation of Rollup as a bundling system, we decreased the amount of the JS by bundling in 2 single files (one for old modules and another one for ESM). At that time that was a huge improvement because the tree shaking was activated in the bundle for the new browsers (ESM) in bundling time for the library. Meaning that any unused code in the library will be excluded from the resulting bundle (which is great). 

## The problem

The consumer of the library couldn't actually achieve tree shaking in his side, which is bad.

For example in my app I had a chunk with this:

<img width="1575" alt="Banners_and_Alerts_and_chunk_2" src="https://user-images.githubusercontent.com/7198934/64473945-61905480-d16d-11e9-96ff-70eb0b2b4144.png">

This is not great because it means that all the library is bundled in the same chunk, in this case, the `vendors` chunk.

and this is the overall view: 

<img width="847" alt="chunks" src="https://user-images.githubusercontent.com/7198934/64960544-c0537d80-d893-11e9-80ec-ce31ad131253.png">



## The solution

By enabling `preserveModules` we say to Rollup "Hey, don't add everything in a single file" which is one of the rules to enable tree shacking. That way we can separate the components into different chunks and exclude the components that are not being used.

This is the important part of the code
```
{
	output: [
	    {
	      dir: 'cjs', // Here we specify where do we want to save the chunks
	      format: 'cjs', // Here the format (es, cjs, iffi...)
	    },
	    {
	      dir: 'es',
	      format: 'es',
	    },
	  ],
	  preserveModules: true, // "Rollup I want them in separate modules not just one !"
}
```

In my app the new modules in the chunk are:

<img width="1136" alt="chunk_2" src="https://user-images.githubusercontent.com/7198934/64959523-a022bf00-d891-11e9-8296-4363640acf24.png">

and this is the overall view: 

<img width="836" alt="chunks" src="https://user-images.githubusercontent.com/7198934/64960368-710d4d00-d893-11e9-931b-2f2f54050f61.png">

As we can see the file size has decreased in the main vendors chunks and increased in the chunk 3 which belongs to a page. Also, the number of modules has increased as expected.

##  ⚠️ Breaking change

When bundling we now generate the directories:

1. `/es` For new browsers
2. `/cjs` For old browsers
3. `/types` For the typescript types

That means that imports of types has to change:

**Before**
`import ... '@zopauk/react-components/dist/components/atoms/Button/Button';`
**After**
`import ... '@zopauk/react-components/types/components/atoms/Button/Button';`

This is not ideal and it has to be fixed to be able to import the types from the index as Matt pointed in Slack. However, this task is out of this PR scope.

Easy peasy if you know what and how to do it 😝