### PR TITLE
fix(zopafooter): set white background color

### DIFF
--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -91,8 +91,40 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   text-align: inherit;
 }
 
+.c7 {
+  background-color: transparent;
+  font-size: inherit;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 600;
+  line-height: inherit;
+  color: #3B46C4;
+  cursor: pointer;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-user-select: auto;
+  -moz-user-select: auto;
+  -ms-user-select: auto;
+  user-select: auto;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 0;
+  border: none;
+}
+
+.c7:hover,
+.c7:active {
+  color: #21247F;
+}
+
+.c7:hover svg path,
+.c7:active svg path {
+  fill: #21247F;
+}
+
 .c0 {
-  margin-bottom: 56px;
+  backgroung-color: #FFFFFF;
+  padding-bottom: 56px;
   padding-top: 64px;
 }
 
@@ -149,37 +181,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   margin: 0;
   padding: 0;
   list-style-type: none;
-}
-
-.c7 {
-  background-color: transparent;
-  font-size: inherit;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 600;
-  line-height: inherit;
-  color: #3B46C4;
-  cursor: pointer;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  user-select: auto;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0;
-  border: none;
-}
-
-.c7:hover,
-.c7:active {
-  color: #21247F;
-}
-
-.c7:hover svg path,
-.c7:active svg path {
-  fill: #21247F;
 }
 
 .c6 {

--- a/src/components/molecules/ZopaFooter/styles/Footer.tsx
+++ b/src/components/molecules/ZopaFooter/styles/Footer.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 import { spacing } from '../../../../constants/spacing';
 import grid from '../../../../constants/grid';
+import { colors } from '../../../..';
 
 export const Footer = styled.footer`
-  margin-bottom: ${spacing[9]};
+  backgroung-color: ${colors.white};
+  padding-bottom: ${spacing[9]};
   padding-top: ${spacing[10]};
 
   @media (min-width: ${grid.breakpoints.l}px) {


### PR DESCRIPTION
## Summary 🍿 

`<ZopaFooter />` will always need to have white background.

#### Changes 🧑‍🏭 
- set white background
- use `padding-bottom` instead of `margin-bottom`