### PR TITLE
Remove reference to v1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ We think it might be useful for someone who wants to start a new react component
 ### Migration
 
 - Check [how to migrate to v2](./etc/docs/migration-v2.md) 🏃🏻
-- Check [documentation for v1](https://zopauk.github.io/react-components/v1).
 
 ## Contributing
 


### PR DESCRIPTION
I was publishing them manually on every release... 

Time has passed ⏰ , I think most of the clients of this library are now on **v2** so I think there's no need to keep the **v1** docs accessible anymore.