### PR TITLE
Render `<footer />` not `<div />`

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -9,7 +9,7 @@ import SocialLinks from './SocialLinks/SocialLinks';
 import Wrapper from './Wrapper/Wrapper';
 import { colors } from '../../../constants/colors';
 
-const StyledWrapper = styled.div`
+const Footer = styled.footer`
   background-color: ${colors.neutral.dark};
   padding: 40px 0;
 `;
@@ -27,7 +27,7 @@ export interface IFooterProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const ZopaFooter = ({ legalOnly = false, baseUrl = 'https://www.zopa.com', ...rest }: IFooterProps) => (
-  <StyledWrapper id="zopa-footer" {...rest}>
+  <Footer {...rest}>
     <FlexContainer gutter={16}>
       {legalOnly || (
         <>
@@ -42,7 +42,7 @@ const ZopaFooter = ({ legalOnly = false, baseUrl = 'https://www.zopa.com', ...re
       )}
       <Legal />
     </FlexContainer>
-  </StyledWrapper>
+  </Footer>
 );
 
 ZopaFooter.defaultProps = {

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -61,9 +61,8 @@ exports[`<ZopaFooter /> renders the component with a legalOnly prop 1`] = `
   }
 }
 
-<div
+<footer
   class="c0"
-  id="zopa-footer"
 >
   <div
     class="c1"
@@ -90,7 +89,7 @@ exports[`<ZopaFooter /> renders the component with a legalOnly prop 1`] = `
       </p>
     </div>
   </div>
-</div>
+</footer>
 `;
 
 exports[`<ZopaFooter /> renders the component with default props 1`] = `
@@ -458,9 +457,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   }
 }
 
-<div
+<footer
   class="c0"
-  id="zopa-footer"
 >
   <div
     class="c1"
@@ -961,5 +959,5 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       </p>
     </div>
   </div>
-</div>
+</footer>
 `;


### PR DESCRIPTION
Semantics 💄 💓

I removed an `id` present there, if consumers still need they can just do:
```jsx
<ZopaFotter id="zopa-footer" />
```