### PR TITLE
Bring back <Button type /> prop 🙇🏻‍♂️

### DIFF
--- a/src/components/atoms/Button/Button.test.tsx
+++ b/src/components/atoms/Button/Button.test.tsx
@@ -3,43 +3,64 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Button from './Button';
 
-it('renders with no a11y violations', async () => {
-  const { container } = render(<Button>Primary</Button>);
-  expect(container.firstChild).toMatchSnapshot();
-  const results = await axe(container.innerHTML);
-  expect(results).toHaveNoViolations();
-});
+describe('<Button />', () => {
+  it('renders with no a11y violations', async () => {
+    const { container } = render(<Button>Primary</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+    const results = await axe(container.innerHTML);
+    expect(results).toHaveNoViolations();
+  });
 
-it('renders as "secondary"', () => {
-  const { container } = render(<Button styling="secondary">Secondary</Button>);
-  expect(container.firstChild).toMatchSnapshot();
-});
+  it('renders as "secondary"', () => {
+    const { container } = render(<Button styling="secondary">Secondary</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 
-it('renders as "link"', () => {
-  const { container } = render(<Button styling="link">Secondary</Button>);
-  expect(container.firstChild).toMatchSnapshot();
-});
+  it('renders as "link"', () => {
+    const { container } = render(<Button styling="link">Secondary</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 
-it('renders disabled', () => {
-  const { container } = render(<Button disabled>Secondary</Button>);
-  expect(container.firstChild).toMatchSnapshot();
-});
+  it('renders disabled', () => {
+    const { container } = render(<Button disabled>Secondary</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 
-it('renders wide', () => {
-  const { container } = render(<Button fullWidth>Secondary</Button>);
-  expect(container.firstChild).toMatchSnapshot();
-});
+  it('renders wide', () => {
+    const { container } = render(<Button fullWidth>Secondary</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 
-it('renders loading as "primary"', () => {
-  const { container } = render(<Button loading>Loading</Button>);
-  expect(container.firstChild).toMatchSnapshot();
-});
+  it('renders loading as "primary"', () => {
+    const { container } = render(<Button loading>Loading</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 
-it('renders loading as "secondary"', () => {
-  const { container } = render(
-    <Button styling="secondary" loading>
-      Waiting
-    </Button>,
-  );
-  expect(container.firstChild).toMatchSnapshot();
+  it('renders loading as "secondary"', () => {
+    const { container } = render(
+      <Button styling="secondary" loading>
+        Waiting
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders loading as "secondary"', () => {
+    const { container } = render(
+      <Button styling="secondary" loading>
+        Waiting
+      </Button>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it.each`
+    type
+    ${'submit'}
+    ${'reset'}
+    ${'button'}
+  `('renders with the specified type: $type', ({ type }) => {
+    const { container } = render(<Button type={type}>Foo</Button>);
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/atoms/Button/Button.test.tsx
+++ b/src/components/atoms/Button/Button.test.tsx
@@ -60,7 +60,8 @@ describe('<Button />', () => {
     ${'reset'}
     ${'button'}
   `('renders with the specified type: $type', ({ type }) => {
-    const { container } = render(<Button type={type}>Foo</Button>);
-    expect(container).toMatchSnapshot();
+    const { getByText } = render(<Button type={type}>Foo</Button>);
+    const target = getByText('Foo');
+    expect(target.getAttribute('type')).toEqual(type);
   });
 });

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -14,6 +14,7 @@ export interface IButtonProps extends HTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
   loading?: boolean;
   fullWidth?: boolean;
+  type?: 'button' | 'submit' | 'reset';
 }
 
 const colorMap = {

--- a/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders as "link" 1`] = `
+exports[`<Button /> renders as "link" 1`] = `
 .c0 {
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -58,7 +58,7 @@ exports[`renders as "link" 1`] = `
 </button>
 `;
 
-exports[`renders as "secondary" 1`] = `
+exports[`<Button /> renders as "secondary" 1`] = `
 .c0 {
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -116,7 +116,7 @@ exports[`renders as "secondary" 1`] = `
 </button>
 `;
 
-exports[`renders disabled 1`] = `
+exports[`<Button /> renders disabled 1`] = `
 .c0 {
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -176,7 +176,7 @@ exports[`renders disabled 1`] = `
 </button>
 `;
 
-exports[`renders loading as "primary" 1`] = `
+exports[`<Button /> renders loading as "primary" 1`] = `
 .c1 {
   width: 20px;
   height: 20px;
@@ -250,7 +250,7 @@ exports[`renders loading as "primary" 1`] = `
 </button>
 `;
 
-exports[`renders loading as "secondary" 1`] = `
+exports[`<Button /> renders loading as "secondary" 1`] = `
 .c1 {
   width: 20px;
   height: 20px;
@@ -323,7 +323,80 @@ exports[`renders loading as "secondary" 1`] = `
 </button>
 `;
 
-exports[`renders wide 1`] = `
+exports[`<Button /> renders loading as "secondary" 2`] = `
+.c1 {
+  width: 20px;
+  height: 20px;
+  border: 3px solid #3B46C4;
+  border-radius: 50%;
+  border-top-color: transparent;
+  -webkit-animation: iVXCSc 1.2s linear infinite;
+  animation: iVXCSc 1.2s linear infinite;
+}
+
+.c0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 16px 24px;
+  font-family: "Open Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 15px;
+  line-height: 1.2;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 8px;
+  color: #21247F;
+  border: none;
+  outline: 0;
+  background: #E9EAFA;
+}
+
+.c0:hover:not(:disabled) {
+  background: #EEEFFB;
+}
+
+.c0:focus:not(:active) {
+  border: 1px solid #FFFFFF;
+  box-shadow: 0 0 4px #3B46C4;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+  background: #F7F7F7;
+  color: #818F9B;
+}
+
+.c0:active:not(:disabled) {
+  border: none;
+  box-shadow: unset;
+  opacity: 0.8;
+}
+
+<button
+  class="c0"
+>
+  <div
+    class="c1"
+  />
+   
+    
+  Waiting
+</button>
+`;
+
+exports[`<Button /> renders wide 1`] = `
 .c0 {
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -383,7 +456,7 @@ exports[`renders wide 1`] = `
 </button>
 `;
 
-exports[`renders with no a11y violations 1`] = `
+exports[`<Button /> renders with no a11y violations 1`] = `
 .c0 {
   -webkit-text-decoration: none;
   text-decoration: none;


### PR DESCRIPTION
On a [previous PR](https://github.com/zopaUK/react-components/pull/291) where I rebranded our `<Button />` component, I missed [the existing `type` prop](https://github.com/zopaUK/react-components/blob/master/src/components/atoms/Button/Button.tsx#L14). This PR brings it back 😇