### PR TITLE
Add form on change

### DIFF
--- a/src/components/hooks/useForm/useForm.test.ts
+++ b/src/components/hooks/useForm/useForm.test.ts
@@ -135,6 +135,41 @@ describe('useForm', () => {
     });
   });
 
+  describe('onChange', () => {
+    it('should be called with the form values when any of them change', async () => {
+      const onChange = jest.fn();
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useForm({
+          initialValues,
+          onSubmit,
+          onChange,
+          validate,
+        }),
+      );
+      await waitForNextUpdate();
+
+      const name = 'Jan';
+      act(() => {
+        result.current.getFieldProps('name').onChange(name);
+      });
+      await waitForNextUpdate();
+      expect(onChange).toHaveBeenCalledWith({
+        ...initialValues,
+        name,
+      });
+
+      const lastName = 'Dzban';
+      act(() => {
+        result.current.getFieldProps('lastName').onChange(lastName);
+      });
+      await waitForNextUpdate();
+      expect(onChange).toHaveBeenCalledWith({
+        name,
+        lastName,
+      });
+    });
+  });
+
   describe('getFieldProps', () => {
     it('should return the correct object', async () => {
       const { result, waitForNextUpdate } = renderHook(() =>

--- a/src/components/hooks/useForm/useForm.ts
+++ b/src/components/hooks/useForm/useForm.ts
@@ -7,6 +7,7 @@ export type TErrors = Record<string, string | undefined>;
 export interface IUseFormProps {
   initialValues: TValues;
   onSubmit: (values: TValues) => void;
+  onChange?: (values: TValues) => void;
   validate?: (values: TValues) => TErrors | Promise<TErrors>;
 }
 
@@ -24,7 +25,7 @@ export interface IUseFormValues {
   handleSubmit: (values: TValues) => void;
 }
 
-const useForm = ({ initialValues, validate, onSubmit }: IUseFormProps): IUseFormValues => {
+const useForm = ({ initialValues, validate, onSubmit, onChange }: IUseFormProps): IUseFormValues => {
   const [values, updateValues] = useState(initialValues);
   const [errors, updateErrors] = useState<Record<string, string | undefined>>({});
   const [touched, updateTouched] = useState<Record<string, boolean>>({});
@@ -49,6 +50,7 @@ const useForm = ({ initialValues, validate, onSubmit }: IUseFormProps): IUseForm
       value: values[name],
       onChange(value: unknown) {
         const newValues = { ...values, [name]: value };
+        onChange && onChange(newValues);
         updateValues(newValues);
         runValidation(newValues);
       },

--- a/src/components/organisms/Form/Form/Form.test.tsx
+++ b/src/components/organisms/Form/Form/Form.test.tsx
@@ -4,7 +4,9 @@ import Form from '..';
 import { act } from 'react-dom/test-utils';
 
 const onSubmit = jest.fn();
+const onChange = jest.fn();
 const fieldLabel = 'First name';
+const fieldName = 'firstName';
 const testId = 'test-form';
 
 interface IForm {
@@ -23,8 +25,14 @@ const validate = (values: IForm) => {
 
 const renderComponent = () =>
   render(
-    <Form data-testid={testId} validate={validate} initialValues={{ firstName: '' }} onSubmit={onSubmit}>
-      <Form.TextField label={fieldLabel} name="firstName" />
+    <Form
+      data-testid={testId}
+      validate={validate}
+      initialValues={{ firstName: '' }}
+      onSubmit={onSubmit}
+      onChange={onChange}
+    >
+      <Form.TextField label={fieldLabel} name={fieldName} />
     </Form>,
   );
 
@@ -33,7 +41,7 @@ describe('<Form />', () => {
     onSubmit.mockReset();
   });
 
-  it('calls onSubmit callback', async () => {
+  it('calls onChange and onSubmit callback', async () => {
     const { getByTestId, getByLabelText } = renderComponent();
     await wait();
     const value = 'name';
@@ -41,11 +49,12 @@ describe('<Form />', () => {
       fireEvent.change(getByLabelText(fieldLabel), { target: { value } });
     });
     await wait();
+    expect(onChange).toHaveBeenCalledWith({ [fieldName]: value });
     act(() => {
       fireEvent.submit(getByTestId(testId));
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith({ firstName: value });
+    expect(onSubmit).toHaveBeenCalledWith({ [fieldName]: value });
   });
 
   it('does not call onSubmit if the form is invalid', async () => {

--- a/src/components/organisms/Form/Form/Form.tsx
+++ b/src/components/organisms/Form/Form/Form.tsx
@@ -6,6 +6,7 @@ const Form: FC<Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit'> & IUseFormProps
   children,
   initialValues,
   onSubmit,
+  onChange,
   validate,
   ...rest
 }) => {
@@ -13,6 +14,7 @@ const Form: FC<Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit'> & IUseFormProps
     initialValues,
     onSubmit,
     validate,
+    onChange,
   });
   return (
     <FormContext.Provider value={context}>


### PR DESCRIPTION
Add `onChange` prop to `useForm` and `<Form />`. This is useful in case you need custom input that consists of various small sub-inputs (e.g. date input)