### PR TITLE
Update CODEOWNERS again... 🤖

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @thegrinder @poteirard @JuliaHempel @lluia @steedems @moshie @app/renovate-approve
+*       @thegrinder @poteirard @JuliaHempel @lluia @steedems @moshie app/renovate-approve


### PR DESCRIPTION
> If you need to add this bot to your CODEOWNERS, you can identify it using app/renovate-approve.

So seems I shouldn't reference `app/renovate-bot` with an `@` as it has not being recognised as a `CODEOWNER` successfully 😅