### PR TITLE
fix(react-modal): move types from dev dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "release": "semantic-release -e ./etc/semantic-release/config.js --no-ci"
   },
   "dependencies": {
+    "@types/react-modal": "^3.10.2",
     "core-js": "^3.3.5",
     "downshift": "^2.2.2",
     "react-modal": "^3.8.1",
@@ -56,7 +57,6 @@
     "@types/node": "^12.12.0",
     "@types/react": "^16.8.2",
     "@types/react-dom": "^16.8.0",
-    "@types/react-modal": "^3.8.0",
     "@types/styled-components": "^4.1.19",
     "@typescript-eslint/eslint-plugin": "^2.6.0",
     "@typescript-eslint/parser": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12089,7 +12089,7 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-modal@^3.11.1:
+react-modal@^3.8.1:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.1.tgz#2a0d6877c9e98f123939ea92d2bb4ad7fa5a17f9"
   integrity sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,10 +1463,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-modal@^3.8.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.10.0.tgz#48a34b454cc670c1bb038253b05c2d0d817ebe30"
-  integrity sha512-HOBSGwtaZXACvYI2kdhOiAG+CtwCxq62TwayFxtsGDtOvBxE4vxKCQI7LnhrihoDchVarqvnH7GKZ8xXHjs+yg==
+"@types/react-modal@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.10.2.tgz#f0b065babb587f010e7c0802238c29a313e1515a"
+  integrity sha512-e1e/HDRo/x7rFF+kX0NgSpV1PvaIrojGpFPrNYIZmLlKR0IukpnMWhHLnRXD3hYXlHTtr4FdWOzhzufU5SfNjA==
   dependencies:
     "@types/react" "*"
 
@@ -12089,7 +12089,7 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-modal@^3.8.1:
+react-modal@^3.11.1:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.1.tgz#2a0d6877c9e98f123939ea92d2bb4ad7fa5a17f9"
   integrity sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==


### PR DESCRIPTION
In order to not force users to manually install the react-modal types I'm moving it from dev dependencies to dependencies. 