### PR TITLE
fix(InputText): remove webkit appearance

### DIFF
--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -12,6 +12,7 @@ const Input = styled.input<IInput>`
   height: 48px;
   font-weight: ${typography.weights.semibold};
   width: 100%;
+  -webkit-appearance: none;
 
   &:focus {
     outline-width: 0;

--- a/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<InputText /> renders the component disabled 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c0:focus {
@@ -56,6 +57,7 @@ exports[`<InputText /> renders the component with error 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c0:focus {
@@ -103,6 +105,7 @@ exports[`<InputText /> renders the component with focus 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c0:focus {
@@ -150,6 +153,7 @@ exports[`<InputText /> renders the component with isValid set as true 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c0:focus {
@@ -197,6 +201,7 @@ exports[`<InputText /> renders the component with the required props 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c0:focus {

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c3:focus {
@@ -151,6 +152,7 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c2:focus {

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c1:focus {
@@ -67,6 +68,7 @@ exports[`<TextField /> renders the component with error 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c1:focus {
@@ -173,6 +175,7 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c1:focus {
@@ -232,6 +235,7 @@ exports[`<TextField /> renders the component with prefix 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c2:focus {
@@ -323,6 +327,7 @@ exports[`<TextField /> renders the component with size 1`] = `
   height: 48px;
   font-weight: 600;
   width: 100%;
+  -webkit-appearance: none;
 }
 
 .c1:focus {


### PR DESCRIPTION
InputText
<img width="433" alt="iPhone_11_Pro_—_13_3" src="https://user-images.githubusercontent.com/7198934/77422216-6517c000-6dcd-11ea-9431-dada477ff511.png">
In some versions of Safari it was adding an extra border