### PR TITLE
fix(button): always render loading button with disabled attribute

### DIFF
--- a/src/components/atoms/Button/Button.md
+++ b/src/components/atoms/Button/Button.md
@@ -52,7 +52,7 @@ import { Button, FlexRow, FlexCol, FlexContainer } from '@zopauk/react-component
 </FlexContainer>;
 ```
 
-- Loading ( _spinner won't show for `styling="link"`_ )
+- Loading ( _spinner won't show for `styling="link"`, loading buttons are always `disabled`_ )
 
 ```tsx
 import { Button, FlexRow, FlexCol, FlexContainer } from '@zopauk/react-components';

--- a/src/components/atoms/Button/Button.test.tsx
+++ b/src/components/atoms/Button/Button.test.tsx
@@ -54,6 +54,11 @@ describe('<Button />', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('renders loading with disabled attribute', () => {
+    const { container } = render(<Button loading>Loading</Button>);
+    expect(container.firstChild).toHaveAttribute('disabled');
+  });
+
   it.each`
     type
     ${'submit'}

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -73,8 +73,14 @@ export const buttonStyle = css<IButtonProps>`
 
   &:disabled {
     cursor: not-allowed;
-    background: ${colors.greyLightest};
-    color: ${colors.grey};
+    ${({ loading }) => {
+      if (!loading) {
+        return css`
+          background: ${colors.greyLightest};
+          color: ${colors.grey};
+        `;
+      }
+    }}
   }
 
   &:active:not(:disabled) {
@@ -89,11 +95,11 @@ const SButton = styled.button<IButtonProps>`
 `;
 
 const Button: React.FC<IButtonProps> = props => {
-  const { children, loading, styling = 'primary', ...rest } = props;
+  const { children, loading, styling = 'primary', disabled, ...rest } = props;
   const isLoading = styling !== 'link' && loading;
 
   return (
-    <SButton styling={styling} {...rest}>
+    <SButton styling={styling} loading={isLoading} disabled={isLoading || disabled} {...rest}>
       {isLoading && (
         <>
           <Spinner negative={styling === 'primary'} size="small" /> {'\u00A0 '}

--- a/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -228,8 +228,6 @@ exports[`<Button /> renders loading as "primary" 1`] = `
 
 .c0:disabled {
   cursor: not-allowed;
-  background: #F7F7F7;
-  color: #818F9B;
 }
 
 .c0:active:not(:disabled) {
@@ -240,6 +238,7 @@ exports[`<Button /> renders loading as "primary" 1`] = `
 
 <button
   class="c0"
+  disabled=""
 >
   <div
     class="c1"
@@ -301,8 +300,6 @@ exports[`<Button /> renders loading as "secondary" 1`] = `
 
 .c0:disabled {
   cursor: not-allowed;
-  background: #F7F7F7;
-  color: #818F9B;
 }
 
 .c0:active:not(:disabled) {
@@ -313,6 +310,7 @@ exports[`<Button /> renders loading as "secondary" 1`] = `
 
 <button
   class="c0"
+  disabled=""
 >
   <div
     class="c1"
@@ -374,8 +372,6 @@ exports[`<Button /> renders loading as "secondary" 2`] = `
 
 .c0:disabled {
   cursor: not-allowed;
-  background: #F7F7F7;
-  color: #818F9B;
 }
 
 .c0:active:not(:disabled) {
@@ -386,6 +382,7 @@ exports[`<Button /> renders loading as "secondary" 2`] = `
 
 <button
   class="c0"
+  disabled=""
 >
   <div
     class="c1"


### PR DESCRIPTION
## Problem 🍿 

A `<Button />` that's rendered with the `loading` option should also be `disabled` (not clickable) but it should keep most of the loading button styles.

## Solution 🔨 

Whenever the button is set to be `loading`, its `disabled` attribute is also set to true.
The disabled `background` and `color` styles are not applied when the button is both `loading` and `disabled`.

![Kapture 2020-05-19 at 17 20 06](https://user-images.githubusercontent.com/7896422/82347098-81b02d00-99f7-11ea-8254-c88ef41e257b.gif)
