### PR TITLE
Move spacing docs to their own section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,3 +141,70 @@ Additionally we added the following plugins/steps:
 | @semantic-release/git       | Semantic-release plugin responsible the update the package version with the next version                                                                                            |
 | @semantic-release/github    | Semantic-release plugin to generates the artifacts for every release (download files), publish a new release, adds comments to github issues or PR and/or generates an Github issue |
 | gh-pages                    | Deployment for the styleguide                                                                                                                                                       |
+
+### Beta releases
+
+#### Conventions
+
+👍🏻 &nbsp;Please use **beta releases with care and mostly for**:
+
+- [x] getting feedback on major versions before releasing them
+- [x] getting feedback on APIs for new features
+
+👎🏻 &nbsp;Don't use beta releases for testing patches/fixes on this library
+
+We rely on a manual process for releasing beta versions of this library.
+( _this could be automated in a near future..._ )
+
+We use the following naming convention for **beta releases**:
+
+```js
+`${upcomingVersion}--beta.${currentBetaIteration}`;
+```
+
+For instance if `4.0.0--beta.4` means it's the **4th beta iteration** of the major version `4.0.0`.
+
+#### Process
+
+To release a beta iteration of your upcoming version:
+
+1. Let's update the version of the library:
+
+```
+# assuming we're in 3.8.0
+$ yarn version --new-version 4.0.0--beta.1
+```
+
+2. Let's compile the source code
+
+```
+# this should create the /es /types and /cjs directories on the project root
+$ yarn compile
+```
+
+3. Let's push our changes so we can tie this beta release to a point in the Git history:
+
+```
+# always do a beta release from a feature branch, never from master!
+$ git push origin milestone/4.0.0
+```
+
+4. Let's publish the package on NPM on the `next` tag (the one we use to publish betas):
+
+```
+# if you're not part of Zopa NPM organization you'll need to request access to be able to publish
+$ npm publish --tag next
+```
+
+5. Now clients of this library can try the beta release doing:
+
+```
+$ yarn add @zopauk/react-components@next
+```
+
+#### Further reading
+
+- [Semantic versioning](https://semver.org/)
+- [NPM distribution tags](https://docs.npmjs.com/adding-dist-tags-to-packages)
+- [`npm version`](https://docs.npmjs.com/cli/version)
+- [`npm publish`](https://docs.npmjs.com/cli-commands/publish.html)

--- a/src/README.md
+++ b/src/README.md
@@ -1,14 +1,14 @@
 This project aims to have all the common styled react components as a library/documentation.
 
-### Installation
+## Installation
 
-- Install it from NPM:
+Install it from NPM:
 
-  ```bash
-  yarn add '@zopauk/react-components'
-  ```
+```bash
+yarn add '@zopauk/react-components'
+```
 
-### Setup
+## Global Styling
 
 ⚠️ &nbsp;&nbsp;In order for the UI to render well, `<GlobalStyles />` needs to be imported and added to the top-most component of the project:
 
@@ -24,76 +24,21 @@ const App = () => (
 );
 ```
 
+## Typography
+
 [Open Sans](https://fonts.google.com/specimen/Open+Sans) is the typography chosen for Zopa's brand.
 
-We currently use three weights:
+We currently use **four weights**:
 
 - 400 ( _regular_ )
 - 600 ( _semibold_ )
 - 700 ( _bold_ )
+- 800 ( _extrabold_ )
 
-As a convenience, you can import `<Fonts />` and add it on the top level of your app:
+This library assumes **Open Sans** is already available, so make sure you link it properly in the root HTML of your application:
 
-```ts static
-import { Fonts } from '@zopauk/react-components';
-
-// root component
-const App = () => (
-  <>
-    <Fonts />
-    // rest of your top-level components
-  </>
-);
+```html static
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700;800&display=swap" rel="stylesheet" />
 ```
-
-It'll grab **Open Sans** from Google's CDN [through a CSS import](https://github.com/zopaUK/react-components/blob/master/src/components/styles/Fonts.tsx#L3-L5).
 
 You're free to use this technique or add the dependency manually to your base HTML `<head />`
-
-### Spacing
-
-Spacing is included as part of the GlobalStyles component and is split into margin and padding each can be used as atomic classes on your components.
-
-We follow the same guidelines set out in Tailwind
-
-Margin: https://tailwindcss.com/docs/margin/
-
-Padding: https://tailwindcss.com/docs/padding/
-
-The number you define in the class selector refers to the index of the spacing constants set out here:
-
-```ts static
-const spacing = {
-  '0': '0',
-  '1': '4px',
-  '2': '8px',
-  '3': '12px',
-  '4': '16px',
-  '5': '20px',
-  '6': '24px',
-  '7': '32px',
-  '8': '40px',
-  '9': '56px',
-  '10': '64px',
-  '11': '104px',
-};
-```
-
-Example:
-
-```tsx
-import { GlobalStyles } from '@zopauk/react-components';
-
-<>
-  <GlobalStyles />
-
-  <h3>Margin</h3>
-  <div className="mx-7">I have a 32px margin on the x axis</div>
-  <div className="my-2">I have a 8px margin on the y axis</div>
-  <div className="ml-6">I have a 24px margin on the left</div>
-
-  <h3>Padding</h3>
-  <div className="p-6 m:p-7">I have a 24px padding on all sides at mobile then 32px at desktop</div>
-  <div className="pb-4">I have a 16px padding on the bottom</div>
-</>;
-```

--- a/src/content/Colors/Colors.md
+++ b/src/content/Colors/Colors.md
@@ -1,6 +1,6 @@
 ### Usage
 
-`<Color />` is **NOT available in the library**. It is used for presentation on this page only.
+You can consume our library colors through the `colors` exported constant:
 
 ```ts static
 import { colors } from '@zopauk/react-components';
@@ -11,23 +11,27 @@ const whiteColor = colors.white; // #fff
 ### Brand Colors
 
 ```ts noeditor
+// `<Color />` is **NOT available in the library**. It is used for presentation on this page only.
 <Colors variant="brand" />
 ```
 
 ### Action Colors
 
 ```ts noeditor
+// `<Color />` is **NOT available in the library**. It is used for presentation on this page only.
 <Colors variant="actions" />
 ```
 
 ### Neutral Colors
 
 ```ts noeditor
+// `<Color />` is **NOT available in the library**. It is used for presentation on this page only.
 <Colors variant="neutral" />
 ```
 
 ### Notification Colors
 
 ```ts noeditor
+// `<Color />` is **NOT available in the library**. It is used for presentation on this page only.
 <Colors variant="notifications" />
 ```

--- a/src/content/Spacing/Spacing.md
+++ b/src/content/Spacing/Spacing.md
@@ -1,0 +1,66 @@
+### Summary
+
+This library exports **Tailwind** flavoured [atomic classes](https://css-tricks.com/lets-define-exactly-atomic-css/) for dealing with spacing within components.
+
+Here's a guide on how to use them:
+
+- [margin](https://tailwindcss.com/docs/margin/#add-margin-to-a-single-side)
+- [padding](https://tailwindcss.com/docs/padding/#add-padding-to-a-single-side)
+
+This is our available spacing scale which is made out of **multiples of 4**:
+
+```tsx static
+const spacingScale = {
+  '0': '0',
+  '1': '4px',
+  '2': '8px',
+  '3': '12px',
+  '4': '16px',
+  '5': '20px',
+  '6': '24px',
+  '7': '32px',
+  '8': '40px',
+  '9': '56px',
+  '10': '64px',
+  '11': '104px',
+};
+
+/**
+ * Using the indexes on the spacing scale above:
+ */
+<div className='mr-10' /> // margin-right: 64px
+<div className='mx-5' /> // margin-left: 20px margin-right: 20px
+<div className='pt-2' /> // padding-top: 8px
+```
+
+You can also specify **breakpoints** at which to start applying the spacing:
+
+```tsx static
+// available breakpoints
+const breakpoints: {
+  l: 992;
+  m: 768;
+  s: 576;
+  xl: 1300;
+  xs: 0;
+};
+
+<div className='l:mr-10' /> // apply `margin-right: 64px` for screens wider than 992px
+<div className='s:pt-2' /> // apply `padding-top: 8px` for screens wider than 576px
+```
+
+### Examples
+
+```tsx
+// `<Spacing />` is NOT available in the library. It is used for documentation only.
+<>
+  <div className="mb-5">
+    <Spacing className="mr-6 p-3">margin-right 24px</Spacing>
+    <Spacing className="p-3">Block</Spacing>
+  </div>
+  <div>
+    <Spacing className="l:mr-9 p-3">margin-right 56px on screens wider than 992px</Spacing>
+    <Spacing className="p-3">Block</Spacing>
+  </div>
+</>
+```

--- a/src/content/Spacing/Spacing.tsx
+++ b/src/content/Spacing/Spacing.tsx
@@ -1,0 +1,15 @@
+import React, { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+import { colors } from '../../constants/colors';
+
+const Square = styled.div`
+  background-color: ${colors.greyLightest};
+  box-shadow: 0px 2px 6px 0px rgba(0, 0, 0, 0.1);
+  font-family: monospace;
+  display: inline-block;
+  padding: 10px;
+`;
+
+export default function Spacing(props: HTMLAttributes<HTMLDivElement>) {
+  return <Square {...props} />;
+}


### PR DESCRIPTION
## Summary

![Screenshot 2020-05-08 at 15 53 17](https://user-images.githubusercontent.com/5938217/81412445-243cf600-9144-11ea-8e9b-7b1c97e3aa12.png)

The new **spacing docs** were in the main **Introduction** section.

I decided to move them to their own section ( _as we do with **colours**_ ) so they gain visibility and hopefully, developers start using them.

I re-worded the content a bit as well and extended the examples to hopefully lessen confusion around them. 
