### PR TITLE
Add approve bot to CODEOWNERS 🤖

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @thegrinder @poteirard @JuliaHempel @lluia @steedems @moshie
+*       @thegrinder @poteirard @JuliaHempel @lluia @steedems @moshie @app/renovate-approve


### PR DESCRIPTION
## Summary 💭

A few weeks ago we added [`renovate-bot`](https://renovate.whitesourcesoftware.com/) to do minor dependency upgrades ( `0.*.0` and `0.0.*` )  for us automatically. 

The bot [raises a PR](https://github.com/zopaUK/react-components/pull/214) for each upgrade, however, given our `master` branch is protected 🔐 ,  we need to manually approve and merge each PR, which can end tedious.

We have now added a second bot, [`renovate-approve`](https://github.com/apps/renovate-approve) so that it can approve and merge those PRs for us. This a **POC** to see how it works for us.