### PR TITLE
Re-skin <Badge /> and <AlertBox /> ( WIP )

### DIFF
--- a/src/components/atoms/AlertBox/AlertBox.tsx
+++ b/src/components/atoms/AlertBox/AlertBox.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactElement, HTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../constants/colors';
-import Alert from '../../icons/Alert/Alert';
+import RoundIcon from '../../icons/RoundIcon/RoundIcon';
 
 export interface IAlertBoxProps extends HTMLAttributes<HTMLDivElement> {
   icon?: ReactElement;
@@ -22,7 +22,7 @@ const IconContainer = styled.div`
 
 const AlertBox: FC<IAlertBoxProps> = ({ children, icon, ...rest }) => (
   <Box {...rest}>
-    <IconContainer>{icon || <Alert />}</IconContainer>
+    <IconContainer>{icon || <RoundIcon variant="waiting" />}</IconContainer>
     {children}
   </Box>
 );

--- a/src/components/atoms/AlertBox/__snapshots__/AlertBox.test.tsx.snap
+++ b/src/components/atoms/AlertBox/__snapshots__/AlertBox.test.tsx.snap
@@ -1,6 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AlertBox /> renders the component with no a11y violations 1`] = `
+.c3 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFB428;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
 .c0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -23,26 +56,15 @@ exports[`<AlertBox /> renders the component with no a11y violations 1`] = `
   <div
     class="c1"
   >
-    <svg
-      height="20px"
-      viewBox="0 0 20 20"
-      width="20px"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="c2"
     >
-      <g
-        fill="none"
-        fill-rule="evenodd"
+      <span
+        class="c3"
       >
-        <path
-          d="M-2-2h24v24H-2z"
-        />
-        <path
-          d="M5.58 2.08L4.15.65C1.75 2.48.17 5.3.03 8.5h2a8.445 8.445 0 0 1 3.55-6.42zM17.97 8.5h2c-.15-3.2-1.73-6.02-4.12-7.85l-1.42 1.43a8.495 8.495 0 0 1 3.54 6.42zM16 9c0-3.07-1.64-5.64-4.5-6.32V2c0-.83-.67-1.5-1.5-1.5S8.5 1.17 8.5 2v.68C5.63 3.36 4 5.92 4 9v5l-2 2v1h16v-1l-2-2V9zm-6 11c.14 0 .27-.01.4-.04.65-.14 1.18-.58 1.44-1.18.1-.24.15-.5.15-.78h-4c.01 1.1.9 2 2.01 2z"
-          fill="#4A3EDE"
-          fill-rule="nonzero"
-        />
-      </g>
-    </svg>
+        !
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/atoms/Badge/Badge.md
+++ b/src/components/atoms/Badge/Badge.md
@@ -2,8 +2,6 @@
 
 Use the `<Badge />` component to label elements in the user interface.
 
-There's four variations available and accepts the same sizes as [`<Text />`](#/Components/Atoms/Text).
-
 ### Examples
 
 - Variations
@@ -13,21 +11,13 @@ import { Fragment } from 'react';
 import { Badge } from '@zopauk/react-components';
 
 <Fragment>
-  <div>
-    <Badge mb>Default</Badge>
-  </div>
-  <div>
-    <Badge styling="waiting" mb>
-      Pending
-    </Badge>
-  </div>
-  <div>
-    <Badge styling="confirmed" mb>
-      Approved
-    </Badge>
-  </div>
-  <div>
-    <Badge styling="invalid">Invalid</Badge>
-  </div>
+  <Badge mb>Default</Badge>
+  <Badge styling="waiting" mb>
+    Pending
+  </Badge>
+  <Badge styling="confirmed" mb>
+    Approved
+  </Badge>
+  <Badge styling="invalid">Invalid</Badge>
 </Fragment>;
 ```

--- a/src/components/atoms/Badge/Badge.test.tsx
+++ b/src/components/atoms/Badge/Badge.test.tsx
@@ -17,17 +17,14 @@ describe('<Badge />', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('renders with specific style', () => {
-    const { container } = render(<Badge styling="confirmed">Content</Badge>);
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
   it.each`
-    size
-    ${'small'}
-    ${'medium'}
-  `('renders with specific size: $size', ({ size }) => {
-    const { container } = render(<Badge size={size}>Content</Badge>);
+    style
+    ${'default'}
+    ${'waiting'}
+    ${'confirmed'}
+    ${'invalid'}
+  `('renders with specific style: $style', ({ style }) => {
+    const { container } = render(<Badge styling={style}>Content</Badge>);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/atoms/Badge/Badge.tsx
+++ b/src/components/atoms/Badge/Badge.tsx
@@ -1,12 +1,9 @@
 import React, { HTMLAttributes } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
-import CheckMark from '../../icons/CheckMark/CheckMark';
 import Text from '../Text/Text';
+import RoundIcon from '../../icons/RoundIcon/RoundIcon';
 
-type TStyling = 'confirmed' | 'default' | 'invalid' | 'waiting';
-type IBgColors = { [S in TStyling]: string };
-type IFontColors = { [S in TStyling]: string };
+type TStyling = 'confirmed' | 'invalid' | 'waiting';
 
 interface IBadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
   /**
@@ -15,48 +12,29 @@ interface IBadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
   styling?: TStyling;
 }
 
-const backgroundColors: IBgColors = {
-  confirmed: colors.semantic.success,
-  default: colors.neutral.dark,
-  invalid: colors.semantic.error,
-  waiting: colors.semantic.alert,
-};
-
-const fontColors: IFontColors = {
-  confirmed: colors.neutral.white,
-  default: colors.neutral.white,
-  invalid: colors.neutral.white,
-  waiting: colors.neutral.dark,
-};
-
 const StyledBadge = styled(Text).attrs({
   size: 'small',
   forwardedAs: 'span',
-})<IBadgeProps>`
-  color: ${({ styling = 'default' }) => styling && fontColors[styling]};
-  background-color: ${({ styling = 'default' }) => styling && backgroundColors[styling]};
-  display: inline-block;
+})`
+  display: flex;
+  align-items: center;
   padding: 4px 10px;
   white-space: nowrap;
   border-radius: 4px;
+  width: max-content;
 `;
 
-const StyledCheckMark = styled(CheckMark)`
-  display: inline-block;
-  margin-right: 5px;
+const ChildWrap = styled.div`
+  margin-left: 8px;
 `;
 
 const Badge: React.FC<IBadgeProps> = ({ children, styling, ...rest }) => {
   return (
-    <StyledBadge styling={styling} {...rest}>
-      {styling === 'confirmed' && <StyledCheckMark color={fontColors.confirmed} />}
-      {children}
+    <StyledBadge {...rest}>
+      <RoundIcon variant={styling} />
+      <ChildWrap>{children}</ChildWrap>
     </StyledBadge>
   );
-};
-
-Badge.defaultProps = {
-  styling: 'default',
 };
 
 export default Badge;

--- a/src/components/atoms/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/atoms/Badge/__snapshots__/Badge.test.tsx.snap
@@ -14,139 +14,425 @@ exports[`<Badge /> renders with no a11y violations 1`] = `
   font-size: 14px;
 }
 
-.c1 {
-  color: #FFFFFF;
-  background-color: #0D0A38;
-  display: inline-block;
-  padding: 4px 10px;
-  white-space: nowrap;
-  border-radius: 4px;
-}
-
-<span
-  class="c0 c1"
->
-  Content
-</span>
-`;
-
-exports[`<Badge /> renders with specific size: "medium" 1`] = `
-.c0 {
+.c3 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
-  color: #0D0A38;
+  color: #FFFFFF;
   line-height: 1.6;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 400;
   font-size: 14px;
-}
-
-.c1 {
-  color: #FFFFFF;
-  background-color: #0D0A38;
-  display: inline-block;
-  padding: 4px 10px;
-  white-space: nowrap;
-  border-radius: 4px;
-}
-
-<span
-  class="c0 c1"
->
-  Content
-</span>
-`;
-
-exports[`<Badge /> renders with specific size: "small" 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  color: #0D0A38;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 14px;
-}
-
-.c1 {
-  color: #FFFFFF;
-  background-color: #0D0A38;
-  display: inline-block;
-  padding: 4px 10px;
-  white-space: nowrap;
-  border-radius: 4px;
-}
-
-<span
-  class="c0 c1"
->
-  Content
-</span>
-`;
-
-exports[`<Badge /> renders with specific style 1`] = `
-.c0 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  color: #0D0A38;
-  line-height: 1.6;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 400;
-  font-size: 14px;
-}
-
-.c1 {
-  color: #FFFFFF;
-  background-color: #1EC06A;
-  display: inline-block;
-  padding: 4px 10px;
-  white-space: nowrap;
-  border-radius: 4px;
 }
 
 .c2 {
-  display: inline-block;
-  margin-right: 5px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 10px;
+  white-space: nowrap;
+  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.c4 {
+  margin-left: 8px;
 }
 
 <span
   class="c0 c1"
 >
-  <svg
-    aria-label="Checkmark"
+  <div
     class="c2"
-    height="12px"
-    role="img"
-    version="1.1"
-    viewBox="0 0 14 12"
-    width="14px"
   >
-    <g
-      fill="none"
-      fill-rule="evenodd"
-      stroke="none"
-      stroke-width="1"
-      transform="translate(-5.000000, -7.000000)"
+    <span
+      class="c3"
+      color="#FFFFFF"
+    >
+      −
+    </span>
+  </div>
+  <div
+    class="c4"
+  >
+    Content
+  </div>
+</span>
+`;
+
+exports[`<Badge /> renders with specific style: "confirmed" 1`] = `
+.c0 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #1EC06A;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 10px;
+  white-space: nowrap;
+  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.c3 {
+  margin-left: 8px;
+}
+
+<span
+  class="c0 c1"
+>
+  <div
+    class="c2"
+  >
+    <svg
+      aria-label="Checkmark"
+      height="10"
+      role="img"
+      version="1.1"
+      viewBox="0 0 14 12"
+      width="10"
     >
       <g
-        fill="#FFFFFF"
+        fill="none"
+        fill-rule="evenodd"
+        stroke="none"
+        stroke-width="1"
+        transform="translate(-5.000000, -7.000000)"
       >
-        <path
-          d="M8.8937112,18.1162104 L5.28067153,13.7796715 C4.86185798,13.276869 4.91785534,12.5208652 5.40783219,12.088863 C5.89547582,11.6556608 6.63277432,11.7132611 7.05275448,12.2196637 L9.70329594,15.3996797 L16.9806188,7.38003928 C17.4204314,6.89643685 18.1588965,6.87123672 18.629041,7.32243899 C19.100352,7.77484127 19.1260175,8.53324509 18.6862049,9.01924754 L10.4025549,18.1480964 C10.0314235,18.5570951 9.3990031,18.5877927 8.99000439,18.2166613 C8.95561314,18.1854542 8.92343754,18.1518893 8.8937112,18.1162104 Z"
-        />
+        <g
+          fill="#FFFFFF"
+        >
+          <path
+            d="M8.8937112,18.1162104 L5.28067153,13.7796715 C4.86185798,13.276869 4.91785534,12.5208652 5.40783219,12.088863 C5.89547582,11.6556608 6.63277432,11.7132611 7.05275448,12.2196637 L9.70329594,15.3996797 L16.9806188,7.38003928 C17.4204314,6.89643685 18.1588965,6.87123672 18.629041,7.32243899 C19.100352,7.77484127 19.1260175,8.53324509 18.6862049,9.01924754 L10.4025549,18.1480964 C10.0314235,18.5570951 9.3990031,18.5877927 8.99000439,18.2166613 C8.95561314,18.1854542 8.92343754,18.1518893 8.8937112,18.1162104 Z"
+          />
+        </g>
       </g>
-    </g>
-  </svg>
-  Content
+    </svg>
+  </div>
+  <div
+    class="c3"
+  >
+    Content
+  </div>
+</span>
+`;
+
+exports[`<Badge /> renders with specific style: "default" 1`] = `
+.c0 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c3 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #FFFFFF;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 10px;
+  white-space: nowrap;
+  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.c4 {
+  margin-left: 8px;
+}
+
+<span
+  class="c0 c1"
+>
+  <div
+    class="c2"
+  >
+    <span
+      class="c3"
+      color="#FFFFFF"
+    >
+      −
+    </span>
+  </div>
+  <div
+    class="c4"
+  >
+    Content
+  </div>
+</span>
+`;
+
+exports[`<Badge /> renders with specific style: "invalid" 1`] = `
+.c0 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c3 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #FFFFFF;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #EE0505;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 10px;
+  white-space: nowrap;
+  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.c4 {
+  margin-left: 8px;
+}
+
+<span
+  class="c0 c1"
+>
+  <div
+    class="c2"
+  >
+    <span
+      class="c3"
+      color="#FFFFFF"
+    >
+      !
+    </span>
+  </div>
+  <div
+    class="c4"
+  >
+    Content
+  </div>
+</span>
+`;
+
+exports[`<Badge /> renders with specific style: "waiting" 1`] = `
+.c0 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #0D0A38;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFB428;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 10px;
+  white-space: nowrap;
+  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.c3 {
+  margin-left: 8px;
+}
+
+<span
+  class="c0 c1"
+>
+  <div
+    class="c2"
+  >
+    <span
+      class="c0"
+    >
+      !
+    </span>
+  </div>
+  <div
+    class="c3"
+  >
+    Content
+  </div>
 </span>
 `;
 
@@ -164,18 +450,77 @@ exports[`<Badge /> renders without crashing 1`] = `
   font-size: 14px;
 }
 
-.c1 {
+.c3 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   color: #FFFFFF;
-  background-color: #0D0A38;
-  display: inline-block;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   padding: 4px 10px;
   white-space: nowrap;
   border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
+.c4 {
+  margin-left: 8px;
 }
 
 <span
   class="c0 c1"
 >
-  Content
+  <div
+    class="c2"
+  >
+    <span
+      class="c3"
+      color="#FFFFFF"
+    >
+      −
+    </span>
+  </div>
+  <div
+    class="c4"
+  >
+    Content
+  </div>
 </span>
 `;

--- a/src/components/icons/RoundIcon/RoundIcon.md
+++ b/src/components/icons/RoundIcon/RoundIcon.md
@@ -1,0 +1,18 @@
+### Summary
+
+...
+
+### Example
+
+```js
+import { RoundIcon, FlexRow, FlexContainer } from '@zopauk/react-components';
+
+<FlexContainer>
+  <FlexRow>
+    <RoundIcon />
+    <RoundIcon variant="confirmed" />
+    <RoundIcon variant="invalid" />
+    <RoundIcon variant="waiting" />
+  </FlexRow>
+</FlexContainer>;
+```

--- a/src/components/icons/RoundIcon/RoundIcon.test.tsx
+++ b/src/components/icons/RoundIcon/RoundIcon.test.tsx
@@ -1,0 +1,24 @@
+import { axe } from 'jest-axe';
+import React from 'react';
+import { render } from '@testing-library/react';
+import RoundIcon from './RoundIcon';
+
+describe('<RoundIcon />', () => {
+  it('renders the component with no a11y violations', async () => {
+    const { container } = render(<RoundIcon />);
+    const results = await axe(container.innerHTML);
+
+    expect(container.firstChild).toMatchSnapshot();
+    expect(results).toHaveNoViolations();
+  });
+
+  it.each`
+    Variant
+    ${'confirmed'}
+    ${'waiting'}
+    ${'invalid'}
+  `('renders specific variant: $variant', ({ variant }) => {
+    const { container } = render(<RoundIcon variant={variant} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/icons/RoundIcon/RoundIcon.tsx
+++ b/src/components/icons/RoundIcon/RoundIcon.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import { colors, typography, Text } from '../../..';
+import CheckMark from '../CheckMark/CheckMark';
+
+interface IRoundIconProps {
+  variant?: 'confirmed' | 'waiting' | 'invalid';
+}
+
+interface IRoundIconCircleProps {
+  bgColor:
+    | typeof colors.neutral.nearDark
+    | typeof colors.semantic.success
+    | typeof colors.semantic.alert
+    | typeof colors.semantic.error;
+}
+
+const RoundIconCircle = styled.div<IRoundIconCircleProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ bgColor }) => bgColor};
+  font-weight: ${typography.weights.bold};
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+`;
+
+export default function RoundIcon({ variant }: IRoundIconProps) {
+  if (variant === 'confirmed')
+    return (
+      <RoundIconCircle bgColor={colors.semantic.success}>
+        <CheckMark width={10} height={10} color={colors.neutral.white} />
+      </RoundIconCircle>
+    );
+
+  if (variant === 'waiting')
+    return (
+      <RoundIconCircle bgColor={colors.semantic.alert}>
+        <Text size="small">!</Text>
+      </RoundIconCircle>
+    );
+
+  if (variant === 'invalid')
+    return (
+      <RoundIconCircle bgColor={colors.semantic.error}>
+        <Text size="small" color={colors.neutral.white}>
+          !
+        </Text>
+      </RoundIconCircle>
+    );
+
+  return (
+    <RoundIconCircle bgColor={colors.neutral.nearDark}>
+      <Text size="small" color={colors.neutral.white}>
+        −
+      </Text>
+    </RoundIconCircle>
+  );
+}

--- a/src/components/icons/RoundIcon/__snapshots__/RoundIcon.test.tsx.snap
+++ b/src/components/icons/RoundIcon/__snapshots__/RoundIcon.test.tsx.snap
@@ -1,0 +1,185 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RoundIcon /> renders specific variant: $variant 1`] = `
+.c1 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #FFFFFF;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+<div
+  class="c0"
+>
+  <span
+    class="c1"
+    color="#FFFFFF"
+  >
+    −
+  </span>
+</div>
+`;
+
+exports[`<RoundIcon /> renders specific variant: $variant 2`] = `
+.c1 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #FFFFFF;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+<div
+  class="c0"
+>
+  <span
+    class="c1"
+    color="#FFFFFF"
+  >
+    −
+  </span>
+</div>
+`;
+
+exports[`<RoundIcon /> renders specific variant: $variant 3`] = `
+.c1 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #FFFFFF;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+<div
+  class="c0"
+>
+  <span
+    class="c1"
+    color="#FFFFFF"
+  >
+    −
+  </span>
+</div>
+`;
+
+exports[`<RoundIcon /> renders the component with no a11y violations 1`] = `
+.c1 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #FFFFFF;
+  line-height: 1.6;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #63637E;
+  font-weight: 700;
+  border-radius: 100%;
+  width: 24px;
+  height: 24px;
+}
+
+<div
+  class="c0"
+>
+  <span
+    class="c1"
+    color="#FFFFFF"
+  >
+    −
+  </span>
+</div>
+`;

--- a/src/components/molecules/RadioField/RadioField.md
+++ b/src/components/molecules/RadioField/RadioField.md
@@ -42,7 +42,7 @@ import { RadioField } from '@zopauk/react-components';
 ```jsx
 import { RadioField } from '@zopauk/react-components';
 
-<RadioField label="I'm checked by default" inputProps={{ value: 'radio4', name: 'radio4', defaultChecked: true }} />;
+<RadioField label="I'm checked by default" inputProps={{ value: 'radio4', name: 'radio4', checked: true }} />;
 ```
 
 - Disabled and pre-selected
@@ -52,7 +52,7 @@ import { RadioField } from '@zopauk/react-components';
 
 <RadioField
   label="I'm disabled and checked"
-  inputProps={{ value: 'radio5', name: 'radio5', disabled: true, defaultChecked: true }}
+  inputProps={{ value: 'radio5', name: 'radio5', disabled: true, checked: true }}
 />;
 ```
 
@@ -64,7 +64,7 @@ import { RadioField } from '@zopauk/react-components';
 <RadioField
   label="I'm disabled, valid and checked"
   isValid={true}
-  inputProps={{ value: 'radio6', name: 'radio6', disabled: true, defaultChecked: true }}
+  inputProps={{ value: 'radio6', name: 'radio6', disabled: true, checked: true }}
 />;
 ```
 

--- a/src/components/molecules/Tooltip/Tooltip.md
+++ b/src/components/molecules/Tooltip/Tooltip.md
@@ -9,7 +9,7 @@ For more information:
 
 ⚠️ &nbsp; If you want the tooltip target to be a React component, you [need to wrap it with `forwardRef`](https://github.com/atomiks/tippy.js-react#component-children).
 
-⚠️ &nbsp; We don't allow to customise `theme`, `animation` and `flipOnUpdate` to make sure the tooltip UX stays the same.
+⚠️ &nbsp; We don't allow to customise `theme`, `animation` and `flipOnUpdate` to make sure the tooltip UX stays consistent.
 
 ⚠️ &nbsp; By default you won't be able to pass JSX to the tooltip content. You can change that via `allowHTML={true}` prop.
 
@@ -17,7 +17,7 @@ For more information:
 
 ```jsx
 import { forwardRef } from 'react';
-import { Tooltip, Button } from '@zopauk/react-components';
+import { Tooltip } from '@zopauk/react-components';
 
 function Example() {
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export { default as ChevronIcon } from './components/icons/Chevron/Chevron';
 export { default as ZopaIcon } from './components/icons/ZopaLogo/ZopaLogo';
 export { default as HamburgerIcon } from './components/icons/Hamburger/Hamburger';
 export { default as ProfileIcon } from './components/icons/Profile/Profile';
+export { default as RoundIcon } from './components/icons/RoundIcon/RoundIcon';
 
 // Hooks
 export { default as useAccordion } from './components/hooks/useAccordion/useAccordion';


### PR DESCRIPTION
## Before

### `<Badge />`

<img src="https://user-images.githubusercontent.com/5938217/72456055-32958980-37c4-11ea-8536-04cb2d692ae7.png" width="100" />

### `<AlertBox />`

<img src="https://user-images.githubusercontent.com/5938217/72456061-375a3d80-37c4-11ea-89cc-dec1958160ea.png" width="300" />

## Now

### `<Badge />`

<img src="https://user-images.githubusercontent.com/5938217/72456208-7f796000-37c4-11ea-8b4e-687e13fcc7b9.png" width="100" />

### `<AlertBox />`

<img src="https://user-images.githubusercontent.com/5938217/72455872-e21e2c00-37c3-11ea-949e-07844d284393.png" width="300" />

## Summary

New styling... 💅🏻 , as you can see now `<AlertBox />` and one version of `<Badge />` use the same icon. I made an abstraction, `<RoundIcon variant />` to handle the case 🤞🏻