### PR TITLE
Move and expose form hooks and reexport their types

### DIFF
--- a/src/components/hooks/useForm/FormContext.ts
+++ b/src/components/hooks/useForm/FormContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import { IUseFormValues } from './useForm';
+
+export const FormContext = createContext<IUseFormValues | undefined>(undefined);

--- a/src/components/hooks/useForm/index.ts
+++ b/src/components/hooks/useForm/index.ts
@@ -1,0 +1,4 @@
+export * from './useForm';
+export { useFieldContext } from './useFieldContext';
+export { useFormContext } from './useFormContext';
+export { FormContext } from './FormContext';

--- a/src/components/hooks/useForm/useFieldContext.ts
+++ b/src/components/hooks/useForm/useFieldContext.ts
@@ -1,0 +1,3 @@
+import { useFormContext } from './useFormContext';
+
+export const useFieldContext = (name: string) => useFormContext().getFieldProps(name);

--- a/src/components/hooks/useForm/useForm.test.ts
+++ b/src/components/hooks/useForm/useForm.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import useForm, { TValues, TErrors } from './useForm';
+
+import { useForm, TValues, TErrors } from './useForm';
 
 const initialValues = {
   name: 'name',

--- a/src/components/hooks/useForm/useForm.ts
+++ b/src/components/hooks/useForm/useForm.ts
@@ -24,7 +24,7 @@ export interface IUseFormValues {
   handleSubmit: (values: TValues) => void;
 }
 
-const useForm = ({ initialValues, validate, onSubmit }: IUseFormProps): IUseFormValues => {
+export const useForm = ({ initialValues, validate, onSubmit }: IUseFormProps): IUseFormValues => {
   const [values, updateValues] = useState(initialValues);
   const [errors, updateErrors] = useState<Record<string, string | undefined>>({});
   const [touched, updateTouched] = useState<Record<string, boolean>>({});
@@ -84,5 +84,3 @@ const useForm = ({ initialValues, validate, onSubmit }: IUseFormProps): IUseForm
     handleSubmit,
   };
 };
-
-export default useForm;

--- a/src/components/hooks/useForm/useFormContext.test.ts
+++ b/src/components/hooks/useForm/useFormContext.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 
-import useFormContext from './useFormContext';
+import { useFormContext } from './useFormContext';
 
 describe('useFormContext', () => {
   it('should throw if no context present', () => {

--- a/src/components/hooks/useForm/useFormContext.ts
+++ b/src/components/hooks/useForm/useFormContext.ts
@@ -1,13 +1,11 @@
 import { useContext } from 'react';
 
-import FormContext from './FormContext';
+import { FormContext } from './FormContext';
 
-const useFormContext = () => {
+export const useFormContext = () => {
   const context = useContext(FormContext);
   if (context === undefined) {
     throw new Error('useFormContext must be used within a Form');
   }
   return context;
 };
-
-export default useFormContext;

--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.md
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.md
@@ -15,8 +15,8 @@ And uses [paypal/downshift](https://github.com/paypal/downshift) internally.
 
 How it works:
 
-- The filtered text is always display in an input text.
-- The selected item is passed to the onChange function.
+- The filtered text is always display in an input text
+- The selected item is passed to the onChange function
 
 Also note that:
 

--- a/src/components/organisms/Form/Form/Form.tsx
+++ b/src/components/organisms/Form/Form/Form.tsx
@@ -1,6 +1,5 @@
 import React, { FC, HTMLAttributes } from 'react';
-import { FormContext } from '../context';
-import useForm, { IUseFormProps } from '../../../hooks/useForm/useForm';
+import { useForm, IUseFormProps, FormContext } from '../../../hooks/useForm';
 
 const Form: FC<Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit'> & IUseFormProps> = ({
   children,

--- a/src/components/organisms/Form/FormButton/FormButton.tsx
+++ b/src/components/organisms/Form/FormButton/FormButton.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import Button, { IButtonProps } from '../../../atoms/Button/Button';
-
-import { useFormContext } from '../context';
+import { useFormContext } from '../../../hooks/useForm';
 
 export interface IFromButtonProps extends IButtonProps {
   type?: 'button' | 'reset' | 'submit';

--- a/src/components/organisms/Form/FormCheckboxField/FormCheckboxField.tsx
+++ b/src/components/organisms/Form/FormCheckboxField/FormCheckboxField.tsx
@@ -1,8 +1,7 @@
 import React, { FC, ChangeEvent } from 'react';
 import CheckboxField from '../../../molecules/CheckboxField/CheckboxField';
 import { IField } from '../../../types';
-
-import { useFieldContext } from '../context';
+import { useFieldContext } from '../../../hooks/useForm';
 
 interface IFormCheckboxFieldProps extends IField<HTMLInputElement> {
   name: string;

--- a/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
+++ b/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
@@ -1,7 +1,6 @@
 import React, { FC, ChangeEvent } from 'react';
 import DropdownField, { IDropdownFieldProps } from '../../../molecules/DropdownField/DropdownField';
-
-import { useFieldContext } from '../context';
+import { useFieldContext } from '../../../hooks/useForm';
 
 interface IFormDropdownFieldProps extends IDropdownFieldProps {
   name: string;

--- a/src/components/organisms/Form/FormDropdownFilteredField/FormDropdownFilteredField.tsx
+++ b/src/components/organisms/Form/FormDropdownFilteredField/FormDropdownFilteredField.tsx
@@ -3,8 +3,7 @@ import DropdownFiltered, {
   IDropdownFilteredProps,
   IDropdownItem,
 } from '../../../molecules/DropdownFiltered/DropdownFiltered';
-
-import { useFieldContext } from '../context';
+import { useFieldContext } from '../../../hooks/useForm';
 
 interface IFormDropdownFilteredFieldProps extends IDropdownFilteredProps {
   name: string;

--- a/src/components/organisms/Form/FormRadioField/FormRadioField.tsx
+++ b/src/components/organisms/Form/FormRadioField/FormRadioField.tsx
@@ -1,7 +1,6 @@
 import React, { FC, ChangeEvent } from 'react';
 import RadioField, { IRadioField } from '../../../molecules/RadioField/RadioField';
-
-import { useFieldContext } from '../context';
+import { useFieldContext } from '../../../hooks/useForm';
 
 interface IFormRadioFieldProps extends IRadioField {
   name: string;

--- a/src/components/organisms/Form/FormTextField/FormTextField.tsx
+++ b/src/components/organisms/Form/FormTextField/FormTextField.tsx
@@ -1,7 +1,6 @@
 import React, { FC, ChangeEvent } from 'react';
 import TextField, { ITextFieldProps } from '../../../molecules/TextField/TextField';
-
-import { useFieldContext } from '../context';
+import { useFieldContext } from '../../../hooks/useForm';
 
 interface IFormTextFieldProps extends ITextFieldProps {
   name: string;

--- a/src/components/organisms/Form/context/FormContext.ts
+++ b/src/components/organisms/Form/context/FormContext.ts
@@ -1,7 +1,0 @@
-import { createContext } from 'react';
-
-import { IUseFormValues } from '../../../hooks/useForm/useForm';
-
-const FormContext = createContext<IUseFormValues | undefined>(undefined);
-
-export default FormContext;

--- a/src/components/organisms/Form/context/index.ts
+++ b/src/components/organisms/Form/context/index.ts
@@ -1,3 +1,0 @@
-export { default as useFieldContext } from './useFieldContext';
-export { default as useFormContext } from './useFormContext';
-export { default as FormContext } from './FormContext';

--- a/src/components/organisms/Form/context/useFieldContext.ts
+++ b/src/components/organisms/Form/context/useFieldContext.ts
@@ -1,5 +1,0 @@
-import useFormContext from './useFormContext';
-
-const useFieldContext = (name: string) => useFormContext().getFieldProps(name);
-
-export default useFieldContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export { default as ProfileIcon } from './components/icons/Profile/Profile';
 
 // Hooks
 export { default as useAccordion } from './components/hooks/useAccordion/useAccordion';
-export { default as useForm } from './components/hooks/useForm/useForm';
+export * from './components/hooks/useForm';
 
 export { colors, typography };
 export { default as Fonts } from './components/styles/Fonts';


### PR DESCRIPTION
- Move `FormContext`, `useFormContext`, and `useFieldContext` to `hooks` folder
- Export these hooks as they might be needed to create custom input components (e.g. to add `onChange`, you need to grab and call the original one you get from context through `useFieldContext`)
- Export hook types (all of them had to be reexported because of this https://github.com/facebook/create-react-app/issues/6054)