### PR TITLE
Type link color properly 🧼

### DIFF
--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors, TLinkHexColors } from '../../../constants/colors';
 import { typography } from '../../../constants/typography';
 
 export interface ILinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
     React.RefAttributes<HTMLAnchorElement> {
   target?: '_blank';
-  color?: any; // see issue #139 for more context on why the explicit `any` here.
+  color?: TLinkHexColors;
   as?: 'a' | 'button';
 }
 
 const SLink = styled.a<ILinkProps>`
+  background-color: transparent;
   font-size: inherit;
   font-family: ${typography.primary};
   font-weight: ${typography.weights.semibold};
   line-height: ${typography.lineHeights.text};
-  color: ${({ color = colors.neutral.dark }) => color};
+  color: ${({ color }) => color};
   cursor: pointer;
   text-decoration: none;
   user-select: auto;

--- a/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Link /> renders the link with default values and the svg is hidden with no a11y violations 1`] = `
 .c0 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -40,6 +41,7 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
 
 exports[`<Link /> renders the link with target _blank with the svg visible 1`] = `
 .c0 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Help /> renders the default Help component with no a11y violations 1`] = `
 .c7 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/components/molecules/ZopaFooter/Links/Links.tsx
+++ b/src/components/molecules/ZopaFooter/Links/Links.tsx
@@ -37,6 +37,7 @@ const StyledListItem = styled.li`
 `;
 
 const BlockLink = styled(Link)`
+  color: ${colors.neutral.medium};
   display: block;
 `;
 
@@ -168,9 +169,7 @@ const Links: FC<ILinksProps> = ({ baseUrl = 'https://www.zopa.com' }) => (
           <StyledList>
             {links.map(({ label, href }) => (
               <StyledListItem key={label}>
-                <BlockLink color={colors.neutral.medium} href={href}>
-                  {label}
-                </BlockLink>
+                <BlockLink href={href}>{label}</BlockLink>
               </StyledListItem>
             ))}
           </StyledList>

--- a/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
@@ -36,11 +36,12 @@ exports[`<Links /> renders the component 1`] = `
 }
 
 .c6 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
   line-height: 1.6;
-  color: #DCDBE2;
+  color: #4A3EDE;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -94,6 +95,7 @@ exports[`<Links /> renders the component 1`] = `
 }
 
 .c7 {
+  color: #DCDBE2;
   display: block;
 }
 
@@ -162,7 +164,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/loans/car-loans"
           >
             Car loans
@@ -173,7 +175,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/loans/debt-consolidation"
           >
             Debt consolidation loans
@@ -184,7 +186,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/loans/home-improvement"
           >
             Home improvement loans
@@ -195,7 +197,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/loans/wedding"
           >
             Wedding loans
@@ -206,7 +208,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/invest"
           >
             Peer-to-peer investments
@@ -217,7 +219,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/invest/isa"
           >
             Innovative Finance ISA
@@ -246,7 +248,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about"
           >
             About Us
@@ -257,7 +259,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about/our-story"
           >
             Our story
@@ -268,7 +270,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about/board"
           >
             Meet the board
@@ -279,7 +281,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about/leadership"
           >
             Meet the leadership team
@@ -290,7 +292,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about/awards"
           >
             Awards
@@ -301,7 +303,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about/careers"
           >
             Careers
@@ -312,7 +314,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://blog.zopa.com"
           >
             Blog
@@ -323,7 +325,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/about/press"
           >
             Press team
@@ -334,7 +336,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/feelgood"
           >
             New products
@@ -363,7 +365,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/privacy-notice"
           >
             Privacy notice
@@ -374,7 +376,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/cookie-policy"
           >
             Cookie policy
@@ -385,7 +387,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/conflicts-policy"
           >
             Conflicts policy
@@ -396,7 +398,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/modern-slavery"
           >
             Modern slavery
@@ -407,7 +409,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/website-terms"
           >
             Website terms
@@ -418,7 +420,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/principles"
           >
             P2P Principles
@@ -447,7 +449,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/contact"
           >
             Support
@@ -458,7 +460,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://helpcentre.zopa.com/"
           >
             Common Questions
@@ -469,7 +471,7 @@ exports[`<Links /> renders the component 1`] = `
         >
           <a
             class="c6 c7"
-            color="#DCDBE2"
+            color="#4A3EDE"
             href="https://www.zopa.com/sitemap"
           >
             Sitemap

--- a/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/SocialLinks/__snapshots__/SocialLinks.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 .c2 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -98,6 +99,7 @@ exports[`<SocialLinks /> renders the component 1`] = `
 }
 
 .c7 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   margin-right: auto;
 }
 
-.c18 {
+.c17 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -119,7 +119,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   padding: 18px 0;
 }
 
-.c19 {
+.c18 {
   color: #A9ACBA;
   margin: 0 0 24px 0;
 }
@@ -193,6 +193,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 .c5 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -221,6 +222,7 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 .c10 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -245,34 +247,6 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
 }
 
 .c10:active {
-  opacity: 0.72;
-}
-
-.c15 {
-  font-size: inherit;
-  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-weight: 600;
-  line-height: 1.6;
-  color: #DCDBE2;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  user-select: auto;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0;
-  border: none;
-}
-
-.c15:hover {
-  opacity: 0.88;
-}
-
-.c15:active {
   opacity: 0.72;
 }
 
@@ -302,11 +276,12 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
   padding: 0;
 }
 
-.c16 {
+.c15 {
+  color: #DCDBE2;
   display: block;
 }
 
-.c17 {
+.c16 {
   background-color: #282F52;
   height: 1px;
 }
@@ -621,8 +596,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/loans/car-loans"
                 >
                   Car loans
@@ -632,8 +607,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/loans/debt-consolidation"
                 >
                   Debt consolidation loans
@@ -643,8 +618,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/loans/home-improvement"
                 >
                   Home improvement loans
@@ -654,8 +629,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/loans/wedding"
                 >
                   Wedding loans
@@ -665,8 +640,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/invest"
                 >
                   Peer-to-peer investments
@@ -676,8 +651,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/invest/isa"
                 >
                   Innovative Finance ISA
@@ -705,8 +680,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about"
                 >
                   About Us
@@ -716,8 +691,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about/our-story"
                 >
                   Our story
@@ -727,8 +702,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about/board"
                 >
                   Meet the board
@@ -738,8 +713,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about/leadership"
                 >
                   Meet the leadership team
@@ -749,8 +724,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about/awards"
                 >
                   Awards
@@ -760,8 +735,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about/careers"
                 >
                   Careers
@@ -771,8 +746,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://blog.zopa.com"
                 >
                   Blog
@@ -782,8 +757,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/about/press"
                 >
                   Press team
@@ -793,8 +768,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/feelgood"
                 >
                   New products
@@ -822,8 +797,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/privacy-notice"
                 >
                   Privacy notice
@@ -833,8 +808,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/cookie-policy"
                 >
                   Cookie policy
@@ -844,8 +819,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/conflicts-policy"
                 >
                   Conflicts policy
@@ -855,8 +830,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/modern-slavery"
                 >
                   Modern slavery
@@ -866,8 +841,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/website-terms"
                 >
                   Website terms
@@ -877,8 +852,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/principles"
                 >
                   P2P Principles
@@ -906,8 +881,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/contact"
                 >
                   Support
@@ -917,8 +892,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://helpcentre.zopa.com/"
                 >
                   Common Questions
@@ -928,8 +903,8 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 class="c14"
               >
                 <a
-                  class="c15 c16"
-                  color="#DCDBE2"
+                  class="c5 c15"
+                  color="#4A3EDE"
                   href="https://www.zopa.com/sitemap"
                 >
                   Sitemap
@@ -941,23 +916,23 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
       </div>
     </div>
     <div
-      class="c17"
+      class="c16"
     />
     <div
       class="c2"
     >
       <p
-        class="c18 c19"
+        class="c17 c18"
       >
         Zopa Limited is authorised and regulated by the Financial Conduct Authority, and entered on the Financial Services Register (718925). Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services Register (800542). Zopa Limited (05197592) and Zopa Bank Limited (10627575) are both incorporated in England & Wales and have their registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
       </p>
       <p
-        class="c18 c19"
+        class="c17 c18"
       >
         © Zopa Bank Limited 2025 All rights reserved. 'Zopa' is a trademark of Zopa Bank Limited.
       </p>
       <p
-        class="c18 c19"
+        class="c17 c18"
       >
         Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the Office of the Information Commissioner (ZA275984, Z8797078).
 

--- a/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Navbar.Link /> should render component with default props 1`] = `
 .c0 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;
@@ -63,6 +64,7 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
 }
 
 .c0 {
+  background-color: transparent;
   font-size: inherit;
   font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-weight: 600;

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,5 +1,5 @@
 export type TTextHexColors = '#FFFFFF' | '#63637E' | '#0D0A38' | '#1EC06A' | '#EE0505';
-export type TLinkHexColors = '#FFFFFF' | '#0D0A38';
+export type TLinkHexColors = '#FFFFFF' | '#4A3EDE';
 
 export interface IBaseColorSpec {
   primary: '#00B9A7';


### PR DESCRIPTION
## Summary

```jsx
<Link color />
```
This prop was typed as `any` given previously this component was extending `<Text />` and **TS** was getting a mess with the `color` props.

Now that it just extends `styled.a` type it properly...
 
## Issue

https://github.com/zopaUK/react-components/issues/139
