### PR TITLE
Small form fixes

### DIFF
--- a/src/components/organisms/Form/hooks/useForm.test.ts
+++ b/src/components/organisms/Form/hooks/useForm.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { useForm, TValues, TErrors } from './useForm';
+import { useForm, TFormValues, TFormErrors } from './useForm';
 
 const initialValues = {
   name: 'name',
@@ -8,8 +8,8 @@ const initialValues = {
 };
 const errorMessage = 'required';
 const onSubmit = jest.fn();
-const validate = (values: TValues) => {
-  const errors: TErrors = {};
+const validate = (values: TFormValues) => {
+  const errors: TFormErrors = {};
   if (values.name === '') {
     errors.name = errorMessage;
   }
@@ -33,7 +33,7 @@ describe('useForm', () => {
       }),
     );
 
-    ['getFieldProps', 'invalid', 'handleSubmit'].forEach(property => {
+    ['getFieldProps', 'invalid', 'handleSubmit', 'touched', 'initialValues'].forEach(property => {
       expect(result.current).toHaveProperty(property);
     });
   });

--- a/src/components/organisms/Form/hooks/useForm.ts
+++ b/src/components/organisms/Form/hooks/useForm.ts
@@ -26,6 +26,7 @@ export interface IUseFormValues {
   invalid: boolean;
   errors: TFormErrors;
   touched: TFormTouched;
+  initialValues: TFormValues;
 }
 
 export const useForm = ({ initialValues, validate, onSubmit, onChange }: IUseFormProps): IUseFormValues => {
@@ -85,5 +86,6 @@ export const useForm = ({ initialValues, validate, onSubmit, onChange }: IUseFor
     handleSubmit,
     errors,
     touched,
+    initialValues,
   };
 };

--- a/src/components/organisms/Form/hooks/useForm.ts
+++ b/src/components/organisms/Form/hooks/useForm.ts
@@ -7,7 +7,7 @@ export type TFormTouched = Record<string, boolean>;
 
 export interface IUseFormProps {
   initialValues: TFormValues;
-  onSubmit: (values: TFormValues) => void;
+  onSubmit?: (values: TFormValues) => void;
   onChange?: (values: TFormValues) => void;
   validate?: (values: TFormValues) => TFormErrors;
 }
@@ -72,7 +72,7 @@ export const useForm = ({ initialValues, validate, onSubmit, onChange }: IUseFor
           {},
         ),
       );
-      if (!invalid) {
+      if (!invalid && onSubmit) {
         onSubmit(values);
       }
     },


### PR DESCRIPTION
- make `onSubmit` optional because it's sometimes not needed, especially in case of subforms that rely mostly on form's `onChange`
- pass through `initialValues` as some more complex forms require comparison of initial values with current form values