### PR TITLE
Interpolate function typing  😅

### DIFF
--- a/src/helpers/responsiveness.ts
+++ b/src/helpers/responsiveness.ts
@@ -22,9 +22,10 @@ const minMedia = {
 };
 
 function interpolate(sizeLabel: keyof typeof sizes, direction: 'min' | 'max') {
-  return (style: TemplateStringsArray) => css`
+  return (style: TemplateStringsArray, ...rest: any) => css`
     @media (${direction}-width: ${sizes[sizeLabel]}px) {
       ${style};
+      ${rest};
     }
   `;
 }


### PR DESCRIPTION
After my [last PR](#127) a bug was introduced where the responsive helpers `minMedia` and `maxMedia` are not typed properly.

Currently they are typed as receiving **only** an array of [template strings](https://github.com/zopaUK/react-components/blob/master/src/helpers/responsiveness.ts#L25-L29), hence doing this is fine:
```js
maxMedia`font-size: 14px;`
```
as it translates roughly to:
```js
maxMedia(['font-size: 14px;'])
```
however if we pass a dynamic value:
```js
maxMedia`font-size: ${mySize};`
```
it translates to:
```js
maxMedia(['font-size: ', ';'], mySize)
```
and hence  **Typescript** will complain that `maxMedia` expects one argument but two were supplied. 
( _you can learn how tagged templates work [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates)_)

I decided to type the rest arguments as `any` for simplicity. We also need to reference the arguments to prevent linting complains, however `styled-components` will grab the values magically for you ✨

Suggestions for better typing very welcome 😛

<img src="https://user-images.githubusercontent.com/5938217/70135818-15c94a80-168b-11ea-84f5-8e2e221cae86.jpg" width="400" />
