### PR TITLE
Adjust placeholder styles 💄

### DIFF
--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -19,8 +19,11 @@ const Input = styled.input<IInput>`
     transition: border 0.2s;
   }
 
-  ::placeholder {
+  &::placeholder {
+    /* Firefox applies by default 0.5 opacity to the placeholder, 'normalize.css' stopped normalising this due to a Microsoft Edge bug */
+    /* @see https://github.com/necolas/normalize.css/issues/741  */
     color: ${colors.neutral.medium};
+    opacity: 1;
   }
 
   &:disabled {

--- a/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
@@ -19,18 +19,22 @@ exports[`<InputText /> renders the component disabled 1`] = `
 
 .c0::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:disabled {
@@ -63,18 +67,22 @@ exports[`<InputText /> renders the component with error 1`] = `
 
 .c0::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:disabled {
@@ -106,18 +114,22 @@ exports[`<InputText /> renders the component with focus 1`] = `
 
 .c0::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:disabled {
@@ -149,18 +161,22 @@ exports[`<InputText /> renders the component with isValid set as true 1`] = `
 
 .c0::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:disabled {
@@ -192,18 +208,22 @@ exports[`<InputText /> renders the component with the required props 1`] = `
 
 .c0::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c0:disabled {

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -33,18 +33,22 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
 
 .c3::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c3::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c3:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c3::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c3:disabled {
@@ -158,18 +162,22 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
 
 .c2::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2:disabled {

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -19,18 +19,22 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
 
 .c1::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:disabled {
@@ -74,18 +78,22 @@ exports[`<TextField /> renders the component with error 1`] = `
 
 .c1::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:disabled {
@@ -176,18 +184,22 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
 
 .c1::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:disabled {
@@ -231,18 +243,22 @@ exports[`<TextField /> renders the component with prefix 1`] = `
 
 .c2::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c2:disabled {
@@ -318,18 +334,22 @@ exports[`<TextField /> renders the component with size 1`] = `
 
 .c1::-webkit-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::-moz-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:-ms-input-placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1::placeholder {
   color: #DCDBE2;
+  opacity: 1;
 }
 
 .c1:disabled {


### PR DESCRIPTION
## Summary

In this library, we make use of [`styled-normalise`](https://github.com/sergeysova/styled-normalize) ( _which is just a wrapper over [`normalise.css`](https://github.com/necolas/normalize.css)_ ) to ensure consistency on the **browser's native CSS**.

Recently we noticed our input's placeholder looked _dimmer_ on Firefox, seems that `normalise.css` is [not normalising that anymore](https://github.com/necolas/normalize.css/issues/741) due to a bug on Edge 🦟

## Related

https://github.com/zopaUK/react-components/issues/243

