### PR TITLE
Deprecate existing icon components 🗑

### DIFF
--- a/src/components/atoms/AlertBox/AlertBox.tsx
+++ b/src/components/atoms/AlertBox/AlertBox.tsx
@@ -29,6 +29,14 @@ const AlertBox: FC<IAlertBoxProps> = ({ children, icon, ...rest }) => (
 );
 
 /**
- * @deprecated `<AlertBox />` is deprecated. It will soon be removed. Use `<Alert />` instead.
+ * @deprecated `<AlertBox />` is deprecated and will be removed in: `4.0.0`. Use [`<Alert severity="warning" />`](#/Components/Atoms/Alert) instead.
  */
-export default deprecate(AlertBox, '<AlertBox /> is deprecated. It will soon be removed. Use <Alert /> instead.');
+export default deprecate(
+  AlertBox,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <AlertBox /> is deprecated and it will be removed in the next major version: 4.0.0.
+  Use <Alert severity="warning" /> instead.
+`,
+);

--- a/src/components/icons/Alert/Alert.tsx
+++ b/src/components/icons/Alert/Alert.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import deprecate from 'util-deprecate';
 import { colors } from '../../../constants/colors';
 
 export interface IAlertProps {
@@ -19,4 +20,15 @@ const AlertIcon: React.FunctionComponent<IAlertProps> = ({ fillColor = colors.ba
   </svg>
 );
 
-export default AlertIcon;
+/**
+ * @deprecated `<AlertIcon />` is deprecated and will be removed in: `4.0.0`. Use [this font-awesome 'exclamation-triangle' icon](https://fontawesome.com/icons/exclamation-triangle?style=solid) instead.
+ */
+export default deprecate(
+  AlertIcon,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <AlertIcon /> is deprecated and it will be removed in the next major version: 4.0.0. 
+  For icons we plan to rely on font-awesome, use: <i class="fas fa-exclamation-triangle" /> instead.
+`,
+);

--- a/src/components/icons/Arrow/Arrow.tsx
+++ b/src/components/icons/Arrow/Arrow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import deprecate from 'util-deprecate';
 import { colors } from '../../../constants/colors';
 
 export type ArrowDirection = 'up' | 'down' | 'left' | 'right' | number | string;
@@ -66,4 +67,15 @@ const Arrow = ({
   </StyledArrow>
 );
 
-export default Arrow;
+/**
+ * @deprecated `<ArrowIcon />` is deprecated and will be removed in: `4.0.0`. Use [font-awesome 'chevron' icons](https://fontawesome.com/icons/chevron-right?style=solid) instead.
+ */
+export default deprecate(
+  Arrow,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <ArrowIcon /> is deprecated and it will be removed in the next major version: 4.0.0. 
+  For icons we plan to rely on font-awesome, use: <i class="fas fa-chevron-{direction}"></i> instead.
+`,
+);

--- a/src/components/icons/CheckMark/CheckMark.tsx
+++ b/src/components/icons/CheckMark/CheckMark.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { colors } from '../../../constants/colors';
+import deprecate from 'util-deprecate';
 
 export interface ICheckMarkProps extends React.SVGProps<SVGSVGElement> {
   /**
@@ -20,4 +21,15 @@ const CheckMark = ({ color = colors.base.secondary, ...rest }: ICheckMarkProps) 
   );
 };
 
-export default CheckMark;
+/**
+ * @deprecated `<CheckMarkIcon />` is deprecated and will be removed in: `4.0.0`. Use [font-awesome 'check' icon](https://fontawesome.com/icons/check?style=solid) instead.
+ */
+export default deprecate(
+  CheckMark,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <CheckMarkIcon /> is deprecated and it will be removed in the next major version: 4.0.0. 
+  For icons we plan to rely on font-awesome, use: <i class="fas fa-check"></i> instead.
+`,
+);

--- a/src/components/icons/Chevron/Chevron.tsx
+++ b/src/components/icons/Chevron/Chevron.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../constants/colors';
+import deprecate from 'util-deprecate';
 
 export type ChevronDirection = 'up' | 'down' | 'left' | 'right';
 
@@ -56,4 +57,15 @@ const Chevron = ({
   </StyledChevron>
 );
 
-export default Chevron;
+/**
+ * @deprecated `<ChevronIcon />` is deprecated and will be removed in: `4.0.0`. Use [font-awesome 'chevron' icons](https://fontawesome.com/icons/chevron-right?style=solid) instead.
+ */
+export default deprecate(
+  Chevron,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <ChevronIcon /> is deprecated and it will be removed in the next major version: 4.0.0. 
+  For icons we plan to rely on font-awesome, use: <i class="fas fa-chevron-{direction}"></i> instead.
+`,
+);

--- a/src/components/icons/Hamburger/Hamburger.tsx
+++ b/src/components/icons/Hamburger/Hamburger.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { colors } from '../../../constants/colors';
+import deprecate from 'util-deprecate';
 
 export interface IHamburgerProps {
   /**
@@ -41,4 +42,15 @@ const Hamburger: React.FunctionComponent<IHamburgerProps> = ({
   );
 };
 
-export default Hamburger;
+/**
+ * @deprecated `<HamburgerIcon />` is deprecated and will be removed in: `4.0.0`. Use [font-awesome 'bars' icon](https://fontawesome.com/icons/bars?style=solid) instead.
+ */
+export default deprecate(
+  Hamburger,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <HamburgerIcon /> is deprecated and it will be removed in the next major version: 4.0.0. 
+  For icons we plan to rely on font-awesome, use: <i class="fas fa-bars"></i> instead.
+`,
+);

--- a/src/components/icons/Profile/Profile.tsx
+++ b/src/components/icons/Profile/Profile.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { colors } from '../../../constants/colors';
+import deprecate from 'util-deprecate';
 
 export interface IProfileProps {
   /**
@@ -52,4 +53,15 @@ const Profile: React.FunctionComponent<IProfileProps> = ({
   );
 };
 
-export default Profile;
+/**
+ * @deprecated `<ProfileIcon />` is deprecated and will be removed in: `4.0.0`. Use [font-awesome 'user' icon](https://fontawesome.com/icons/user?style=solid) instead.
+ */
+export default deprecate(
+  Profile,
+  `
+  ❗️ [@zopauk/react-components]
+  
+  <ProfileIcon /> is deprecated and it will be removed in the next major version: 4.0.0. 
+  For icons we plan to rely on font-awesome, use: <i class="fas fa-user"></i> instead.
+`,
+);


### PR DESCRIPTION
## Summary

![Screenshot 2020-04-24 at 13 19 51](https://user-images.githubusercontent.com/5938217/80207406-5cb1df80-862e-11ea-8c63-1a1dec055015.png)


Deprecate existing icon components using [`util-deprecate`](https://www.npmjs.com/package/util-deprecate) and point to which **font-awesome** icons to use instead.

## Story

[ZDS-11](https://jira.zopa/browse/ZDS-11)