### PR TITLE
<Text size="lead" />

### DIFF
--- a/src/components/atoms/SidekickCard/SidekickCard.md
+++ b/src/components/atoms/SidekickCard/SidekickCard.md
@@ -9,10 +9,10 @@ They come in three variations.
 - Triumph
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
-import { SidekickCard, Text } from '@zopauk/react-components';
+import { SidekickCard, Text, Heading } from '@zopauk/react-components';
 
 <SidekickCard type="triumph">
-  <h2>The action has been successfully completed</h2>
+  <Heading as="h3">The action has been successfully completed</Heading>
   <Text as="p">Awesome everything is alright</Text>
 </SidekickCard>;
 ```
@@ -20,10 +20,10 @@ import { SidekickCard, Text } from '@zopauk/react-components';
 - Verified
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
-import { SidekickCard, Text } from '@zopauk/react-components';
+import { SidekickCard, Text, Heading } from '@zopauk/react-components';
 
 <SidekickCard type="verified">
-  <h2>Your account has been verfied</h2>
+  <Heading as="h3">Your account has been verfied</Heading>
   <Text as="p">You can start using your account now</Text>
 </SidekickCard>;
 ```
@@ -31,10 +31,10 @@ import { SidekickCard, Text } from '@zopauk/react-components';
 - Alert
 
 ```jsx { "props": { "style": { "backgroundColor": "#141E64", "border": "none" } } }
-import { SidekickCard, Text } from '@zopauk/react-components';
+import { SidekickCard, Text, Heading } from '@zopauk/react-components';
 
 <SidekickCard type="alert">
-  <h2>The action has a problem</h2>
+  <Heading as="h3">The action has a problem</Heading>
   <Text as="p">Ops, something went wrong</Text>
 </SidekickCard>;
 ```

--- a/src/components/atoms/Text/Text.md
+++ b/src/components/atoms/Text/Text.md
@@ -43,10 +43,11 @@ import { Fragment } from 'react';
 import { Text } from '@zopauk/react-components';
 
 <Fragment>
-  <Text mb>Medium ( 16px, default )</Text>
-  <Text size="small" mb>
-    Small ( 14px, small )
+  <Text size="lead" mb>
+    Lead ( 20px )
   </Text>
+  <Text mb>Medium ( 16px, default )</Text>
+  <Text size="small">Small ( 14px )</Text>
 </Fragment>;
 ```
 

--- a/src/components/atoms/Text/Text.test.tsx
+++ b/src/components/atoms/Text/Text.test.tsx
@@ -34,6 +34,7 @@ describe('<Text />', () => {
 
   it.each`
     size       | pixels
+    ${'lead'}  | ${'20px'}
     ${'base'}  | ${'16px'}
     ${'small'} | ${'14px'}
   `('can render at different sizes:  $size – $pixels', ({ size, pixels }) => {

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, FC } from 'react';
 import styled from 'styled-components';
 import { typography } from '../../../constants/typography';
 import { colors, INeutralColorSpec, ISemanticColorSpec } from '../../../constants/colors';
@@ -10,9 +10,9 @@ export interface ITextProps extends HTMLAttributes<HTMLSpanElement | HTMLParagra
    */
   weight?: keyof typeof typography.weights;
   /**
-   * The size you want to render your text at, currently only `12px` | `14px` | `16px` supported.
+   * The size you want to render your text at, currently only `14px` | `16px` and `20px` supported.
    */
-  size?: keyof typeof typography.sizes.text;
+  size?: keyof typeof typography.sizes.text | 'lead';
   /**
    * The HTML5 tag you want to render your text on, currently only `<span>` and `<p>` are supported.
    */
@@ -47,12 +47,10 @@ const Text = styled.span<ITextProps>`
   line-height: ${typography.lineHeights.text};
   font-family: ${typography.primary};
   font-weight: ${({ weight = 'regular' }) => typography.weights[weight]};
-  font-size: ${({ size = 'base' }) => {
-    return typography.sizes.text[size];
-  }};
+  font-size: ${({ size = 'base' }) => (size === 'lead' ? typography.sizes.heading.h4 : typography.sizes.text[size])};
 `;
 
-const TextWrap: React.FunctionComponent<ITextProps> = props => <Text {...props} />;
+const TextWrap: FC<ITextProps> = props => <Text {...props} />;
 
 TextWrap.defaultProps = {
   as: 'span',


### PR DESCRIPTION
## Summary 🍿 

Already in existing designs (👇 **Savings Dashboard** )

<img src="https://user-images.githubusercontent.com/5938217/65242974-a90cce00-dae7-11e9-8401-c0680279aa4d.png" width="400" />

and new ones (👇 **Shopfront new BP page** )

<img src="https://user-images.githubusercontent.com/5938217/65243037-d2c5f500-dae7-11e9-8a0d-82163b604e21.png" width="400" />

Paragraphs of text `<p>` appear with the `<h4>` font size ( `20px` ).

At the moment, `<Text />` only renders at `16px` or `14px` but **the design team
 has approved** the need to add an option to render it at `20px`.

This PR brings that new size to `<Text />`:
```jsx
<Text size="lead">Wooohoo I render big and nice at 20px</Text>
```

Note that this doesn't break our new [typography spec](https://user-images.githubusercontent.com/5938217/65140301-85298980-da0e-11e9-82cc-2a541449d660.png)... when designed it wasn't taken in account the semantics needed on the web ( _for instance in the **mobile app** is fine to mark long text as a **heading 4**..._ )  