### PR TITLE
Compile errors 🧜🏼‍♂️

### DIFF
--- a/src/hooks/useViewport/ViewportProvider.tsx
+++ b/src/hooks/useViewport/ViewportProvider.tsx
@@ -1,14 +1,6 @@
-import React, { createContext } from 'react';
+import React from 'react';
 import { useViewport, IUseViewportOptions } from './useViewport';
-
-interface IViewportSize {
-  width: number | undefined;
-  height: number | undefined;
-}
-
-type TViewportContext = IViewportSize;
-
-const ViewportContext = createContext<TViewportContext>({ width: undefined, height: undefined });
+import { ViewportContext } from './context';
 
 const ViewportProvider: React.FC<IUseViewportOptions> = ({ children, ...rest }) => {
   const size = useViewport(rest);

--- a/src/hooks/useViewport/context.ts
+++ b/src/hooks/useViewport/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import { IViewportSize } from './types';
+
+export const ViewportContext = createContext<IViewportSize>({ width: undefined, height: undefined });

--- a/src/hooks/useViewport/types.ts
+++ b/src/hooks/useViewport/types.ts
@@ -1,0 +1,4 @@
+export interface IViewportSize {
+  width: number | undefined;
+  height: number | undefined;
+}

--- a/src/hooks/useViewport/useViewport.ts
+++ b/src/hooks/useViewport/useViewport.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useState, useContext } from 'react';
 import throttle from 'lodash.throttle';
-import { ViewportContext } from './ViewportProvider';
+import { ViewportContext } from './context';
+import { IViewportSize } from './types';
 
 export interface IUseViewportOptions {
   /**
@@ -9,7 +10,7 @@ export interface IUseViewportOptions {
   timeout?: number;
 }
 
-function readViewport() {
+function readViewport(): IViewportSize {
   const width = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
   const height = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
@@ -19,7 +20,7 @@ function readViewport() {
   };
 }
 
-export function useViewport({ timeout = 300 }: IUseViewportOptions = {}) {
+export function useViewport({ timeout = 300 }: IUseViewportOptions = {}): IViewportSize {
   const contextSize = useContext(ViewportContext);
   if (contextSize.width !== undefined) return contextSize;
 


### PR DESCRIPTION
## Summary 

Address circular dependencies in `useViewport` surfaced when compiling the library 😇
```
src/hooks/useViewport/useViewport.ts:22:17 - error TS4058: Return type of exported function has or is using name 'IViewportSize' from external m
odule "/Users/lluis.agusti/Code/zopa-react-components/src/hooks/useViewport/ViewportProvider" but cannot be named.

22 export function useViewport({ timeout = 300 }: IUseViewportOptions = {}) {
```
