### PR TITLE
<FlexCol /> should inherit native HTML types as well

### DIFF
--- a/src/components/layout/FlexCol/FlexCol.test.tsx
+++ b/src/components/layout/FlexCol/FlexCol.test.tsx
@@ -3,8 +3,43 @@ import { render } from '@testing-library/react';
 import FlexCol from './FlexCol';
 
 describe('<FlexCol />', () => {
-  it('renders a FlexCol component', () => {
+  it('renders without issues', () => {
     const { container } = render(<FlexCol />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders with a custom gutter', () => {
+    const customGutter = 12;
+    const { container } = render(<FlexCol gutter={12}>A column</FlexCol>);
+
+    expect(container.firstChild).toHaveStyleRule('padding-right', `${customGutter}px`);
+    expect(container.firstChild).toHaveStyleRule('padding-left', `${customGutter}px`);
+  });
+
+  it('renders with custom alignment', () => {
+    const customAlignment = 'flex-start';
+    const { container } = render(<FlexCol align={customAlignment}>A column</FlexCol>);
+
+    expect(container.firstChild).toHaveStyleRule('align-self', customAlignment);
+  });
+
+  it('renders with custom columns', () => {
+    const { container } = render(
+      <FlexCol cols={4} m={2}>
+        A column
+      </FlexCol>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders hidden at certain breakpoint', () => {
+    const { container } = render(<FlexCol m="hidden">A column</FlexCol>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders filling the columns at certain breakpoint', () => {
+    const { container } = render(<FlexCol m="fill">A column</FlexCol>);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/layout/FlexCol/FlexCol.tsx
+++ b/src/components/layout/FlexCol/FlexCol.tsx
@@ -50,7 +50,7 @@ const genRelativeWidth = (breakpoint: TGridBreakpoints, colWidth: TColWidth, col
     flex: 0 0 ${(colWidth / cols) * 100}%;
     max-width: ${(colWidth / cols) * 100}%;
     `
-      : null}
+      : null};
   }
 `;
 
@@ -88,7 +88,7 @@ const StyledFlexCol = styled.div<IFlexCol>`
       })}
 `;
 
-const FlexCol: FC<IFlexColProps> = props => <StyledFlexCol {...props} />;
+const FlexCol: FC<IFlexCol> = props => <StyledFlexCol {...props} />;
 
 FlexCol.defaultProps = {
   align: 'auto',

--- a/src/components/layout/FlexCol/__snapshots__/FlexCol.test.tsx.snap
+++ b/src/components/layout/FlexCol/__snapshots__/FlexCol.test.tsx.snap
@@ -1,6 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<FlexCol /> renders a FlexCol component 1`] = `
+exports[`<FlexCol /> renders filling the columns at certain breakpoint 1`] = `
+.c0 {
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: px;
+  padding-left: px;
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: block;
+    -webkit-flex-basis: 0;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+}
+
+<div
+  class="c0"
+>
+  A column
+</div>
+`;
+
+exports[`<FlexCol /> renders hidden at certain breakpoint 1`] = `
+.c0 {
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: px;
+  padding-left: px;
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: none;
+  }
+}
+
+<div
+  class="c0"
+>
+  A column
+</div>
+`;
+
+exports[`<FlexCol /> renders with custom columns 1`] = `
+.c0 {
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: px;
+  padding-left: px;
+  -webkit-align-self: auto;
+  -ms-flex-item-align: auto;
+  align-self: auto;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: block;
+    -webkit-flex: 0 0 50%;
+    -ms-flex: 0 0 50%;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+}
+
+<div
+  class="c0"
+  cols="4"
+>
+  A column
+</div>
+`;
+
+exports[`<FlexCol /> renders without issues 1`] = `
 .c0 {
   position: relative;
   width: 100%;

--- a/src/components/layout/FlexRow/FlexRow.tsx
+++ b/src/components/layout/FlexRow/FlexRow.tsx
@@ -50,7 +50,7 @@ const StyledFlexRow = styled.div<IFlexRow>`
   align-items: ${props => props.align};
 `;
 
-const FlexRow: React.FunctionComponent<IFlexRow> = ({ children, ...props }) => {
+const FlexRow: React.FC<IFlexRow> = ({ children, ...props }) => {
   const childrenWithProps = React.Children.toArray(children)
     .filter(child => !!child)
     .map(child => React.cloneElement(child as any, { gutter: props.gutter, cols: props.cols }));

--- a/src/components/layout/FlexRow/FlexRow.tsx
+++ b/src/components/layout/FlexRow/FlexRow.tsx
@@ -50,7 +50,7 @@ const StyledFlexRow = styled.div<IFlexRow>`
   align-items: ${props => props.align};
 `;
 
-const FlexRow: React.FC<IFlexRow> = ({ children, ...props }) => {
+const FlexRow: React.FunctionComponent<IFlexRow> = ({ children, ...props }) => {
   const childrenWithProps = React.Children.toArray(children)
     .filter(child => !!child)
     .map(child => React.cloneElement(child as any, { gutter: props.gutter, cols: props.cols }));


### PR DESCRIPTION
## Summary 💅🏻

Addressing #154, following my last PR on types I forgot to make `<FlexCol />` also extend `HTMLAttributes`  💆🏻‍♂️

I added a couple more tests on `<FlexCol />` to improve coverage, as **Codecov** was complaining about it 🌧