### PR TITLE
fix(inputtext): remove outline at all

### DIFF
--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -13,9 +13,9 @@ const Input = styled.input<IInput>`
   font-weight: ${typography.weights.semibold};
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 
   &:focus {
-    outline-width: 0;
     border: 2px solid ${colors.base.secondary};
     transition: border 0.2s;
   }

--- a/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`<InputText /> renders the component disabled 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c0:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -58,10 +58,10 @@ exports[`<InputText /> renders the component with error 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c0:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -106,10 +106,10 @@ exports[`<InputText /> renders the component with focus 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c0:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -154,10 +154,10 @@ exports[`<InputText /> renders the component with isValid set as true 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c0:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -202,10 +202,10 @@ exports[`<InputText /> renders the component with the required props 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c0:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c3:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -153,10 +153,10 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c2:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c1:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -69,10 +69,10 @@ exports[`<TextField /> renders the component with error 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c1:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -176,10 +176,10 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c1:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -236,10 +236,10 @@ exports[`<TextField /> renders the component with prefix 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c2:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;
@@ -328,10 +328,10 @@ exports[`<TextField /> renders the component with size 1`] = `
   font-weight: 600;
   width: 100%;
   -webkit-appearance: none;
+  outline: none;
 }
 
 .c1:focus {
-  outline-width: 0;
   border: 2px solid #4A3EDE;
   -webkit-transition: border 0.2s;
   transition: border 0.2s;


### PR DESCRIPTION
outline in input text is still present in some safari versions 🤷‍♂ 
