### PR TITLE
fix(footer): update terms link

### DIFF
--- a/src/components/molecules/ZopaFooter/Links/Links.tsx
+++ b/src/components/molecules/ZopaFooter/Links/Links.tsx
@@ -131,8 +131,8 @@ const linkGroups = (baseUrl: string) => [
         label: 'Modern slavery',
       },
       {
-        href: `${baseUrl}/website-terms`,
-        label: 'Website terms',
+        href: `${baseUrl}/terms-of-use`,
+        label: 'Terms of use',
       },
       {
         href: `${baseUrl}/principles`,

--- a/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/Links/__snapshots__/Links.test.tsx.snap
@@ -406,9 +406,9 @@ exports[`<Links /> renders the component 1`] = `
           <a
             class="c6 c7"
             color="#DCDBE2"
-            href="https://www.zopa.com/website-terms"
+            href="https://www.zopa.com/terms-of-use"
           >
-            Website terms
+            Terms of use
           </a>
         </li>
         <li

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -862,9 +862,9 @@ exports[`<ZopaFooter /> renders the component with default props 1`] = `
                 <a
                   class="c15 c16"
                   color="#DCDBE2"
-                  href="https://www.zopa.com/website-terms"
+                  href="https://www.zopa.com/terms-of-use"
                 >
-                  Website terms
+                  Terms of use
                 </a>
               </li>
               <li


### PR DESCRIPTION
This needs to be timed with some other work we have for the terms page

Please don't merge until we have the redirect and page in place.