### PR TITLE
Improve form field types

### DIFF
--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -28,7 +28,16 @@ const Help = styled(Text)`
   display: block;
 `;
 
-const DropdownField = ({ label, errorMessage, size, helpText, htmlSelectSize, name, ...rest }: IDropdownFieldProps) => {
+const DropdownField = ({
+  label,
+  errorMessage,
+  size,
+  helpText,
+  htmlSelectSize,
+  name,
+  inputProps,
+  ...rest
+}: IDropdownFieldProps) => {
   if (!name) {
     throw Error("You didn't supply a name for the dropdown. Check the docs.");
   }
@@ -43,6 +52,7 @@ const DropdownField = ({ label, errorMessage, size, helpText, htmlSelectSize, na
           name={name}
           aria-label={label ? undefined : name}
           size={htmlSelectSize}
+          {...inputProps}
           {...rest}
         />
       </SizedContainer>

--- a/src/components/organisms/Form/FormCheckboxField/FormCheckboxField.tsx
+++ b/src/components/organisms/Form/FormCheckboxField/FormCheckboxField.tsx
@@ -1,13 +1,9 @@
 import React, { FC, ChangeEvent } from 'react';
 import CheckboxField from '../../../molecules/CheckboxField/CheckboxField';
-import { IField } from '../../../types';
 import { useFieldContext } from '../hooks';
+import { IFormInputField } from '../types';
 
-interface IFormCheckboxFieldProps extends IField<HTMLInputElement> {
-  name: string;
-}
-
-const FormCheckboxField: FC<IFormCheckboxFieldProps> = ({ name, inputProps, ...rest }) => {
+const FormCheckboxField: FC<IFormInputField> = ({ name, inputProps, ...rest }) => {
   const { error, touched, value, onChange, onBlur } = useFieldContext(name);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
+++ b/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
@@ -1,12 +1,14 @@
 import React, { FC, ChangeEvent } from 'react';
 import DropdownField, { IDropdownFieldProps } from '../../../molecules/DropdownField/DropdownField';
+import { ISelect } from '../../../types';
 import { useFieldContext } from '../hooks';
 
-interface IFormDropdownFieldProps extends IDropdownFieldProps {
+export interface IFormDropdownFieldProps extends Omit<IDropdownFieldProps, 'inputProps'> {
+  inputProps?: ISelect;
   name: string;
 }
 
-const FormDropdownField: FC<IFormDropdownFieldProps> = ({ name, ...rest }) => {
+const FormDropdownField: FC<IFormDropdownFieldProps> = ({ name, inputProps, ...rest }) => {
   const { error, touched, onChange, onBlur } = useFieldContext(name);
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -18,8 +20,11 @@ const FormDropdownField: FC<IFormDropdownFieldProps> = ({ name, ...rest }) => {
       name={name}
       isValid={touched && !error}
       errorMessage={touched && error ? error : ''}
-      onChange={handleChange}
-      onBlur={onBlur}
+      inputProps={{
+        onChange: handleChange,
+        onBlur: onBlur,
+        ...inputProps,
+      }}
       {...rest}
     />
   );

--- a/src/components/organisms/Form/FormDropdownFilteredField/FormDropdownFilteredField.tsx
+++ b/src/components/organisms/Form/FormDropdownFilteredField/FormDropdownFilteredField.tsx
@@ -4,8 +4,10 @@ import DropdownFiltered, {
   IDropdownItem,
 } from '../../../molecules/DropdownFiltered/DropdownFiltered';
 import { useFieldContext } from '../hooks';
+import { IInput } from '../../../types';
 
-interface IFormDropdownFilteredFieldProps extends IDropdownFilteredProps {
+interface IFormDropdownFilteredFieldProps extends Omit<IDropdownFilteredProps, 'inputProps'> {
+  inputProps?: IInput;
   name: string;
 }
 

--- a/src/components/organisms/Form/FormRadioField/FormRadioField.test.tsx
+++ b/src/components/organisms/Form/FormRadioField/FormRadioField.test.tsx
@@ -24,8 +24,8 @@ const validate = (values: IForm) => {
 const renderComponent = () =>
   render(
     <Form initialValues={{ employmentType: '' }} validate={validate} onSubmit={onSubmit}>
-      <Form.RadioField label="Employed" name="employmentType" value="employed" />
-      <Form.RadioField label="Unemployed" name="employmentType" value="unemployed" />
+      <Form.RadioField label="Employed" name="employmentType" inputProps={{ value: 'employed' }} />
+      <Form.RadioField label="Unemployed" name="employmentType" inputProps={{ value: 'unemployed' }} />
       <Form.Button disabled={false}>{buttonLabel}</Form.Button>
     </Form>,
   );

--- a/src/components/organisms/Form/FormRadioField/FormRadioField.tsx
+++ b/src/components/organisms/Form/FormRadioField/FormRadioField.tsx
@@ -1,13 +1,9 @@
 import React, { FC, ChangeEvent } from 'react';
-import RadioField, { IRadioField } from '../../../molecules/RadioField/RadioField';
+import RadioField from '../../../molecules/RadioField/RadioField';
 import { useFieldContext } from '../hooks';
+import { IFormInputField } from '../types';
 
-interface IFormRadioFieldProps extends IRadioField {
-  name: string;
-  value: string;
-}
-
-const FormRadioField: FC<IFormRadioFieldProps> = ({ name, value, inputProps, ...rest }) => {
+const FormRadioField: FC<IFormInputField> = ({ name, inputProps, ...rest }) => {
   const { error, touched, onChange, onBlur } = useFieldContext(name);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -17,7 +13,13 @@ const FormRadioField: FC<IFormRadioFieldProps> = ({ name, value, inputProps, ...
   return (
     <RadioField
       hasError={touched && !!error}
-      inputProps={{ onChange: handleChange, onBlur, value, name, ...inputProps }}
+      inputProps={{
+        onChange: handleChange,
+        onBlur,
+        value: inputProps ? inputProps.value : undefined,
+        name,
+        ...inputProps,
+      }}
       {...rest}
     />
   );

--- a/src/components/organisms/Form/FormTextField/FormTextField.tsx
+++ b/src/components/organisms/Form/FormTextField/FormTextField.tsx
@@ -1,12 +1,9 @@
 import React, { FC, ChangeEvent } from 'react';
-import TextField, { ITextFieldProps } from '../../../molecules/TextField/TextField';
+import TextField from '../../../molecules/TextField/TextField';
 import { useFieldContext } from '../hooks';
+import { IFormInputField } from '../types';
 
-interface IFormTextFieldProps extends ITextFieldProps {
-  name: string;
-}
-
-const FormTextField: FC<IFormTextFieldProps> = ({ name, inputProps, ...rest }) => {
+const FormTextField: FC<IFormInputField> = ({ name, inputProps, ...rest }) => {
   const { error, touched, value, onChange, onBlur } = useFieldContext(name);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/organisms/Form/types.ts
+++ b/src/components/organisms/Form/types.ts
@@ -1,0 +1,6 @@
+import { IField, IInput } from '../../types';
+
+export interface IFormInputField extends Omit<IField<HTMLInputElement>, 'inputProps'> {
+  inputProps?: IInput<HTMLInputElement>;
+  name: string;
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, HTMLAttributes } from 'react';
+import { InputHTMLAttributes, SelectHTMLAttributes, HTMLAttributes } from 'react';
 
 /**
  * GLOBAL TYPES ACROSS COMPONENTS
@@ -18,7 +18,14 @@ export interface IInputStatus {
   hasError?: boolean;
 }
 
-export interface IInput extends IInputStatus, InputHTMLAttributes<HTMLInputElement> {
+export interface IInput<T = HTMLInputElement> extends IInputStatus, InputHTMLAttributes<T> {
+  /**
+   * Attribute used for testing porpuses
+   */
+  'data-automation'?: string;
+}
+
+export interface ISelect<T = HTMLSelectElement> extends IInputStatus, SelectHTMLAttributes<T> {
   /**
    * Attribute used for testing porpuses
    */
@@ -45,7 +52,7 @@ export interface IField<T = HTMLDivElement> extends HTMLAttributes<T> {
   /**
    * Props for the native input element
    */
-  inputProps: IInput;
+  inputProps: IInput<T>;
   /**
    * Container size
    */


### PR DESCRIPTION
Since, Form inputs grab most of the props off of the context, they don't need `inputProps` which are made optional here