### PR TITLE
Export `<Navbar />` height 📐

### DIFF
--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { colors } from '../../../../constants/colors';
+import { navbarHeight } from '../../../../constants/components';
 import useScrollThreshold from '../useScrollThreshold/useScrollThreshold';
 import FlexContainer from '../../../layout/FlexContainer/FlexContainer';
 
@@ -17,7 +18,7 @@ const LayoutOuter = styled.div<ILayoutOuterProps>`
   right: 0;
   z-index: 1;
   background-color: ${({ backgroundColor }) => backgroundColor};
-  height: 80px;
+  height: ${navbarHeight}px;
   transition: box-shadow 0.2s ease-in-out;
   box-shadow: 0 0 0 transparent;
   ${({ overlap }) => overlap && `box-shadow: rgba(0, 0, 0, 0.2) 0 1px 2px;`}
@@ -35,7 +36,7 @@ const LayoutInner = styled.nav`
 `;
 
 const Spacer = styled.div`
-  height: 80px;
+  height: ${navbarHeight}px;
 `;
 
 const Container = styled(FlexContainer)`

--- a/src/constants/components.ts
+++ b/src/constants/components.ts
@@ -1,0 +1,1 @@
+export const navbarHeight = 80;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 // Global (colors, fonts, ...)
 export { typography } from './constants/typography';
 export { colors } from './constants/colors';
+export * from './constants/components';
 export { default as grid } from './constants/grid';
 export { default as Fonts } from './components/styles/Fonts';
 export { default as GlobalStyles } from './components/styles/GlobalStyles';


### PR DESCRIPTION
<img src="https://media.giphy.com/media/zZfyfVv7Pp0C4/giphy.gif" width="300" />

Many times is helpful for the clients of this library to be able to read programmatically the height of `<Navbar />` and adjust their layouts accordingly ( _if needed_ ). 