### PR TITLE
fix(card): fix card styling to follow mobile-first approach

### DIFF
--- a/src/components/atoms/Card/Card.tsx
+++ b/src/components/atoms/Card/Card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { colors } from '../../../constants/colors';
-import { maxMedia } from '../../../helpers/responsiveness';
+import { minMedia } from '../../../helpers/responsiveness';
 
 export interface ICardProps {
   type?: TCardTypes;
@@ -18,25 +18,26 @@ const borderRadius: { [index in TCardTypes]: string } = {
 const Card = styled.div<ICardProps>`
   background-color: ${colors.neutral.white};
   border-color: ${colors.neutral.white};
-  border-radius: ${({ type }) => borderRadius[type as TCardTypes]};
   border-style: solid;
   border-width: 2px;
+  border-radius: 0;
+  padding: 2em 1em;
   display: ${({ display = 'block' }) => display};
-  padding: 2em;
-
   ${({ type }) =>
     type === 'linkCard'
-      ? `
-    cursor: pointer;
-    user-select: none;
-  `
+      ? css`
+          cursor: pointer;
+          user-select: none;
+        `
       : undefined}
 
-  ${maxMedia.tablet`
-    border-radius: 0;
-    padding-left: 1em;
-    padding-right: 1em;
-  `};
+  ${minMedia.tablet`
+      padding: 2em;
+      ${({ type }: ICardProps) =>
+        css`
+          border-radius: ${borderRadius[type as TCardTypes]};
+        `};
+    `};
 `;
 
 Card.defaultProps = {

--- a/src/components/atoms/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/atoms/Card/__snapshots__/Card.test.tsx.snap
@@ -4,18 +4,17 @@ exports[`<Card type="card"/> renders default card type with explicit card type 1
 .c0 {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
-  border-radius: 4px;
   border-style: solid;
   border-width: 2px;
+  border-radius: 0;
+  padding: 2em 1em;
   display: block;
-  padding: 2em;
 }
 
-@media (max-width:720px) {
+@media (min-width:720px) {
   .c0 {
-    border-radius: 0;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 2em;
+    border-radius: 4px;
   }
 }
 
@@ -33,18 +32,17 @@ exports[`<Card type="card"/> renders default card type with implicit card type w
 .c0 {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
-  border-radius: 4px;
   border-style: solid;
   border-width: 2px;
+  border-radius: 0;
+  padding: 2em 1em;
   display: block;
-  padding: 2em;
 }
 
-@media (max-width:720px) {
+@media (min-width:720px) {
   .c0 {
-    border-radius: 0;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 2em;
+    border-radius: 4px;
   }
 }
 
@@ -62,18 +60,17 @@ exports[`<Card type="card"/> renders the card type with multiple props 1`] = `
 .c0 {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
-  border-radius: 4px;
   border-style: solid;
   border-width: 2px;
+  border-radius: 0;
+  padding: 2em 1em;
   display: block;
-  padding: 2em;
 }
 
-@media (max-width:720px) {
+@media (min-width:720px) {
   .c0 {
-    border-radius: 0;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 2em;
+    border-radius: 4px;
   }
 }
 
@@ -91,11 +88,11 @@ exports[`<Card type="linkCard"/> renders default linkCard 1`] = `
 .c0 {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
-  border-radius: 8px;
   border-style: solid;
   border-width: 2px;
+  border-radius: 0;
+  padding: 2em 1em;
   display: block;
-  padding: 2em;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -103,11 +100,10 @@ exports[`<Card type="linkCard"/> renders default linkCard 1`] = `
   user-select: none;
 }
 
-@media (max-width:720px) {
+@media (min-width:720px) {
   .c0 {
-    border-radius: 0;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 2em;
+    border-radius: 8px;
   }
 }
 
@@ -121,11 +117,11 @@ exports[`<Card type="linkCard"/> renders the component with props 1`] = `
 .c0 {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
-  border-radius: 8px;
   border-style: solid;
   border-width: 2px;
+  border-radius: 0;
+  padding: 2em 1em;
   display: block;
-  padding: 2em;
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -133,11 +129,10 @@ exports[`<Card type="linkCard"/> renders the component with props 1`] = `
   user-select: none;
 }
 
-@media (max-width:720px) {
+@media (min-width:720px) {
   .c0 {
-    border-radius: 0;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 2em;
+    border-radius: 8px;
   }
 }
 


### PR DESCRIPTION
Fix card styling so that it follows mobile-first approach (i.e. uses `min-width` instead of `max-width` media queries)