### PR TITLE
feat(inputrange): adding Input Range without controls

### DIFF
--- a/src/components/atoms/InputRange/InputRange.md
+++ b/src/components/atoms/InputRange/InputRange.md
@@ -1,0 +1,131 @@
+### Summary
+
+Use `<InputRange />` to render a native HTML `<input type="range" />`.
+
+### Examples
+
+With default props:
+
+```tsx
+import { InputRange } from '@zopauk/react-components';
+
+<InputRange />;
+```
+
+With default value:
+
+```tsx
+import { InputRange } from '@zopauk/react-components';
+
+<InputRange defaultValue={75} />;
+```
+
+With min and max:
+
+```tsx
+import { InputRange } from '@zopauk/react-components';
+
+<InputRange min={100} max={200} />;
+```
+
+With step:
+
+```tsx
+import { InputRange } from '@zopauk/react-components';
+
+<InputRange step={10} />;
+```
+
+With default value, min, max and step:
+
+```tsx
+import { InputRange } from '@zopauk/react-components';
+
+<InputRange defaultValue={150} min={100} max={500} step={50} />;
+```
+
+### Controlled Examples
+
+Store value of `<InputRange />`:
+
+```tsx
+import { Fragment, useState } from 'react';
+import { InputRange, Text } from '@zopauk/react-components';
+
+const ControlledInputRange = () => {
+  const [value, setValue] = useState(75);
+  const onChangeHandler = event => setValue(Number(event.target.value));
+
+  return (
+    <Fragment>
+      <Text mb>Value: {value}</Text>
+      <InputRange value={value} onChange={onChangeHandler} />
+    </Fragment>
+  );
+};
+
+<ControlledInputRange />;
+```
+
+Store value of `<InputRange />` with min and max:
+
+```tsx
+import { Fragment, useState } from 'react';
+import { InputRange, Text } from '@zopauk/react-components';
+
+const ControlledInputRange = () => {
+  const [value, setValue] = useState(150);
+  const onChangeHandler = event => setValue(Number(event.target.value));
+
+  return (
+    <Fragment>
+      <Text mb>Value: {value}</Text>
+      <InputRange value={value} min={100} max={200} onChange={onChangeHandler} />
+    </Fragment>
+  );
+};
+
+<ControlledInputRange />;
+```
+
+Store value of `<InputRange />` with step:
+
+```tsx
+import { Fragment, useState } from 'react';
+import { InputRange, Text } from '@zopauk/react-components';
+
+const ControlledInputRange = () => {
+  const [value, setValue] = useState(50);
+  const onChangeHandler = event => setValue(Number(event.target.value));
+
+  return (
+    <Fragment>
+      <Text mb>Value: {value}</Text>
+      <InputRange value={value} step={10} onChange={onChangeHandler} />
+    </Fragment>
+  );
+};
+
+<ControlledInputRange />;
+```
+
+Store value of `<InputRange />` with min, max and step:
+
+```tsx
+import { Fragment, useState } from 'react';
+import { InputRange, Text } from '@zopauk/react-components';
+
+const ControlledInputRange = () => {
+  const [value, setValue] = useState(150);
+  const onChangeHandler = event => setValue(Number(event.target.value));
+
+  return (
+    <Fragment>
+      <Text mb>Value: {value}</Text>
+      <InputRange value={value} min={100} max={500} step={50} onChange={onChangeHandler} />
+    </Fragment>
+  );
+};
+
+<ControlledInputRange />;
+```

--- a/src/components/atoms/InputRange/InputRange.test.tsx
+++ b/src/components/atoms/InputRange/InputRange.test.tsx
@@ -1,0 +1,32 @@
+import React, { ChangeEvent, useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import InputRange from './InputRange';
+import { axe } from 'jest-axe';
+
+describe('<InputRange />', () => {
+  it('renders and updates as expected', async () => {
+    const ControlledInputRange = () => {
+      const [value, setValue] = useState(75);
+      const onChangeHandler = (event: ChangeEvent<HTMLInputElement>) => setValue(Number(event.target.value));
+
+      return <InputRange value={value} onChange={onChangeHandler} />;
+    };
+
+    render(<ControlledInputRange />);
+
+    const input = (await screen.findByRole('slider')) as HTMLInputElement;
+
+    expect(input.value).toEqual('75');
+
+    fireEvent.change(input, { target: { value: '25' } });
+
+    expect(input.value).toEqual('25');
+  });
+
+  it('renders the component with no a11y violations', async () => {
+    const { container } = render(<InputRange aria-label="slider" defaultValue={51} />);
+    const results = await axe(container.innerHTML);
+    expect(container.firstChild).toMatchSnapshot();
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/atoms/InputRange/InputRange.tsx
+++ b/src/components/atoms/InputRange/InputRange.tsx
@@ -1,0 +1,125 @@
+import React, { InputHTMLAttributes, useState, ChangeEvent, useRef, useEffect } from 'react';
+import styled, { css } from 'styled-components';
+import { colors } from '../../../constants/colors';
+import { calculateTrackPosition } from './helpers';
+
+const trackHeight = 8;
+const thumbDiameter = 40;
+
+const TrackStyles = css`
+  box-sizing: border-box;
+  border: none;
+  border-radius: ${trackHeight / 2}px;
+  height: ${trackHeight}px;
+  background: ${colors.neutral.light};
+`;
+
+const ThumbStyles = css`
+  box-sizing: border-box;
+  border: none;
+  border-radius: 50%;
+  width: ${thumbDiameter}px;
+  height: ${thumbDiameter}px;
+  background: #007468;
+`;
+
+const ThumbStylesFocus = css`
+  background: ${colors.base.secondary};
+`;
+
+interface IInput extends InputHTMLAttributes<HTMLInputElement> {
+  trackPosition: number;
+}
+
+const SInputRange = styled.input<IInput>`
+  -webkit-appearance: none;
+  width: 100%;
+  height: ${thumbDiameter}px;
+
+  &::-webkit-slider-runnable-track {
+    ${TrackStyles}
+  }
+  &::-moz-range-track {
+    ${TrackStyles}
+  }
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    margin-top: ${(trackHeight - thumbDiameter) * 0.5}px;
+    ${ThumbStyles}
+  }
+  &::-moz-range-thumb {
+    ${ThumbStyles}
+  }
+
+  &::-webkit-slider-runnable-track {
+    background: -webkit-gradient(
+      linear,
+      0% 0%,
+      100% 0%,
+      color-stop(${({ trackPosition }) => trackPosition}, ${colors.base.primary}),
+      color-stop(${({ trackPosition }) => trackPosition}, ${colors.neutral.medium})
+    );
+  }
+  &::-moz-range-progress {
+    border-radius: ${trackHeight / 2}px;
+    height: ${trackHeight}px;
+    background: ${colors.base.primary};
+  }
+
+  &:focus {
+    outline: none;
+
+    &::-webkit-slider-thumb {
+      ${ThumbStylesFocus}
+    }
+    &::-moz-range-thumb {
+      ${ThumbStylesFocus}
+    }
+  }
+
+  ::-moz-focus-outer {
+    border: 0;
+  }
+`;
+
+interface IInputRange extends InputHTMLAttributes<HTMLInputElement> {
+  defaultValue?: number;
+  value?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+const InputRange = ({ min = 0, max = 100, onChange, ...otherProps }: IInputRange) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [trackPosition, setTrackPosition] = useState(0.5);
+
+  const calculateTrackPositionFromInput = (input: HTMLInputElement) => {
+    return calculateTrackPosition({ min: Number(input.min), max: Number(input.max), value: Number(input.value) });
+  };
+
+  useEffect(() => {
+    inputRef.current && setTrackPosition(calculateTrackPositionFromInput(inputRef.current));
+  }, []);
+
+  const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    setTrackPosition(calculateTrackPositionFromInput(e.target));
+    onChange && onChange(e);
+  };
+
+  return (
+    <SInputRange
+      {...otherProps}
+      role="slider"
+      trackPosition={trackPosition}
+      min={min}
+      max={max}
+      onChange={onChangeHandler}
+      type="range"
+      ref={inputRef}
+    />
+  );
+};
+
+export default InputRange;

--- a/src/components/atoms/InputRange/__snapshots__/InputRange.test.tsx.snap
+++ b/src/components/atoms/InputRange/__snapshots__/InputRange.test.tsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<InputRange /> renders the component with no a11y violations 1`] = `
+.c0 {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 40px;
+}
+
+.c0::-webkit-slider-runnable-track {
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  height: 8px;
+  background: #EAEAEE;
+}
+
+.c0::-moz-range-track {
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  height: 8px;
+  background: #EAEAEE;
+}
+
+.c0::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  margin-top: -16px;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  background: #007468;
+}
+
+.c0::-moz-range-thumb {
+  box-sizing: border-box;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  background: #007468;
+}
+
+.c0::-webkit-slider-runnable-track {
+  background: -webkit-gradient( linear, 0% 0%, 100% 0%, color-stop(0.51,#00B9A7), color-stop(0.51,#DCDBE2) );
+}
+
+.c0::-moz-range-progress {
+  border-radius: 4px;
+  height: 8px;
+  background: #00B9A7;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus::-webkit-slider-thumb {
+  background: #4A3EDE;
+}
+
+.c0:focus::-moz-range-thumb {
+  background: #4A3EDE;
+}
+
+.c0::-moz-focus-outer {
+  border: 0;
+}
+
+<input
+  aria-label="slider"
+  class="c0"
+  max="100"
+  min="0"
+  role="slider"
+  type="range"
+  value="51"
+/>
+`;

--- a/src/components/atoms/InputRange/helpers/helpers.test.ts
+++ b/src/components/atoms/InputRange/helpers/helpers.test.ts
@@ -1,0 +1,22 @@
+import { calculateTrackPosition } from './index';
+
+describe('calculateTrackPosition', () => {
+  it.each`
+    min          | max          | value   | expectedPosition
+    ${undefined} | ${undefined} | ${50}   | ${0.5}
+    ${undefined} | ${200}       | ${50}   | ${0.25}
+    ${50}        | ${undefined} | ${75}   | ${0.5}
+    ${100}       | ${1100}      | ${600}  | ${0.5}
+    ${-10}       | ${10}        | ${0}    | ${0.5}
+    ${-200}      | ${-100}      | ${-125} | ${0.75}
+    ${100}       | ${100}       | ${100}  | ${0}
+    ${100}       | ${50}        | ${50}   | ${0}
+    ${100}       | ${200}       | ${500}  | ${1}
+    ${100}       | ${200}       | ${50}   | ${0}
+  `(
+    'Calculates proper position for min: $min, max: $max and value: $value',
+    ({ min, max, value, expectedPosition }) => {
+      expect(calculateTrackPosition({ min, max, value })).toBe(expectedPosition);
+    },
+  );
+});

--- a/src/components/atoms/InputRange/helpers/index.ts
+++ b/src/components/atoms/InputRange/helpers/index.ts
@@ -1,0 +1,25 @@
+interface ITrackPosition {
+  min?: number;
+  max?: number;
+  value: number;
+}
+
+export const calculateTrackPosition = ({ min = 0, max = 100, value }: ITrackPosition) => {
+  if (max < min) {
+    return 0;
+  }
+
+  if (value > max) {
+    return 1;
+  }
+
+  if (value < min) {
+    return 0;
+  }
+
+  if (value === min && value === max) {
+    return 0;
+  }
+
+  return (value - min) / (max - min);
+};

--- a/src/components/atoms/README.md
+++ b/src/components/atoms/README.md
@@ -9,6 +9,7 @@ Atoms are usually made with only one single HTML element.
 - [`<ErrorMessage />`](#/Components/Atoms/ErrorMessage)
 - [`<Heading />`](#/Components/Atoms/Heading)
 - [`<InputLabel />`](#/Components/Atoms/InputLabel)
+- [`<InputRange />`](#/Components/Atoms/InputRange)
 - [`<InputText />`](#/Components/Atoms/InputText)
 - [`<Link />`](#/Components/Atoms/Link)
 - [`<SidekickCard />`](#/Components/Atoms/SidekickCard)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { default as DropdownFiltered } from './components/molecules/DropdownFilt
 export { default as Spinner } from './components/atoms/Spinner/Spinner';
 export { default as ErrorMessage } from './components/atoms/ErrorMessage/ErrorMessage';
 export { default as InputLabel } from './components/atoms/InputLabel/InputLabel';
+export { default as InputRange } from './components/atoms/InputRange/InputRange';
 export { default as InputText } from './components/atoms/InputText/InputText';
 export { default as Text } from './components/atoms/Text/Text';
 export { default as Heading } from './components/atoms/Heading/Heading';


### PR DESCRIPTION
I will add controls in a new Molecule (in a new PR). Still thinking in a proper name, I will go with
InputRangeWithControls for now.

Notes: This is a v3 version of the InputRange. We will add correct colors and states in v4.

Related JIRA: https://jira.zopa/browse/SHOPDEV-6087