### PR TITLE
fix(dropdownfiltered): don't overwrite input's onChange and onFocus

### DIFF
--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
@@ -149,6 +149,8 @@ export default class DropdownFiltered extends React.PureComponent<IDropdownFilte
       labelProps,
       isValid,
       disabled,
+      onChange,
+      onFocus,
       ...rest
     } = this.props;
     if (!name) {


### PR DESCRIPTION
Don't overwrite dropdown's input `onChange` and `onFocus`