### PR TITLE
Forward refs in inputs

### DIFF
--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -19,7 +19,7 @@ export interface IDropdownProps extends React.SelectHTMLAttributes<HTMLSelectEle
 
 export const Option = styled.option``;
 
-const Dropdown = styled.select<IDropdownProps>`
+const StyledDropdown = styled.select<IDropdownProps>`
   appearance: none;
   background: transparent url(${chevronDown}) no-repeat calc(100% - 13px) center;
   background-size: 13px;
@@ -37,9 +37,6 @@ const Dropdown = styled.select<IDropdownProps>`
   }
 `;
 
-// TODO: Styleguidist to be able to locate styled components. See #147.
-export const StyleguidistDropdown = forwardRef<HTMLSelectElement, IDropdownProps>((props, ref) => (
-  <Dropdown ref={ref} {...props} />
-));
+const Dropdown = forwardRef<HTMLSelectElement, IDropdownProps>((props, ref) => <StyledDropdown ref={ref} {...props} />);
 
 export default Dropdown;

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../constants/colors';
 import chevronDown from '../../../content/images/chevron-down.svg';
@@ -38,6 +38,8 @@ const Dropdown = styled.select<IDropdownProps>`
 `;
 
 // TODO: Styleguidist to be able to locate styled components. See #147.
-export const StyleguidistDropdown: FC<IDropdownProps> = props => <Dropdown {...props} />;
+export const StyleguidistDropdown = forwardRef<HTMLSelectElement, IDropdownProps>((props, ref) => (
+  <Dropdown ref={ref} {...props} />
+));
 
 export default Dropdown;

--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, forwardRef } from 'react';
 import styled from 'styled-components';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import Text from '../../atoms/Text/Text';
@@ -28,27 +28,30 @@ const Help = styled(Text)`
   display: block;
 `;
 
-const DropdownField = ({ label, errorMessage, size, helpText, htmlSelectSize, name, ...rest }: IDropdownFieldProps) => {
-  if (!name) {
-    throw Error("You didn't supply a name for the dropdown. Check the docs.");
-  }
+const DropdownField = forwardRef<HTMLSelectElement, IDropdownFieldProps>(
+  ({ label, errorMessage, size, helpText, htmlSelectSize, name, ...rest }, ref) => {
+    if (!name) {
+      throw Error("You didn't supply a name for the dropdown. Check the docs.");
+    }
 
-  return (
-    <>
-      {label && <Label htmlFor={`text-id-${name}`}>{label}</Label>}
-      {helpText && <Help size="small">{helpText}</Help>}
-      <SizedContainer size={size}>
-        <Dropdown
-          id={`text-id-${name}`}
-          name={name}
-          aria-label={label ? undefined : name}
-          size={htmlSelectSize}
-          {...rest}
-        />
-      </SizedContainer>
-      {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
-    </>
-  );
-};
+    return (
+      <>
+        {label && <Label htmlFor={`text-id-${name}`}>{label}</Label>}
+        {helpText && <Help size="small">{helpText}</Help>}
+        <SizedContainer size={size}>
+          <Dropdown
+            id={`text-id-${name}`}
+            name={name}
+            aria-label={label ? undefined : name}
+            size={htmlSelectSize}
+            ref={ref}
+            {...rest}
+          />
+        </SizedContainer>
+        {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
+      </>
+    );
+  },
+);
 
 export default DropdownField;

--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -29,29 +29,23 @@ const Help = styled(Text)`
 `;
 
 const DropdownField = forwardRef<HTMLSelectElement, IDropdownFieldProps>(
-  ({ label, errorMessage, size, helpText, htmlSelectSize, name, ...rest }, ref) => {
-    if (!name) {
-      throw Error("You didn't supply a name for the dropdown. Check the docs.");
-    }
-
-    return (
-      <>
-        {label && <Label htmlFor={`text-id-${name}`}>{label}</Label>}
-        {helpText && <Help size="small">{helpText}</Help>}
-        <SizedContainer size={size}>
-          <Dropdown
-            id={`text-id-${name}`}
-            name={name}
-            aria-label={label ? undefined : name}
-            size={htmlSelectSize}
-            ref={ref}
-            {...rest}
-          />
-        </SizedContainer>
-        {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
-      </>
-    );
-  },
+  ({ label, errorMessage, size, helpText, htmlSelectSize, name, ...rest }, ref) => (
+    <>
+      {label && <Label htmlFor={`text-id-${name}`}>{label}</Label>}
+      {helpText && <Help size="small">{helpText}</Help>}
+      <SizedContainer size={size}>
+        <Dropdown
+          id={`text-id-${name}`}
+          name={name}
+          aria-label={label ? undefined : name}
+          size={htmlSelectSize}
+          ref={ref}
+          {...rest}
+        />
+      </SizedContainer>
+      {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
+    </>
+  ),
 );
 
 export default DropdownField;

--- a/src/components/molecules/TextField/TextField.test.tsx
+++ b/src/components/molecules/TextField/TextField.test.tsx
@@ -49,4 +49,11 @@ describe('<TextField />', () => {
     const { container } = render(<TextField inputProps={{ name: 'test1' }} size="short" prefix={'£'} />);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('throws if no name provided', () => {
+    console.error = jest.fn();
+    expect(() => render(<TextField inputProps={{}} errorMessage="Ops !" />)).toThrow(
+      'Name must be set in inputProps. Check the docs.',
+    );
+  });
 });

--- a/src/components/molecules/TextField/TextField.test.tsx
+++ b/src/components/molecules/TextField/TextField.test.tsx
@@ -52,8 +52,13 @@ describe('<TextField />', () => {
 
   it('throws if no name provided', () => {
     console.error = jest.fn();
-    expect(() => render(<TextField inputProps={{}} errorMessage="Ops !" />)).toThrow(
-      'Name must be set in inputProps. Check the docs.',
+    expect(() => render(<TextField inputProps={{}} />)).toThrow('Name must be set in inputProps. Check the docs.');
+  });
+
+  it('throws if prefix is longer than one character', () => {
+    console.error = jest.fn();
+    expect(() => render(<TextField inputProps={{ name: 'test1' }} prefix="$$" />)).toThrow(
+      'Prefixes can only have one character',
     );
   });
 });

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import Text from '../../atoms/Text/Text';
@@ -46,37 +46,39 @@ const Prefix = styled.span<IPrefixProps>`
   }
 `;
 
-const TextField: FC<ITextFieldProps> = props => {
-  const { label, errorMessage, isValid, inputProps, size, helpText, prefix } = props;
-  const { name } = inputProps;
+const TextField = forwardRef<HTMLInputElement, ITextFieldProps>(
+  ({ label, errorMessage, isValid, inputProps, size, helpText, prefix }, ref) => {
+    const { name } = inputProps;
 
-  if (!name) {
-    throw Error('Name must be set in inputProps. Check the docs.');
-  }
+    if (!name) {
+      throw Error('Name must be set in inputProps. Check the docs.');
+    }
 
-  if (prefix && prefix.length > 1) {
-    throw Error('Prefixes can only have one character');
-  }
+    if (prefix && prefix.length > 1) {
+      throw Error('Prefixes can only have one character');
+    }
 
-  const input = (
-    <InputText
-      id={`text-id-${name}`}
-      type="text"
-      hasError={!!errorMessage}
-      isValid={isValid}
-      aria-label={label ? undefined : name}
-      {...inputProps}
-    />
-  );
+    const input = (
+      <InputText
+        id={`text-id-${name}`}
+        type="text"
+        hasError={!!errorMessage}
+        isValid={isValid}
+        aria-label={label ? undefined : name}
+        ref={ref}
+        {...inputProps}
+      />
+    );
 
-  return (
-    <>
-      {label && <TextFieldLabel htmlFor={`text-id-${name}`}>{label}</TextFieldLabel>}
-      {helpText && <Text size="small">{helpText}</Text>}
-      <SizedContainer size={size}>{prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}</SizedContainer>
-      {errorMessage && <TextFieldError data-automation={`ZA.error-${name}`}>{errorMessage}</TextFieldError>}
-    </>
-  );
-};
+    return (
+      <>
+        {label && <TextFieldLabel htmlFor={`text-id-${name}`}>{label}</TextFieldLabel>}
+        {helpText && <Text size="small">{helpText}</Text>}
+        <SizedContainer size={size}>{prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}</SizedContainer>
+        {errorMessage && <TextFieldError data-automation={`ZA.error-${name}`}>{errorMessage}</TextFieldError>}
+      </>
+    );
+  },
+);
 
 export default TextField;

--- a/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
+++ b/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ChangeEvent } from 'react';
+import React, { forwardRef, ChangeEvent } from 'react';
 import DropdownField, { IDropdownFieldProps } from '../../../molecules/DropdownField/DropdownField';
 import { useFieldContext } from '../hooks';
 
@@ -6,7 +6,7 @@ interface IFormDropdownFieldProps extends IDropdownFieldProps {
   name: string;
 }
 
-const FormDropdownField: FC<IFormDropdownFieldProps> = ({ name, ...rest }) => {
+const FormDropdownField = forwardRef<HTMLSelectElement, IFormDropdownFieldProps>(({ name, ...rest }, ref) => {
   const { error, touched, onChange, onBlur } = useFieldContext(name);
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -20,9 +20,10 @@ const FormDropdownField: FC<IFormDropdownFieldProps> = ({ name, ...rest }) => {
       errorMessage={touched && error ? error : ''}
       onChange={handleChange}
       onBlur={onBlur}
+      ref={ref}
       {...rest}
     />
   );
-};
+});
 
 export default FormDropdownField;

--- a/src/components/organisms/Form/FormTextField/FormTextField.tsx
+++ b/src/components/organisms/Form/FormTextField/FormTextField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ChangeEvent } from 'react';
+import React, { forwardRef, ChangeEvent } from 'react';
 import TextField, { ITextFieldProps } from '../../../molecules/TextField/TextField';
 import { useFieldContext } from '../hooks';
 
@@ -6,7 +6,7 @@ interface IFormTextFieldProps extends ITextFieldProps {
   name: string;
 }
 
-const FormTextField: FC<IFormTextFieldProps> = ({ name, inputProps, ...rest }) => {
+const FormTextField = forwardRef<HTMLInputElement, IFormTextFieldProps>(({ name, inputProps, ...rest }, ref) => {
   const { error, touched, value, onChange, onBlur } = useFieldContext(name);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -18,9 +18,10 @@ const FormTextField: FC<IFormTextFieldProps> = ({ name, inputProps, ...rest }) =
       isValid={touched && !error}
       errorMessage={touched && error ? error : ''}
       inputProps={{ onChange: handleChange, onBlur, value, name, ...inputProps }}
+      ref={ref}
       {...rest}
     />
   );
-};
+});
 
 export default FormTextField;


### PR DESCRIPTION
Forward refs to all `<input />` and `<select />` elements to be able to, for example, programatically focus on an element. 