### PR TITLE
<*Fiel /> components → Adjust childs spacing 😐 📐

### DIFF
--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -19,7 +19,7 @@ const Input = styled.input<IInput>`
     transition: border 0.2s;
   }
 
-  ::-webkit-input-placeholder {
+  ::placeholder {
     color: ${colors.neutral.medium};
   }
 

--- a/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
@@ -21,6 +21,18 @@ exports[`<InputText /> renders the component disabled 1`] = `
   color: #DCDBE2;
 }
 
+.c0::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c0:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::placeholder {
+  color: #DCDBE2;
+}
+
 .c0:disabled {
   background-color: #EAEAEE;
 }
@@ -50,6 +62,18 @@ exports[`<InputText /> renders the component with error 1`] = `
 }
 
 .c0::-webkit-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c0:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::placeholder {
   color: #DCDBE2;
 }
 
@@ -84,6 +108,18 @@ exports[`<InputText /> renders the component with focus 1`] = `
   color: #DCDBE2;
 }
 
+.c0::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c0:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::placeholder {
+  color: #DCDBE2;
+}
+
 .c0:disabled {
   background-color: #EAEAEE;
 }
@@ -115,6 +151,18 @@ exports[`<InputText /> renders the component with isValid set as true 1`] = `
   color: #DCDBE2;
 }
 
+.c0::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c0:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::placeholder {
+  color: #DCDBE2;
+}
+
 .c0:disabled {
   background-color: #EAEAEE;
 }
@@ -143,6 +191,18 @@ exports[`<InputText /> renders the component with the required props 1`] = `
 }
 
 .c0::-webkit-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c0:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c0::placeholder {
   color: #DCDBE2;
 }
 

--- a/src/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/src/components/molecules/CheckboxField/CheckboxField.tsx
@@ -52,6 +52,7 @@ const Label = styled(InputLabel)`
   color: ${colors.neutral.dark};
   position: relative;
   user-select: none;
+  margin-bottom: 0;
 
   &:before {
     content: '';
@@ -82,18 +83,24 @@ const Label = styled(InputLabel)`
   }
 `;
 
-const CheckboxField: React.FC<IField> = props => {
+const FieldError = styled(ErrorMessage)`
+  margin-top: 5px;
+`;
+
+const CheckboxField: React.FC<Omit<IField, 'helpText'>> = props => {
   const { label, inputProps, errorMessage, size, ...rest } = props;
   const { name } = inputProps;
 
   if (!name) throw Error('Name must be set in inputProps. Check the docs.');
 
   return (
-    <SizedContainer size={size} {...rest}>
-      <Input id={`checkbox-id-${name}`} type="checkbox" {...inputProps} />
-      <Label htmlFor={`checkbox-id-${name}`}>{label}</Label>
-      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-    </SizedContainer>
+    <>
+      <SizedContainer size={size} {...rest}>
+        <Input id={`checkbox-id-${name}`} type="checkbox" {...inputProps} />
+        <Label htmlFor={`checkbox-id-${name}`}>{label}</Label>
+      </SizedContainer>
+      {errorMessage && <FieldError>{errorMessage}</FieldError>}
+    </>
   );
 };
 

--- a/src/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/src/components/molecules/CheckboxField/CheckboxField.tsx
@@ -87,7 +87,7 @@ const FieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const CheckboxField: React.FC<Omit<IField, 'helpText'>> = props => {
+const CheckboxField = (props: Omit<IField, 'helpText'>) => {
   const { label, inputProps, errorMessage, size, ...rest } = props;
   const { name } = inputProps;
 

--- a/src/components/molecules/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/molecules/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`<CheckboxField /> renders the component with props with no a11y violati
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  margin-bottom: 0;
 }
 
 .c2:before {

--- a/src/components/molecules/DropdownField/DropdownField.md
+++ b/src/components/molecules/DropdownField/DropdownField.md
@@ -9,11 +9,11 @@ import { DropdownField } from '@zopauk/react-components';
 
 <DropdownField
   hasError={true}
-  label="Your cool dropdown ❤"
+  label="Your cool dropdown"
   errorMessage="You need to choose something!"
   size="short"
   name="foo"
-  helpText="Some contextual help"
+  helpText="Additional info"
 >
   <option value="first">First value</option>
   <option value="second">Second value</option>

--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -15,23 +15,33 @@ export interface IDropdownFieldProps extends IField<HTMLSelectElement> {
   name: string;
 }
 
+export interface ILabelProps {
+  withHelpText?: boolean;
+}
+
+const Label = styled(InputLabel)<ILabelProps>`
+  ${({ withHelpText }) => withHelpText && `margin-bottom: 0;`}
+`;
+
 const FieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const Label = styled(InputLabel)`
+const Help = styled(Text).attrs({
+  size: 'small',
+})`
   margin-bottom: 5px;
-`;
-
-const Help = styled(Text)`
-  margin-bottom: 10px;
   display: block;
 `;
 
 const DropdownField = forwardRef<HTMLSelectElement, IDropdownFieldProps>(
   ({ label, errorMessage, size, helpText, htmlSelectSize, name, ...rest }, ref) => (
     <>
-      {label && <Label htmlFor={`text-id-${name}`}>{label}</Label>}
+      {label && (
+        <Label withHelpText={!!helpText} htmlFor={`text-id-${name}`}>
+          {label}
+        </Label>
+      )}
       {helpText && <Help size="small">{helpText}</Help>}
       <SizedContainer size={size}>
         <Dropdown

--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -27,9 +27,7 @@ const FieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const Help = styled(Text).attrs({
-  size: 'small',
-})`
+const HelpText = styled(Text)`
   margin-bottom: 5px;
   display: block;
 `;
@@ -42,7 +40,7 @@ const DropdownField = forwardRef<HTMLSelectElement, IDropdownFieldProps>(
           {label}
         </Label>
       )}
-      {helpText && <Help size="small">{helpText}</Help>}
+      {helpText && <HelpText size="small">{helpText}</HelpText>}
       <SizedContainer size={size}>
         <Dropdown
           id={`text-id-${name}`}

--- a/src/components/molecules/DropdownField/__snapshots__/DropdownField.test.tsx.snap
+++ b/src/components/molecules/DropdownField/__snapshots__/DropdownField.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`<DropdownField /> renders the component with props with no a11y violati
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
   font-size: 16px;
-  margin-bottom: 5px;
 }
 
 <label

--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
@@ -95,7 +95,6 @@ const Options = styled.div<IOptionsListProps>`
 
 const SearchInputWrap = styled.div`
   position: relative;
-  margin: 5px 0;
 `;
 
 const SearchArrowWrap = styled.div`
@@ -105,6 +104,10 @@ const SearchArrowWrap = styled.div`
   right: 12px;
   cursor: pointer;
   display: flex;
+`;
+
+const FieldError = styled(ErrorMessage)`
+  margin-top: 5px;
 `;
 
 export default class DropdownFiltered extends React.PureComponent<IDropdownFilteredProps> {
@@ -208,7 +211,7 @@ export default class DropdownFiltered extends React.PureComponent<IDropdownFilte
             </Options>
           )}
         </SearchInputWrap>
-        {showError && <ErrorMessage data-automation={`ZA.error-${name}`}>{errorMessage}</ErrorMessage>}
+        {showError && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
       </div>
     );
   };

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -60,7 +60,6 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
 
 .c2 {
   position: relative;
-  margin: 5px 0;
 }
 
 .c5 {
@@ -174,7 +173,6 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
 
 .c1 {
   position: relative;
-  margin: 5px 0;
 }
 
 .c4 {

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -35,6 +35,18 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
   color: #DCDBE2;
 }
 
+.c3::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c3:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c3::placeholder {
+  color: #DCDBE2;
+}
+
 .c3:disabled {
   background-color: #EAEAEE;
 }
@@ -145,6 +157,18 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
 }
 
 .c2::-webkit-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c2::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c2:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c2::placeholder {
   color: #DCDBE2;
 }
 

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -17,6 +17,11 @@ const zoomIn = keyframes`
 
 const FieldContainer = styled(SizedContainer)`
   position: relative;
+  margin-bottom: 10px;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 `;
 
 const Label = styled(InputLabel)<IInputStatus>`
@@ -25,6 +30,7 @@ const Label = styled(InputLabel)<IInputStatus>`
   color: ${colors.neutral.dark};
   font-weight: 400;
   position: relative;
+  margin-bottom: 0;
 
   &:before {
     content: '';

--- a/src/components/molecules/RadioField/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/molecules/RadioField/__snapshots__/RadioField.test.tsx.snap
@@ -8,6 +8,11 @@ exports[`<RadioField /> renders the component with props with no a11y violations
 
 .c1 {
   position: relative;
+  margin-bottom: 10px;
+}
+
+.c1:last-of-type {
+  margin-bottom: 0;
 }
 
 .c3 {
@@ -30,6 +35,7 @@ exports[`<RadioField /> renders the component with props with no a11y violations
   color: #0D0A38;
   font-weight: 400;
   position: relative;
+  margin-bottom: 0;
 }
 
 .c3:before {

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -2,8 +2,8 @@ import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import Text from '../../atoms/Text/Text';
-import InputLabel from '../../atoms/InputLabel/InputLabel';
 import InputText from '../../atoms/InputText/InputText';
+import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
 import { typography } from '../../../constants/typography';
 import { colors } from '../../../constants/colors';
@@ -17,12 +17,27 @@ export interface IPrefixProps {
   prefix: string;
 }
 
-const TextFieldError = styled(ErrorMessage)`
-  margin-top: 5px;
+export interface IContainerProps {
+  withError?: boolean;
+}
+
+export interface ILabelProps {
+  withHelpText?: boolean;
+}
+
+const Container = styled(SizedContainer)<IContainerProps>`
+  ${({ withError }) => withError && `margin-bottom: 5px;`}
 `;
 
-const TextFieldLabel = styled(InputLabel)`
+const Label = styled(InputLabel)<ILabelProps>`
+  ${({ withHelpText }) => withHelpText && `margin-bottom: 0;`}
+`;
+
+const HelpText = styled(Text).attrs({
+  size: 'small',
+})`
   margin-bottom: 5px;
+  display: block;
 `;
 
 const Prefix = styled.span<IPrefixProps>`
@@ -72,10 +87,16 @@ const TextField = forwardRef<HTMLInputElement, ITextFieldProps>(
 
     return (
       <>
-        {label && <TextFieldLabel htmlFor={`text-id-${name}`}>{label}</TextFieldLabel>}
-        {helpText && <Text size="small">{helpText}</Text>}
-        <SizedContainer size={size}>{prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}</SizedContainer>
-        {errorMessage && <TextFieldError data-automation={`ZA.error-${name}`}>{errorMessage}</TextFieldError>}
+        {label && (
+          <Label withHelpText={!!helpText} htmlFor={`text-id-${name}`}>
+            {label}
+          </Label>
+        )}
+        {helpText && <HelpText size="small">{helpText}</HelpText>}
+        <Container withError={!!errorMessage} size={size}>
+          {prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}
+        </Container>
+        {errorMessage && <ErrorMessage data-automation={`ZA.error-${name}`}>{errorMessage}</ErrorMessage>}
       </>
     );
   },

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -17,23 +17,19 @@ export interface IPrefixProps {
   prefix: string;
 }
 
-export interface IContainerProps {
-  withError?: boolean;
-}
-
 export interface ILabelProps {
   withHelpText?: boolean;
 }
-
-const Container = styled(SizedContainer)<IContainerProps>`
-  ${({ withError }) => withError && `margin-bottom: 5px;`}
-`;
 
 const Label = styled(InputLabel)<ILabelProps>`
   ${({ withHelpText }) => withHelpText && `margin-bottom: 0;`}
 `;
 
-const HelpText = styled(Text).attrs({
+const FieldError = styled(ErrorMessage)`
+  margin-top: 5px;
+`;
+
+const Help = styled(Text).attrs({
   size: 'small',
 })`
   margin-bottom: 5px;
@@ -92,11 +88,9 @@ const TextField = forwardRef<HTMLInputElement, ITextFieldProps>(
             {label}
           </Label>
         )}
-        {helpText && <HelpText size="small">{helpText}</HelpText>}
-        <Container withError={!!errorMessage} size={size}>
-          {prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}
-        </Container>
-        {errorMessage && <ErrorMessage data-automation={`ZA.error-${name}`}>{errorMessage}</ErrorMessage>}
+        {helpText && <Help size="small">{helpText}</Help>}
+        <SizedContainer size={size}>{prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}</SizedContainer>
+        {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
       </>
     );
   },

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -29,7 +29,7 @@ const FieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const Help = styled(Text).attrs({
+const HelpText = styled(Text).attrs({
   size: 'small',
 })`
   margin-bottom: 5px;
@@ -88,7 +88,7 @@ const TextField = forwardRef<HTMLInputElement, ITextFieldProps>(
             {label}
           </Label>
         )}
-        {helpText && <Help size="small">{helpText}</Help>}
+        {helpText && <HelpText size="small">{helpText}</HelpText>}
         <SizedContainer size={size}>{prefix ? <Prefix prefix={prefix}>{input}</Prefix> : input}</SizedContainer>
         {errorMessage && <FieldError data-automation={`ZA.error-${name}`}>{errorMessage}</FieldError>}
       </>

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
 }
 
 <div
-  class="c0 "
+  class="c0"
 >
   <input
     aria-label="test1"
@@ -44,7 +44,7 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
 `;
 
 exports[`<TextField /> renders the component with error 1`] = `
-.c2 {
+.c1 {
   border: 2px solid #EE0505;
   border-radius: 4px;
   padding: 0 10px;
@@ -53,18 +53,18 @@ exports[`<TextField /> renders the component with error 1`] = `
   width: 100%;
 }
 
-.c2:focus {
+.c1:focus {
   outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
 }
 
-.c2::-webkit-input-placeholder {
+.c1::-webkit-input-placeholder {
   color: #DCDBE2;
 }
 
-.c2:disabled {
+.c1:disabled {
   background-color: #EAEAEE;
 }
 
@@ -73,16 +73,12 @@ exports[`<TextField /> renders the component with error 1`] = `
   width: 100%;
 }
 
-.c1 {
-  margin-bottom: 5px;
-}
-
 <div
-  class="c0 c1"
+  class="c0"
 >
   <input
     aria-label="test1"
-    class="c2"
+    class="c1"
     id="text-id-test1"
     name="test1"
     type="text"
@@ -168,7 +164,7 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
 }
 
 <div
-  class="c0 "
+  class="c0"
 >
   <input
     aria-label="test1"
@@ -238,7 +234,7 @@ exports[`<TextField /> renders the component with prefix 1`] = `
 }
 
 <div
-  class="c0 "
+  class="c0"
 >
   <span
     class="c1"
@@ -286,7 +282,7 @@ exports[`<TextField /> renders the component with size 1`] = `
 }
 
 <div
-  class="c0 "
+  class="c0"
 >
   <input
     aria-label="test1"

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 "
 >
   <input
     aria-label="test1"
@@ -44,7 +44,7 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
 `;
 
 exports[`<TextField /> renders the component with error 1`] = `
-.c1 {
+.c2 {
   border: 2px solid #EE0505;
   border-radius: 4px;
   padding: 0 10px;
@@ -53,18 +53,18 @@ exports[`<TextField /> renders the component with error 1`] = `
   width: 100%;
 }
 
-.c1:focus {
+.c2:focus {
   outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
 }
 
-.c1::-webkit-input-placeholder {
+.c2::-webkit-input-placeholder {
   color: #DCDBE2;
 }
 
-.c1:disabled {
+.c2:disabled {
   background-color: #EAEAEE;
 }
 
@@ -73,12 +73,16 @@ exports[`<TextField /> renders the component with error 1`] = `
   width: 100%;
 }
 
+.c1 {
+  margin-bottom: 5px;
+}
+
 <div
-  class="c0"
+  class="c0 c1"
 >
   <input
     aria-label="test1"
-    class="c1"
+    class="c2"
     id="text-id-test1"
     name="test1"
     type="text"
@@ -99,7 +103,7 @@ exports[`<TextField /> renders the component with error and label and size 1`] =
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
   font-size: 16px;
-  margin-bottom: 5px;
+  margin-bottom: 0;
 }
 
 <label
@@ -123,7 +127,6 @@ exports[`<TextField /> renders the component with label 1`] = `
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
   font-size: 16px;
-  margin-bottom: 5px;
 }
 
 <label
@@ -165,7 +168,7 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 "
 >
   <input
     aria-label="test1"
@@ -235,7 +238,7 @@ exports[`<TextField /> renders the component with prefix 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 "
 >
   <span
     class="c1"
@@ -283,7 +286,7 @@ exports[`<TextField /> renders the component with size 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 "
 >
   <input
     aria-label="test1"

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -21,6 +21,18 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
   color: #DCDBE2;
 }
 
+.c1::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c1:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c1::placeholder {
+  color: #DCDBE2;
+}
+
 .c1:disabled {
   background-color: #EAEAEE;
 }
@@ -61,6 +73,18 @@ exports[`<TextField /> renders the component with error 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c1::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c1:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c1::placeholder {
   color: #DCDBE2;
 }
 
@@ -154,6 +178,18 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
   color: #DCDBE2;
 }
 
+.c1::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c1:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c1::placeholder {
+  color: #DCDBE2;
+}
+
 .c1:disabled {
   background-color: #EAEAEE;
 }
@@ -194,6 +230,18 @@ exports[`<TextField /> renders the component with prefix 1`] = `
 }
 
 .c2::-webkit-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c2::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c2:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c2::placeholder {
   color: #DCDBE2;
 }
 
@@ -269,6 +317,18 @@ exports[`<TextField /> renders the component with size 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c1::-moz-placeholder {
+  color: #DCDBE2;
+}
+
+.c1:-ms-input-placeholder {
+  color: #DCDBE2;
+}
+
+.c1::placeholder {
   color: #DCDBE2;
 }
 


### PR DESCRIPTION
## The bug{s} 🦟

### help text and error message spacing

<img src="https://user-images.githubusercontent.com/5938217/75340339-9a92c180-5892-11ea-8c20-2d0dc51cbca5.png" width="100" />

<img src="https://user-images.githubusercontent.com/5938217/75340514-e9405b80-5892-11ea-9fc4-efa010e08457.png" width="100" />

The _white-space_ after the **label** on `<TextField />` was off. I suspect it comes from [an update we did in `<InputLabel />`](https://github.com/zopaUK/react-components/pull/170) a few weeks ago.

I made the spacing consistent as well in `<DropdownField />` and `<DropdownFiltered />`.

### default margin on radio and checkboxes

<img src="https://user-images.githubusercontent.com/5938217/75346208-7e951d00-589e-11ea-8e84-ef4566af422e.png" width="150" />

<img src="https://user-images.githubusercontent.com/5938217/75346248-940a4700-589e-11ea-8d1b-8307e06ba5b9.png" width="150" />

There was a default `margin-bottom` applied without need to `<RadioField />` and `<CheckboxField />`. I removed it and made it appear only when more than one element is rendered through `:last-of-type`. 💭

## Notes  &nbsp;👀

This might justify picking up again [the spike on visual diff](https://github.com/zopaUK/react-components/issues/14) with [Percy](percy.io/).