### PR TITLE
Enforce naming convention with eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,13 +17,16 @@ module.exports = {
     // -- TYPESCRIPT
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      { selector: 'variableLike', format: ['camelCase', 'UPPER_CASE', 'StrictPascalCase'] },
+      { selector: 'typeLike', format: ['StrictPascalCase'] },
+    ],
     '@typescript-eslint/no-explicit-any': 'off', // TODO: Fix all any
     '@typescript-eslint/no-object-literal-type-assertion': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
-    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       {

--- a/etc/docs/migration-v4.md
+++ b/etc/docs/migration-v4.md
@@ -5,8 +5,8 @@
 # Index
 
 - [Overview](#overview)
-  - [What has changed](#what-has-changed)
-  - [What we added](#new-additions)
+  - [What has changed?](#what-has-changed)
+  - [What we added?](#new-additions)
 
 # Overview 🔭
 
@@ -192,9 +192,13 @@ Also, a new `controls` prop has been added to hide/show `+` and `-` buttons on t
 
 All the existing icons have been removed in favor of font awesome icons.
 We've added an `<Icon />` component which is a thin wrapper around `<FontAwesomeIcon />`.
-`<ZopaIcon />` has been replaced with `<Logo />` component
+`<ZopaIcon />` has been replaced with `<Logo />` component.
 
-## New additions
+### Naming conventions
+
+All the types are interfaces no longer have the prefix `I` or `T` and this is enforced in eslint.
+
+## What we added?
 
 ### 📐 `Spacing`
 

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "util-deprecate": "^1.0.2"
   },
   "peerDependencies": {
+    "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "styled-components": "^4.4.0",
-    "typescript": ">=3.x <4",
-    "@fortawesome/free-solid-svg-icons": "^5.13.0"
+    "typescript": ">=3.x <4"
   },
   "devDependencies": {
     "@commitlint/cli": "8.3.5",

--- a/src/components/atoms/Alert/Alert.tsx
+++ b/src/components/atoms/Alert/Alert.tsx
@@ -4,14 +4,14 @@ import { faCheckCircle, faExclamationCircle, faInfoCircle, faMinusCircle } from 
 import Icon from '../Icon/Icon';
 import { typography } from '../../../constants/typography';
 
-type TSeverity = 'info' | 'alert' | 'warning' | 'success';
+type Severity = 'info' | 'alert' | 'warning' | 'success';
 
-interface IAlertProps {
-  severity?: TSeverity;
+interface AlertProps {
+  severity?: Severity;
 }
 
-type TAlertElementsBySeverity = Record<
-  TSeverity,
+type AlertElementsBySeverity = Record<
+  Severity,
   {
     icon: string;
     background: string;
@@ -20,7 +20,7 @@ type TAlertElementsBySeverity = Record<
   }
 >;
 
-const MAP_BY_SEVERITY: TAlertElementsBySeverity = {
+const MAP_BY_SEVERITY: AlertElementsBySeverity = {
   info: { icon: '#818F9B', background: '#EFEFEF', text: '#2C3236', component: () => <Icon variant={faInfoCircle} /> },
   alert: { icon: '#FF453A', background: '#FFDAD8', text: '#940700', component: () => <Icon variant={faMinusCircle} /> },
   warning: {
@@ -37,7 +37,7 @@ const MAP_BY_SEVERITY: TAlertElementsBySeverity = {
   },
 };
 
-const Wrapper = styled.div<Required<IAlertProps>>`
+const Wrapper = styled.div<Required<AlertProps>>`
   display: flex;
   position: relative;
   padding: 8px 16px 8px 16px;
@@ -60,7 +60,7 @@ const Wrapper = styled.div<Required<IAlertProps>>`
   }
 `;
 
-const IconWrapper = styled.div<Required<IAlertProps>>`
+const IconWrapper = styled.div<Required<AlertProps>>`
   margin-right: 8px;
   font-size: 20px;
   color: ${({ severity }) => MAP_BY_SEVERITY[severity].icon};
@@ -70,7 +70,7 @@ const IconWrapper = styled.div<Required<IAlertProps>>`
   }
 `;
 
-const Alert: FC<IAlertProps> = ({ severity = 'info', children, ...rest }) => {
+const Alert: FC<AlertProps> = ({ severity = 'info', children, ...rest }) => {
   const Icon = MAP_BY_SEVERITY[severity].component;
 
   return (

--- a/src/components/atoms/Badge/Badge.tsx
+++ b/src/components/atoms/Badge/Badge.tsx
@@ -4,18 +4,18 @@ import { colors } from '../../../constants/colors';
 import Text from '../Text/Text';
 import { typography } from '../../../constants/typography';
 
-type TStyling = 'confirmed' | 'default' | 'invalid' | 'waiting';
-type TColorMapField = { bg: string; text: string };
-type TColorMap = { [S in TStyling]: TColorMapField };
+type Styling = 'confirmed' | 'default' | 'invalid' | 'waiting';
+type ColorMapField = { bg: string; text: string };
+type ColorMap = Record<Styling, ColorMapField>;
 
-interface IBadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+interface BadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
   /**
    * The style you want to assign to your badge.
    */
-  styling?: TStyling;
+  styling?: Styling;
 }
 
-const colorMap: TColorMap = {
+const colorMap: ColorMap = {
   confirmed: {
     bg: colors.successLight,
     text: colors.success,
@@ -37,7 +37,7 @@ const colorMap: TColorMap = {
 const StyledBadge = styled(Text).attrs({
   size: 'small',
   forwardedAs: 'span',
-})<IBadgeProps>`
+})<BadgeProps>`
   ${({ styling = 'default' }) => css`
     background-color: ${colorMap[styling].bg};
     color: ${colorMap[styling].text};
@@ -50,7 +50,7 @@ const StyledBadge = styled(Text).attrs({
   font-weight: ${typography.weights.semiBold};
 `;
 
-const Badge: React.FC<IBadgeProps> = ({ children, styling, ...rest }) => {
+const Badge: React.FC<BadgeProps> = ({ children, styling, ...rest }) => {
   return (
     <StyledBadge styling={styling} {...rest}>
       {children}

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -5,10 +5,10 @@ import { typography } from '../../../constants/typography';
 import { spacing } from '../../../constants/spacing';
 import Spinner from '../Spinner/Spinner';
 
-export type TStyling = 'primary' | 'secondary' | 'link';
+export type Styling = 'primary' | 'secondary' | 'link';
 
-export interface IButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  styling?: TStyling;
+export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  styling?: Styling;
   disabled?: boolean;
   loading?: boolean;
   fullWidth?: boolean;
@@ -33,7 +33,7 @@ const colorMap = {
   },
 };
 
-export const buttonStyle = css<IButtonProps>`
+export const buttonStyle = css<ButtonProps>`
   text-decoration: none;
   box-sizing: border-box;
   display: inline-flex;
@@ -92,23 +92,23 @@ export const buttonStyle = css<IButtonProps>`
   }
 `;
 
-const SButton = styled.button<IButtonProps>`
+const ButtonWrapper = styled.button<ButtonProps>`
   ${buttonStyle}
 `;
 
-const Button: React.FC<IButtonProps> = props => {
+const Button: React.FC<ButtonProps> = props => {
   const { children, loading, styling = 'primary', disabled, ...rest } = props;
   const isLoading = styling !== 'link' && loading;
 
   return (
-    <SButton styling={styling} loading={isLoading} disabled={isLoading || disabled} {...rest}>
+    <ButtonWrapper styling={styling} loading={isLoading} disabled={isLoading || disabled} {...rest}>
       {isLoading && (
         <>
           <Spinner negative={styling === 'primary'} size="small" /> {'\u00A0 '}
         </>
       )}
       {children}
-    </SButton>
+    </ButtonWrapper>
   );
 };
 

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { typography } from '../../../constants/typography';
 
 export const DEFAULT_COLOR = colors.greyLight;
 
-export interface IDropdownProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+export interface DropdownProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   /**
    * Border gets red if this is set to true.
    */
@@ -20,7 +20,7 @@ export interface IDropdownProps extends React.SelectHTMLAttributes<HTMLSelectEle
 
 export const Option = styled.option``;
 
-const StyledDropdown = styled.select<IDropdownProps>`
+const StyledDropdown = styled.select<DropdownProps>`
   appearance: none;
   background: transparent url(${chevronDown}) no-repeat calc(100% - 13px) center;
   background-size: 13px;
@@ -39,6 +39,6 @@ const StyledDropdown = styled.select<IDropdownProps>`
   }
 `;
 
-const Dropdown = forwardRef<HTMLSelectElement, IDropdownProps>((props, ref) => <StyledDropdown ref={ref} {...props} />);
+const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>((props, ref) => <StyledDropdown ref={ref} {...props} />);
 
 export default Dropdown;

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -1,16 +1,16 @@
 import React, { FC } from 'react';
 import styled, { css } from 'styled-components';
 import { typography } from '../../../constants/typography';
-import { colors, TColors } from '../../../constants/colors';
+import { colors, Colors } from '../../../constants/colors';
 import grid from '../../../constants/grid';
 
-type THeadingTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
+type HeadingTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
 
-export interface IStyledHeadingProps {
+export interface StyledHeadingProps {
   /**
    * The HTML5 tag you want to render your heading, it's used to determine the size of the heading as well.
    */
-  as: THeadingTags;
+  as: HeadingTags;
   /**
    * Override the default size assigned to the rendered HTML tag.
    * @default `as`
@@ -20,7 +20,7 @@ export interface IStyledHeadingProps {
    * Accepts a subset of the Zopa brand colors. Same as the ones accepted by `<Text />`.
    * @default `colors.greyDarkest`
    */
-  color?: TColors['white'] | TColors['grey'] | TColors['greyDarkest'];
+  color?: Colors['white'] | Colors['grey'] | Colors['greyDarkest'];
   /**
    * Where the rendered text should be aligned to.
    * @default 'inherit'
@@ -52,7 +52,7 @@ const letterSpacingMap = {
   h6: '-0.01px',
 };
 
-const Heading = styled.h1<IStyledHeadingProps>`
+const Heading = styled.h1<StyledHeadingProps>`
   ${({ as, size }) => {
     const tag = size || (as === 'span' ? 'h4' : as);
     return css`
@@ -83,6 +83,6 @@ const Heading = styled.h1<IStyledHeadingProps>`
 `;
 
 // TODO: Styleguidist to be able to locate styled components. See #147.
-export const StyleguidistHeading: FC<IStyledHeadingProps> = props => <Heading {...props} />;
+export const StyleguidistHeading: FC<StyledHeadingProps> = props => <Heading {...props} />;
 
 export default Heading;

--- a/src/components/atoms/InputLabel/InputLabel.tsx
+++ b/src/components/atoms/InputLabel/InputLabel.tsx
@@ -3,14 +3,14 @@ import styled from 'styled-components';
 import { typography } from '../../../constants/typography';
 import { colors } from '../../../constants/colors';
 
-export interface IInputLabelProps extends HTMLAttributes<HTMLLabelElement> {
+export interface InputLabelProps extends HTMLAttributes<HTMLLabelElement> {
   /**
    * Define the associated input identifier
    */
   htmlFor: string;
 }
 
-const InputLabel = styled.label<IInputLabelProps>`
+const InputLabel = styled.label<InputLabelProps>`
   display: block;
   margin: 0 0 10px;
   letter-spacing: 0;
@@ -21,6 +21,6 @@ const InputLabel = styled.label<IInputLabelProps>`
 `;
 
 // TODO: Styleguidist to be able to locate styled components. See #147.
-export const StyleguidistInputLabel: FC<IInputLabelProps> = props => <InputLabel {...props} />;
+export const StyleguidistInputLabel: FC<InputLabelProps> = props => <InputLabel {...props} />;
 
 export default InputLabel;

--- a/src/components/atoms/InputRange/InputRange.tsx
+++ b/src/components/atoms/InputRange/InputRange.tsx
@@ -3,7 +3,7 @@ import { calculateTrackPosition } from './helpers';
 import { Button, Icon, Input, Wrapper } from './styles';
 import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 
-export interface IInputRange extends Omit<InputHTMLAttributes<HTMLInputElement>, 'defaultValue' | 'onChange'> {
+export interface InputRange extends Omit<InputHTMLAttributes<HTMLInputElement>, 'defaultValue' | 'onChange'> {
   value: number;
   onChange: (value: number) => void;
   min?: number;
@@ -12,7 +12,7 @@ export interface IInputRange extends Omit<InputHTMLAttributes<HTMLInputElement>,
   controls?: boolean;
 }
 
-const InputRange = forwardRef<HTMLInputElement, IInputRange>(
+const InputRange = forwardRef<HTMLInputElement, InputRange>(
   ({ min = 0, max = 100, step = 1, controls = false, value, onChange, ...otherProps }, ref) => {
     const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
       onChange(Number(e.target.value));

--- a/src/components/atoms/InputRange/helpers/index.ts
+++ b/src/components/atoms/InputRange/helpers/index.ts
@@ -1,10 +1,10 @@
-interface ITrackPosition {
+interface TrackPosition {
   min?: number;
   max?: number;
   value: number;
 }
 
-export const calculateTrackPosition = ({ min = 0, max = 100, value }: ITrackPosition) => {
+export const calculateTrackPosition = ({ min = 0, max = 100, value }: TrackPosition) => {
   if (max < min) {
     return 0;
   }

--- a/src/components/atoms/InputRange/styles/Button.tsx
+++ b/src/components/atoms/InputRange/styles/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import grid from '../../../../constants/grid';
-import { IButtonProps, buttonStyle } from '../../Button/Button';
+import { ButtonProps, buttonStyle } from '../../Button/Button';
 
 const ButtonWrapper = styled.div`
   padding: 12px;
@@ -10,7 +10,7 @@ const ButtonWrapper = styled.div`
   }
 `;
 
-const SButton = styled.button`
+const StyledButton = styled.button`
   ${buttonStyle};
   display: flex;
   justify-content: center;
@@ -26,10 +26,10 @@ const SButton = styled.button`
   }
 `;
 
-export const Button = (props: IButtonProps) => {
+export const Button = (props: ButtonProps) => {
   return (
     <ButtonWrapper>
-      <SButton {...props} />
+      <StyledButton {...props} />
     </ButtonWrapper>
   );
 };

--- a/src/components/atoms/InputRange/styles/Input.tsx
+++ b/src/components/atoms/InputRange/styles/Input.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { colors } from '../../../../constants/colors';
 import grid from '../../../../constants/grid';
 import arrowsAltH from '../../../../content/images/arrows-alt-h.svg';
-import { IInputRange } from '../InputRange';
+import { InputRange } from '../InputRange';
 
 const trackHeight = 8;
 const thumbDiameter = 50;
@@ -39,7 +39,7 @@ const ThumbStylesFocus = css`
 `;
 
 export const Input = styled.input<
-  Omit<IInputRange, 'onChange'> & { trackPosition: number; onChange: (e: ChangeEvent<HTMLInputElement>) => void }
+  Omit<InputRange, 'onChange'> & { trackPosition: number; onChange: (e: ChangeEvent<HTMLInputElement>) => void }
 >`
   -webkit-appearance: none;
   width: 100%;

--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import { colors } from '../../../constants/colors';
 import { typography } from '../../../constants/typography';
 import { getBorderColorByStatus } from '../../../helpers/utils';
-import { IInput } from '../../types';
+import { InputProps } from '../../types';
 
-const Input = styled.input<IInput>`
+const Input = styled.input<InputProps>`
   border: 2px solid ${getBorderColorByStatus};
   border-radius: 4px;
   padding: 0 10px;
@@ -32,7 +32,7 @@ const Input = styled.input<IInput>`
   }
 `;
 
-const InputText = forwardRef<HTMLInputElement, IInput>((props, ref) => {
+const InputText = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return <Input {...props} ref={ref} />;
 });
 

--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { colors } from '../../../constants/colors';
 import { typography } from '../../../constants/typography';
 
-export interface ILinkProps
+export interface LinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
     React.RefAttributes<HTMLAnchorElement> {
   target?: '_blank';
@@ -12,7 +12,7 @@ export interface ILinkProps
   showTargetIcon?: boolean;
 }
 
-export const linkStyle = css<ILinkProps>`
+export const linkStyle = css<LinkProps>`
   background-color: transparent;
   font-size: inherit;
   font-family: ${typography.primary};
@@ -36,11 +36,11 @@ export const linkStyle = css<ILinkProps>`
   }
 `;
 
-const SLink = styled.a<ILinkProps>`
+const StyledLink = styled.a<LinkProps>`
   ${linkStyle}
 `;
 
-const STargetIcon = styled.svg`
+const TargetIconWrapper = styled.svg`
   margin-left: 6px;
   top: 2px;
   position: relative;
@@ -48,22 +48,22 @@ const STargetIcon = styled.svg`
 
 const TargetIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
-    <STargetIcon xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+    <TargetIconWrapper xmlns="http://www.w3.org/2000/svg" width="15" height="15">
       <g fill={props.color || colors.actionPlain}>
         <path d="M2.6 4H0v11h11v-2.6H2.6z" />
         <path d="M4 0v11h11V0H4zm9.7 1.3v8.4L5.2 1.3h8.5z" />
       </g>
-    </STargetIcon>
+    </TargetIconWrapper>
   );
 };
 
-const Link = React.forwardRef<HTMLAnchorElement, ILinkProps>(
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   ({ children, color = colors.actionPlain, target, showTargetIcon = true, ...rest }, ref) => {
     return (
-      <SLink ref={ref} color={color} target={target} {...rest}>
+      <StyledLink ref={ref} color={color} target={target} {...rest}>
         {children}
         {target === '_blank' && showTargetIcon && <TargetIcon color={color} />}
-      </SLink>
+      </StyledLink>
     );
   },
 );

--- a/src/components/atoms/SidekickCard/SidekickCard.tsx
+++ b/src/components/atoms/SidekickCard/SidekickCard.tsx
@@ -6,11 +6,11 @@ import triumph from '../../../content/images/triumph-icon.svg';
 import verified from '../../../content/images/valid-icon.svg';
 import { maxMedia } from '../../../helpers/responsiveness';
 
-export type TSidekickCardTypes = 'triumph' | 'verified' | 'alert';
+export type SidekickCardTypes = 'triumph' | 'verified' | 'alert';
 
-export interface ISidekickCardProps {
+export interface SidekickCardProps {
   /** Type of SidekickCard to render */
-  type: TSidekickCardTypes;
+  type: SidekickCardTypes;
 }
 
 const sidekickTypeColors = {
@@ -25,7 +25,7 @@ const typeIcons = {
   verified,
 };
 
-const SidekickCard = styled.div<ISidekickCardProps>`
+const SidekickCard = styled.div<SidekickCardProps>`
   border-radius: 4px;
   background: url(${({ type }) => typeIcons[type]}) 24px 48px no-repeat ${colors.white};
   padding: 48px 48px 48px 80px;
@@ -39,6 +39,6 @@ const SidekickCard = styled.div<ISidekickCardProps>`
 `;
 
 // TODO: Styleguidist to be able to locate styled components. See #147.
-export const StyleguidistSidekickCard: FC<ISidekickCardProps> = props => <SidekickCard {...props} />;
+export const StyleguidistSidekickCard: FC<SidekickCardProps> = props => <SidekickCard {...props} />;
 
 export default SidekickCard;

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { colors } from '../../../constants/colors';
 
-export interface ISpinnerProps {
+export interface SpinnerProps {
   /**
    * Size of the spinner
    * @default 'standard'
@@ -24,7 +24,7 @@ const spin = keyframes`
   }
 `;
 
-const StyledSpinner = styled.div<ISpinnerProps>`
+const StyledSpinner = styled.div<SpinnerProps>`
   ${({ size = 'standard', negative = false }) => css`
     width: ${size === 'small' ? 20 : 40}px;
     height: ${size === 'small' ? 20 : 40}px;
@@ -35,6 +35,6 @@ const StyledSpinner = styled.div<ISpinnerProps>`
   animation: ${spin} 1.2s linear infinite;
 `;
 
-const Spinner: React.FC<ISpinnerProps> = props => <StyledSpinner {...props} />;
+const Spinner: React.FC<SpinnerProps> = props => <StyledSpinner {...props} />;
 
 export default Spinner;

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -2,9 +2,9 @@ import React, { HTMLAttributes } from 'react';
 import { FC } from 'react';
 import styled from 'styled-components';
 import { typography } from '../../../constants/typography';
-import { colors, TColors } from '../../../constants/colors';
+import { colors, Colors } from '../../../constants/colors';
 
-export interface ITextProps extends HTMLAttributes<HTMLSpanElement> {
+export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
   /**
    * The weight of the rendered text.
    * @default 'regular'
@@ -35,12 +35,12 @@ export interface ITextProps extends HTMLAttributes<HTMLSpanElement> {
    * @default `colors.greyDarkest`
    */
   color?:
-    | TColors['white']
-    | TColors['grey']
-    | TColors['greyDark']
-    | TColors['greyDarkest']
-    | TColors['success']
-    | TColors['alert'];
+    | Colors['white']
+    | Colors['grey']
+    | Colors['greyDark']
+    | Colors['greyDarkest']
+    | Colors['success']
+    | Colors['alert'];
 }
 
 const lineHeightMap = {
@@ -49,7 +49,7 @@ const lineHeightMap = {
   small: '18px',
 };
 
-const Text = styled.span<ITextProps>`
+const Text = styled.span<TextProps>`
   margin: 0;
   letter-spacing: 0;
   color: ${({ color = colors.greyDarkest }) => color};
@@ -70,7 +70,7 @@ const Text = styled.span<ITextProps>`
   `}
 `;
 
-const TextWrap: FC<ITextProps> = React.forwardRef<HTMLSpanElement, ITextProps>((props, ref) => (
+const TextWrap: FC<TextProps> = React.forwardRef<HTMLSpanElement, TextProps>((props, ref) => (
   <Text {...props} ref={ref} />
 ));
 

--- a/src/components/layout/FlexCol/FlexCol.tsx
+++ b/src/components/layout/FlexCol/FlexCol.tsx
@@ -1,30 +1,30 @@
 import React, { FC } from 'react';
 import styled, { css } from 'styled-components';
-import grid, { TGridBreakpoints } from '../../../constants/grid';
+import grid, { GridBreakpoints } from '../../../constants/grid';
 
-export type TAlignSelf = 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'auto';
-export type TColWidth = number | 'fill' | 'auto' | 'hidden';
+export type AlignSelf = 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'auto';
+export type ColWidth = number | 'fill' | 'auto' | 'hidden';
 
-export interface IFlexColProps {
-  align?: TAlignSelf;
+export interface FlexColProps {
+  align?: AlignSelf;
   cols?: number;
   gutter?: number;
-  l?: TColWidth;
-  m?: TColWidth;
-  s?: TColWidth;
-  xl?: TColWidth;
-  xs?: TColWidth;
+  l?: ColWidth;
+  m?: ColWidth;
+  s?: ColWidth;
+  xl?: ColWidth;
+  xs?: ColWidth;
 }
 
-export interface IFlexCol extends React.HTMLAttributes<HTMLDivElement>, IFlexColProps {}
+export interface FlexCol extends React.HTMLAttributes<HTMLDivElement>, FlexColProps {}
 
-const genHidden = (breakpoint: TGridBreakpoints) => css`
+const genHidden = (breakpoint: GridBreakpoints) => css`
   @media (min-width: ${grid.breakpoints[breakpoint]}px) {
     display: none;
   }
 `;
 
-const genFillWidth = (breakpoint: TGridBreakpoints) => css`
+const genFillWidth = (breakpoint: GridBreakpoints) => css`
   @media (min-width: ${grid.breakpoints[breakpoint]}px) {
     display: block;
     flex-basis: 0;
@@ -33,7 +33,7 @@ const genFillWidth = (breakpoint: TGridBreakpoints) => css`
   }
 `;
 
-const genAutoWidth = (breakpoint: TGridBreakpoints) => css`
+const genAutoWidth = (breakpoint: GridBreakpoints) => css`
   @media (min-width: ${grid.breakpoints[breakpoint]}px) {
     display: block;
     flex: 0 0 auto;
@@ -42,7 +42,7 @@ const genAutoWidth = (breakpoint: TGridBreakpoints) => css`
   }
 `;
 
-const genRelativeWidth = (breakpoint: TGridBreakpoints, colWidth: TColWidth, cols: IFlexColProps['cols']) => css`
+const genRelativeWidth = (breakpoint: GridBreakpoints, colWidth: ColWidth, cols: FlexColProps['cols']) => css`
   @media (min-width: ${grid.breakpoints[breakpoint]}px) {
     display: block;
     ${typeof colWidth === 'number' && typeof cols === 'number'
@@ -54,7 +54,7 @@ const genRelativeWidth = (breakpoint: TGridBreakpoints, colWidth: TColWidth, col
   }
 `;
 
-const getWidth = (breakpoint: TGridBreakpoints, colWidth: TColWidth, cols: IFlexColProps['cols']) => {
+const getWidth = (breakpoint: GridBreakpoints, colWidth: ColWidth, cols: FlexColProps['cols']) => {
   switch (colWidth) {
     case 'hidden':
       return genHidden(breakpoint);
@@ -67,7 +67,7 @@ const getWidth = (breakpoint: TGridBreakpoints, colWidth: TColWidth, cols: IFlex
   }
 };
 
-const StyledFlexCol = styled.div<IFlexCol>`
+const StyledFlexCol = styled.div<FlexCol>`
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -78,17 +78,17 @@ const StyledFlexCol = styled.div<IFlexCol>`
     Object.keys(grid.breakpoints)
       .sort((a, b) => {
         // Note: TS infers `a` and `b` as strings, hence the type assertion here.
-        return grid.breakpoints[a as TGridBreakpoints] - grid.breakpoints[b as TGridBreakpoints];
+        return grid.breakpoints[a as GridBreakpoints] - grid.breakpoints[b as GridBreakpoints];
       })
       .filter(breakpoint => Object.keys(props).includes(breakpoint))
       .map(breakpoint => {
         // Note: TS infers `breakpoint` as string again... hence more type assertion here.
-        const colWidth = props[breakpoint as TGridBreakpoints] || 'auto';
-        return getWidth(breakpoint as TGridBreakpoints, colWidth, props.cols);
+        const colWidth = props[breakpoint as GridBreakpoints] || 'auto';
+        return getWidth(breakpoint as GridBreakpoints, colWidth, props.cols);
       })}
 `;
 
-const FlexCol: FC<IFlexCol> = props => <StyledFlexCol {...props} />;
+const FlexCol: FC<FlexCol> = props => <StyledFlexCol {...props} />;
 
 FlexCol.defaultProps = {
   align: 'auto',

--- a/src/components/layout/FlexContainer/FlexContainer.tsx
+++ b/src/components/layout/FlexContainer/FlexContainer.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import styled from 'styled-components';
 import grid from '../../../constants/grid';
 
-export interface IFlexContainerProps {
+export interface FlexContainerGutter {
   gutter?: number;
 }
 
-export interface IFlexContainer extends React.HTMLAttributes<HTMLDivElement>, IFlexContainerProps {}
+export interface FlexContainerProps extends React.HTMLAttributes<HTMLDivElement>, FlexContainerGutter {}
 
-const defaultProps: Partial<IFlexContainer> = {
+const defaultProps: Partial<FlexContainerProps> = {
   gutter: grid.gutter,
 };
 
-const StyledFlexContainer = styled.div<IFlexContainer>`
+const StyledFlexContainer = styled.div<FlexContainerProps>`
   width: 100%;
   max-width: 100%;
   padding-right: ${props => props.gutter}px;
@@ -33,7 +33,7 @@ const StyledFlexContainer = styled.div<IFlexContainer>`
   }
 `;
 
-const FlexContainer = (props: IFlexContainer) => <StyledFlexContainer {...props} />;
+const FlexContainer = (props: FlexContainerProps) => <StyledFlexContainer {...props} />;
 FlexContainer.defaultProps = defaultProps;
 
 export default FlexContainer;

--- a/src/components/layout/FlexRow/FlexRow.tsx
+++ b/src/components/layout/FlexRow/FlexRow.tsx
@@ -2,16 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import grid from '../../../constants/grid';
 
-export type TFlexAlignmentValues =
-  | 'stretch'
-  | 'center'
-  | 'flex-start'
-  | 'flex-end'
-  | 'baseline'
-  | 'initial'
-  | 'inherit';
+export type FlexAlignmentValues = 'stretch' | 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'initial' | 'inherit';
 
-export type TFlexJustificationValues =
+export type FlexJustificationValues =
   | 'flex-start'
   | 'flex-end'
   | 'center'
@@ -20,19 +13,19 @@ export type TFlexJustificationValues =
   | 'initial'
   | 'inherit';
 
-export type TFlexDirectionValues = 'row' | 'row-reverse' | 'column' | 'column-reverse' | 'initial' | 'inherit';
+export type FlexDirectionValues = 'row' | 'row-reverse' | 'column' | 'column-reverse' | 'initial' | 'inherit';
 
-export interface IFlexRowProps {
-  align?: TFlexAlignmentValues;
+export interface FlexRowProps {
+  align?: FlexAlignmentValues;
   cols?: number;
   gutter?: number;
-  justify?: TFlexJustificationValues;
-  direction?: TFlexDirectionValues;
+  justify?: FlexJustificationValues;
+  direction?: FlexDirectionValues;
 }
 
-export interface IFlexRow extends React.HTMLAttributes<HTMLDivElement>, IFlexRowProps {}
+export interface FlexRow extends React.HTMLAttributes<HTMLDivElement>, FlexRowProps {}
 
-const defaultProps: Partial<IFlexRow> = {
+const defaultProps: Partial<FlexRow> = {
   align: 'flex-start',
   cols: grid.cols,
   gutter: grid.gutter,
@@ -40,7 +33,7 @@ const defaultProps: Partial<IFlexRow> = {
   direction: 'row',
 };
 
-const StyledFlexRow = styled.div<IFlexRow>`
+const StyledFlexRow = styled.div<FlexRow>`
   display: flex;
   flex-wrap: wrap;
   flex-direction: ${props => props.direction};
@@ -50,7 +43,7 @@ const StyledFlexRow = styled.div<IFlexRow>`
   align-items: ${props => props.align};
 `;
 
-const FlexRow: React.FunctionComponent<IFlexRow> = ({ children, ...props }) => {
+const FlexRow: React.FunctionComponent<FlexRow> = ({ children, ...props }) => {
   const childrenWithProps = React.Children.toArray(children)
     .filter(child => !!child)
     .map(child => React.cloneElement(child as any, { gutter: props.gutter, cols: props.cols }));

--- a/src/components/layout/SizedContainer/SizedContainer.tsx
+++ b/src/components/layout/SizedContainer/SizedContainer.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TContainerSizes } from '../../types';
+import { ContainerSizes } from '../../types';
 
-export interface ISizedContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  size?: TContainerSizes;
+export interface SizedContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: ContainerSizes;
 }
 
-const mapSizeToMaxWith: { [index in TContainerSizes]: string } = {
+const mapSizeToMaxWith: Record<ContainerSizes, string> = {
   fullLength: '100%',
   long: '336px',
   medium: '222px',
   short: '148px',
-};
+} as const;
 
-const Container = styled.div<ISizedContainerProps>`
+const Container = styled.div<SizedContainerProps>`
   max-width: ${({ size = 'medium' }) => mapSizeToMaxWith[size]};
   width: 100%;
 `;
 
-const SizedContainer = ({ size = 'fullLength', ...rest }: ISizedContainerProps) => <Container size={size} {...rest} />;
+const SizedContainer = ({ size = 'fullLength', ...rest }: SizedContainerProps) => <Container size={size} {...rest} />;
 
 export default SizedContainer;

--- a/src/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/src/components/molecules/CheckboxField/CheckboxField.tsx
@@ -6,9 +6,9 @@ import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
 import { typography } from '../../../constants/typography';
-import { IField, IInput } from '../../types';
+import { FieldProps, InputProps } from '../../types';
 
-export interface ICheckboxFieldProps extends IField, IInput {
+export interface CheckboxFieldProps extends FieldProps, InputProps {
   name: string;
 }
 
@@ -21,7 +21,7 @@ const zoomOut = keyframes`
   }
 `;
 
-const Input = styled.input<IInput>`
+const Input = styled.input<InputProps>`
   left: -100%;
   opacity: 0;
   z-index: -1;
@@ -91,7 +91,7 @@ const FieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const CheckboxField = (props: ICheckboxFieldProps) => {
+const CheckboxField = (props: CheckboxFieldProps) => {
   const { label, errorMessage, className, inputSize, name, ...rest } = props;
 
   return (

--- a/src/components/molecules/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/molecules/CheckboxGroupField/CheckboxGroupField.tsx
@@ -9,16 +9,16 @@ const CheckboxWrapper = styled.div`
   padding: 4px 0;
 `;
 
-interface ICheckboxGroupFieldItem<Val extends Record<string, boolean>> {
+interface CheckboxGroupFieldItem<Val extends Record<string, boolean>> {
   label: string;
   name: keyof Val;
   defaultChecked?: boolean;
   disabled?: boolean;
 }
 
-export interface ICheckboxGroupFieldProps<Val extends Record<string, boolean>> {
+export interface CheckboxGroupFieldProps<Val extends Record<string, boolean>> {
   label: string;
-  items: ICheckboxGroupFieldItem<Val>[];
+  items: CheckboxGroupFieldItem<Val>[];
   onChange?: (value: Val) => void;
   disabled?: boolean;
   value?: Val;
@@ -30,7 +30,7 @@ const CheckboxGroupField = <Val extends Record<string, boolean>>({
   onChange,
   value,
   disabled,
-}: ICheckboxGroupFieldProps<Val>) => {
+}: CheckboxGroupFieldProps<Val>) => {
   const [innerValue, setInnerValue] = useState<Val>(
     items.reduce(
       (acc, { name, defaultChecked }) => ({

--- a/src/components/molecules/DropdownField/DropdownField.tsx
+++ b/src/components/molecules/DropdownField/DropdownField.tsx
@@ -5,9 +5,9 @@ import Text from '../../atoms/Text/Text';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import Dropdown from '../../atoms/Dropdown/Dropdown';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
-import { ISelect, IField } from '../../types';
+import { SelectProps, FieldProps } from '../../types';
 
-export interface IDropdownFieldProps extends IField, ISelect {
+export interface DropdownFieldProps extends FieldProps, SelectProps {
   /**
    * Size attribute for the rendered HTML `<select>` element
    */
@@ -15,11 +15,11 @@ export interface IDropdownFieldProps extends IField, ISelect {
   name: string;
 }
 
-export interface ILabelProps {
+export interface LabelProps {
   withHelpText?: boolean;
 }
 
-const Label = styled(InputLabel)<ILabelProps>`
+const Label = styled(InputLabel)<LabelProps>`
   ${({ withHelpText }) => withHelpText && `margin-bottom: 0;`}
 `;
 
@@ -32,7 +32,7 @@ const HelpText = styled(Text)`
   display: block;
 `;
 
-const DropdownField = forwardRef<HTMLSelectElement, IDropdownFieldProps>(
+const DropdownField = forwardRef<HTMLSelectElement, DropdownFieldProps>(
   ({ label, errorMessage, inputSize, helpText, htmlSelectSize, name, ...rest }, ref) => (
     <>
       {label && (

--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
@@ -7,21 +7,21 @@ import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
 import Icon from '../../atoms/Icon/Icon';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
-import { IField, IInput } from '../../types';
+import { FieldProps, InputProps } from '../../types';
 import Option from './Option';
-import Options, { IOptionsListProps } from './Options';
-import { ISearchInputProps, SearchInput, SearchArrowWrap, SearchInputWrap } from './SearchInput';
+import Options, { OptionsListProps } from './Options';
+import { SearchInputProps, SearchInput, SearchArrowWrap, SearchInputWrap } from './SearchInput';
 
-export interface IDropdownItem {
+export interface DropdownItem {
   value: string;
 }
 
-export interface IDropdownFilteredProps
-  extends DownshiftProps<IDropdownItem>,
-    ISearchInputProps,
-    IOptionsListProps,
-    Omit<IInput, 'onSelect' | 'onChange' | 'children'>,
-    IField {
+export interface DropdownFilteredProps
+  extends DownshiftProps<DropdownItem>,
+    SearchInputProps,
+    OptionsListProps,
+    Omit<InputProps, 'onSelect' | 'onChange' | 'children'>,
+    FieldProps {
   /**
    * Native props for the native label element.
    */
@@ -29,14 +29,14 @@ export interface IDropdownFilteredProps
   /**
    * Items for the options
    */
-  items: IDropdownItem[];
+  items: DropdownItem[];
 }
 
 const FieldError = styled(ErrorMessage)`
   margin-top: 5px;
 `;
 
-const DropdownFiltered = (props: IDropdownFilteredProps) => {
+const DropdownFiltered = (props: DropdownFilteredProps) => {
   const {
     errorMessage,
     items = [],
@@ -70,7 +70,7 @@ const DropdownFiltered = (props: IDropdownFilteredProps) => {
           openMenu,
           closeMenu,
           selectedItem,
-        }: ControllerStateAndHelpers<IDropdownItem>) => {
+        }: ControllerStateAndHelpers<DropdownItem>) => {
           const filteredResults = items.filter(({ value }) => searchMatch(value, inputValue || ''));
 
           const showError = errorMessage && !isOpen;

--- a/src/components/molecules/DropdownFiltered/Option.ts
+++ b/src/components/molecules/DropdownFiltered/Option.ts
@@ -2,12 +2,12 @@ import { typography } from '../../../constants/typography';
 import { colors } from '../../../constants/colors';
 import styled, { css } from 'styled-components';
 
-interface IOption extends React.HTMLAttributes<HTMLDivElement> {
+interface OptionProps extends React.HTMLAttributes<HTMLDivElement> {
   highLighted?: boolean;
   selected?: boolean;
 }
 
-const Option = styled.div<IOption>`
+const Option = styled.div<OptionProps>`
   cursor: pointer;
   padding: 8px;
   line-height: 32px;

--- a/src/components/molecules/DropdownFiltered/Options.ts
+++ b/src/components/molecules/DropdownFiltered/Options.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 import { colors } from '../../../constants/colors';
 
-export interface IOptionsListProps {
+export interface OptionsListProps {
   optionsListMaxHeight?: string;
 }
 
-const Options = styled.div<IOptionsListProps>`
+const Options = styled.div<OptionsListProps>`
   z-index: 1;
   width: 100%;
   background: ${colors.white};

--- a/src/components/molecules/DropdownFiltered/SearchInput.ts
+++ b/src/components/molecules/DropdownFiltered/SearchInput.ts
@@ -1,13 +1,13 @@
 import styled, { css } from 'styled-components';
 import { colors } from '../../../constants/colors';
 import InputText from '../../atoms/InputText/InputText';
-import { IInput } from '../../types';
+import { InputProps } from '../../types';
 
-export interface ISearchInputProps {
+export interface SearchInputProps {
   isOpen?: boolean;
 }
 
-export const SearchInput = styled(InputText)<ISearchInputProps & IInput>`
+export const SearchInput = styled(InputText)<SearchInputProps & InputProps>`
   margin: 0;
   padding: 8px 32px 8px 16px;
   ${({ hasError }) => !hasError && 'margin-bottom: 0'};

--- a/src/components/molecules/ExpiryModal/ExpiryModal.tsx
+++ b/src/components/molecules/ExpiryModal/ExpiryModal.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import Modal, { TModalProps } from '../Modal/Modal';
+import Modal, { ModalProps } from '../Modal/Modal';
 import Text from '../../atoms/Text/Text';
 import Heading from '../../atoms/Heading/Heading';
 import Button from '../../atoms/Button/Button';
 
-interface IExpiryModalProps extends TModalProps {
+interface ExpiryModalProps extends ModalProps {
   /**
    * A callback that fires once the user clicks on 'Log out'
    **/
@@ -31,7 +31,7 @@ const SessionHint = styled(Text).attrs({
   margin-bottom: 40px;
 `;
 
-export default function ExpiryModal({ onEndSession, onKeepSession, ...rest }: IExpiryModalProps) {
+export default function ExpiryModal({ onEndSession, onKeepSession, ...rest }: ExpiryModalProps) {
   return (
     <Modal {...rest}>
       <ModalInner>

--- a/src/components/molecules/Help/Help.tsx
+++ b/src/components/molecules/Help/Help.tsx
@@ -31,11 +31,11 @@ const OpeningHoursWrapper = styled.div`
   max-width: 350px;
 `;
 
-export interface IHelpProps extends HTMLAttributes<HTMLDivElement> {
+export interface HelpProps extends HTMLAttributes<HTMLDivElement> {
   email: string;
 }
 
-const Help: React.FC<IHelpProps> = ({ email, ...rest }) => (
+const Help: React.FC<HelpProps> = ({ email, ...rest }) => (
   <HelpWrap {...rest}>
     <HelpContent>
       <FlexRow gutter={16}>

--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactModal from 'react-modal';
 import ModalStyles from './ModalStyles/ModalStyles';
 
-export type TModalProps = ReactModal.Props;
+export type ModalProps = ReactModal.Props;
 
-class Modal extends React.PureComponent<TModalProps> {
+class Modal extends React.PureComponent<ModalProps> {
   public static Styles = ModalStyles;
   public static setAppElement = ReactModal.setAppElement;
 

--- a/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
+++ b/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
@@ -2,14 +2,14 @@ import { createGlobalStyle } from 'styled-components';
 
 import { colors } from '../../../../constants/colors';
 
-export interface IModalStylesProps {
+export interface ModalStylesProps {
   /**
    * The CSS `z-index` value to be applied on the rendered modal.
    */
   zIndex?: number;
 }
 
-const ModalStyles = createGlobalStyle<IModalStylesProps>`
+const ModalStyles = createGlobalStyle<ModalStylesProps>`
   .zopa-modal-body--open {
     overflow: hidden;
   }

--- a/src/components/molecules/Progress/Progress.tsx
+++ b/src/components/molecules/Progress/Progress.tsx
@@ -4,19 +4,19 @@ import { colors } from '../../../constants/colors';
 import { typography } from '../../../constants/typography';
 import Text from '../../atoms/Text/Text';
 
-export interface IProgressionStyleProps {
+export interface ProgressionStyleProps {
   width?: string;
   progressColor?: string;
 }
 
-export interface IProgressProps extends IProgressionStyleProps, HTMLAttributes<HTMLDivElement> {
+export interface ProgressProps extends ProgressionStyleProps, HTMLAttributes<HTMLDivElement> {
   totalSteps: number;
   currentStep: number;
   style?: CSSProperties;
   withStep?: boolean;
 }
 
-const SProgressBar = styled.div`
+const ProgressBar = styled.div`
   position: relative;
   width: 100%;
   border-radius: 100px;
@@ -24,7 +24,7 @@ const SProgressBar = styled.div`
   height: 4px;
 `;
 
-const SProgression = styled.div<IProgressionStyleProps>`
+const Progression = styled.div<ProgressionStyleProps>`
   width: ${({ width }) => width};
   position: relative;
   border-radius: 100px;
@@ -43,16 +43,16 @@ const SProgression = styled.div<IProgressionStyleProps>`
   }
 `;
 
-const Progress: React.FC<IProgressProps> = ({ totalSteps, currentStep, withStep = true, progressColor, ...rest }) => (
-  <SProgressBar {...rest}>
-    <SProgression width={`${(100 / totalSteps) * currentStep}%`} progressColor={progressColor}>
+const Progress: React.FC<ProgressProps> = ({ totalSteps, currentStep, withStep = true, progressColor, ...rest }) => (
+  <ProgressBar {...rest}>
+    <Progression width={`${(100 / totalSteps) * currentStep}%`} progressColor={progressColor}>
       {withStep && (
         <Text size="small">
           Step {currentStep} of {totalSteps}
         </Text>
       )}
-    </SProgression>
-  </SProgressBar>
+    </Progression>
+  </ProgressBar>
 );
 
 export default Progress;

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -4,7 +4,7 @@ import { colors } from '../../../constants/colors';
 import { getBorderColorByStatus } from '../../../helpers/utils';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
-import { IField, IInputStatus, IInput } from '../../types';
+import { FieldProps, InputStatus, InputProps } from '../../types';
 
 const zoomIn = keyframes`
   from {
@@ -24,7 +24,7 @@ const FieldContainer = styled(SizedContainer)`
   }
 `;
 
-const Label = styled(InputLabel)<IInputStatus>`
+const Label = styled(InputLabel)<InputStatus>`
   display: flex;
   line-height: 1.4;
   color: ${colors.greyDarkest};
@@ -52,7 +52,7 @@ const Label = styled(InputLabel)<IInputStatus>`
   }
 `;
 
-const Input = styled.input<IInputStatus>`
+const Input = styled.input<InputStatus>`
   width: 1px;
   height: 1px;
   opacity: 0;
@@ -102,9 +102,9 @@ const Input = styled.input<IInputStatus>`
   }
 `;
 
-export interface IRadioField extends IField, IInput {}
+export interface RadioField extends FieldProps, InputProps {}
 
-const RadioField = ({ label, hasError, errorMessage, isValid, value, inputSize, className, ...rest }: IRadioField) => {
+const RadioField = ({ label, hasError, errorMessage, isValid, value, inputSize, className, ...rest }: RadioField) => {
   if (!value) throw Error('Value must be set in inputProps. Check the docs.');
 
   return (

--- a/src/components/molecules/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/molecules/RadioGroupField/RadioGroupField.tsx
@@ -9,22 +9,22 @@ const RadioWrapper = styled.div`
   padding: 4px 0;
 `;
 
-interface IRadioGroupFieldItem {
+interface RadioGroupFieldItem {
   value: string;
   label: string;
   defaultChecked?: boolean;
   disabled?: boolean;
 }
 
-export interface IRadioGroupFieldProps {
+export interface RadioGroupFieldProps {
   label: string;
-  items: IRadioGroupFieldItem[];
+  items: RadioGroupFieldItem[];
   onChange: (value: string) => void;
   disabled?: boolean;
   value?: string;
 }
 
-const RadioGroupField = ({ items, label, onChange, value, disabled }: IRadioGroupFieldProps) => {
+const RadioGroupField = ({ items, label, onChange, value, disabled }: RadioGroupFieldProps) => {
   const { value: defaultValue } = items.find(({ defaultChecked }) => defaultChecked) || {};
 
   const [innerValue, setInnerValue] = useState(defaultValue);

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -7,20 +7,20 @@ import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
 import { typography } from '../../../constants/typography';
 import { colors } from '../../../constants/colors';
-import { IField, IInput } from '../../types';
+import { FieldProps, InputProps } from '../../types';
 
-export interface ITextFieldProps extends IField, IInput {
+export interface TextFieldProps extends FieldProps, InputProps {
   prefix?: string;
 }
 
-export interface IPrefixProps {
+export interface PrefixProps {
   prefix: string;
 }
 
-export interface ILabelProps {
+export interface LabelProps {
   withHelpText?: boolean;
 }
-const Label = styled(InputLabel)<ILabelProps>`
+const Label = styled(InputLabel)<LabelProps>`
   ${({ withHelpText }) => withHelpText && `margin-bottom: 0;`}
 `;
 
@@ -35,12 +35,12 @@ const HelpText = styled(Text).attrs({
   display: block;
 `;
 
-const Prefix = styled.span<IPrefixProps>`
+const Prefix = styled.span<PrefixProps>`
   position: relative;
   display: block;
   
   &::before {
-    content: '${({ prefix }: IPrefixProps) => prefix}';
+    content: '${({ prefix }: PrefixProps) => prefix}';
     position: absolute;
     left: 10px;
     top: 0;
@@ -56,7 +56,7 @@ const Prefix = styled.span<IPrefixProps>`
   }
 `;
 
-const TextField = forwardRef<HTMLInputElement, ITextFieldProps>(
+const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   ({ label, errorMessage, isValid, name, inputSize, helpText, prefix, ...rest }, ref) => {
     if (!name) {
       throw Error('Name must be set in inputProps. Check the docs.');

--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -12,11 +12,11 @@ import linkedin from '../../../content/images/social/linkedin.svg';
 import Logo from '../../atoms/Logo/Logo';
 import Link from '../../atoms/Link/Link';
 
-export interface IFooterProps extends HTMLAttributes<HTMLDivElement> {
+export interface FooterProps extends HTMLAttributes<HTMLDivElement> {
   baseUrl?: string;
 }
 
-const ZopaFooter = ({ baseUrl = 'https://www.zopa.com', ...rest }: IFooterProps) => (
+const ZopaFooter = ({ baseUrl = 'https://www.zopa.com', ...rest }: FooterProps) => (
   <Footer {...rest}>
     <FlexContainer gutter={16}>
       <FlexRow className="mb-6">

--- a/src/components/molecules/ZopaFooter/styles/ListLink.tsx
+++ b/src/components/molecules/ZopaFooter/styles/ListLink.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import Link, { ILinkProps } from '../../../atoms/Link/Link';
+import Link, { LinkProps } from '../../../atoms/Link/Link';
 import { typography } from '../../../../constants/typography';
 import { spacing } from '../../../../constants/spacing';
 
-const SListItem = styled.li`
+const ListItem = styled.li`
   margin-bottom: ${spacing[4]};
 
   &:last-child {
@@ -12,7 +12,7 @@ const SListItem = styled.li`
   }
 `;
 
-const SListLink = styled(Link)`
+const ListLinkWrapper = styled(Link)`
   font-weight: ${typography.weights.regular};
   text-decoration: none;
 
@@ -22,8 +22,8 @@ const SListLink = styled(Link)`
   }
 `;
 
-export const ListLink = (props: ILinkProps) => (
-  <SListItem>
-    <SListLink {...props} />
-  </SListItem>
+export const ListLink = (props: LinkProps) => (
+  <ListItem>
+    <ListLinkWrapper {...props} />
+  </ListItem>
 );

--- a/src/components/molecules/ZopaFooter/styles/SocialLink.tsx
+++ b/src/components/molecules/ZopaFooter/styles/SocialLink.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import styled from 'styled-components';
-import Link, { ILinkProps } from '../../../atoms/Link/Link';
+import Link, { LinkProps } from '../../../atoms/Link/Link';
 import { Icon } from './Icon';
 import { spacing } from '../../../../constants/spacing';
 
-interface ISocialLink extends ILinkProps {
+interface SocialLink extends LinkProps {
   variant: string;
 }
 
-const SLink = styled(Link)`
+const LinkWrapper = styled(Link)`
   margin: 0 ${spacing[2]};
 `;
 
-export const SocialLink = ({ variant, ...otherProps }: ISocialLink) => (
-  <SLink {...otherProps}>
+export const SocialLink = ({ variant, ...otherProps }: SocialLink) => (
+  <LinkWrapper {...otherProps}>
     <Icon variant={variant} />
-  </SLink>
+  </LinkWrapper>
 );

--- a/src/components/organisms/Accordion/Accordion/Accordion.tsx
+++ b/src/components/organisms/Accordion/Accordion/Accordion.tsx
@@ -3,9 +3,9 @@ import React, { FC, HTMLAttributes } from 'react';
 import { AccordionContext } from '../hooks';
 import { useAccordion } from '../hooks/useAccordion';
 
-export interface IAccordion extends HTMLAttributes<HTMLDivElement> {}
+export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {}
 
-const Accordion: FC<IAccordion> = ({ children, ...rest }) => {
+const Accordion: FC<AccordionProps> = ({ children, ...rest }) => {
   const context = useAccordion();
   return (
     <AccordionContext.Provider value={context}>

--- a/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.tsx
+++ b/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.tsx
@@ -5,7 +5,7 @@ import Text from '../../../atoms/Text/Text';
 import { useAccordionContext } from '../hooks';
 import { spacing } from '../../../../constants/spacing';
 
-export interface IAccordionHeader extends Omit<HTMLAttributes<HTMLButtonElement>, 'onClick'> {
+export interface AccordionHeader extends Omit<HTMLAttributes<HTMLButtonElement>, 'onClick'> {
   id: string;
   index: number;
   textSize?: 'body' | 'small';
@@ -46,7 +46,7 @@ const Cross = styled.span<{ active: boolean }>`
       `, linear-gradient(to right, transparent 35%, ${colors.grey} 35%, ${colors.grey} 65%, transparent 65%)`};
 `;
 
-const AccordionHeader: FC<IAccordionHeader> = ({ children, id, index, textSize = 'body', onClick, ...rest }) => {
+const AccordionHeader: FC<AccordionHeader> = ({ children, id, index, textSize = 'body', onClick, ...rest }) => {
   const { getHeaderProps, isActiveSection } = useAccordionContext();
   const { ref, onClick: contextOnClick, ...headerPropsRest } = getHeaderProps(id, index);
 

--- a/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
+++ b/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
@@ -2,12 +2,12 @@ import React, { FC } from 'react';
 
 import { useAccordionContext } from '../hooks';
 
-interface IAccordionSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+interface AccordionSectionProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string;
   index: number;
 }
 
-const AccordionSection: FC<IAccordionSectionProps> = ({ children, id, index, ...rest }) => {
+const AccordionSection: FC<AccordionSectionProps> = ({ children, id, index, ...rest }) => {
   const { getSectionProps } = useAccordionContext();
   const { ref, ...sectionPropsRest } = getSectionProps(id, index);
   return (

--- a/src/components/organisms/Accordion/hooks/AccordionContext.ts
+++ b/src/components/organisms/Accordion/hooks/AccordionContext.ts
@@ -1,11 +1,11 @@
 import { createContext } from 'react';
 
-import { TGetAccordionHeaderProps, TGetAccordionSectionProps, TIsActiveAccordionSection } from './useAccordion';
+import { GetAccordionHeaderProps, GetAccordionSectionProps, IsActiveAccordionSection } from './useAccordion';
 
-export interface IAccordionContext {
-  getHeaderProps: TGetAccordionHeaderProps;
-  getSectionProps: TGetAccordionSectionProps;
-  isActiveSection: TIsActiveAccordionSection;
+export interface AccordionContext {
+  getHeaderProps: GetAccordionHeaderProps;
+  getSectionProps: GetAccordionSectionProps;
+  isActiveSection: IsActiveAccordionSection;
 }
 
-export const AccordionContext = createContext<IAccordionContext | undefined>(undefined);
+export const AccordionContext = createContext<AccordionContext | undefined>(undefined);

--- a/src/components/organisms/Accordion/hooks/useAccordion.ts
+++ b/src/components/organisms/Accordion/hooks/useAccordion.ts
@@ -2,7 +2,7 @@ import { useRef, useState, KeyboardEvent, RefObject } from 'react';
 import { isArrowDown, isArrowUp } from '../../../../helpers/keyboard-keys';
 import { mod } from '../../../../helpers/utils';
 
-export interface IAccordionHeaderProps {
+export interface AccordionHeaderProps {
   'aria-controls': string;
   'aria-disabled': boolean;
   'aria-expanded': boolean;
@@ -14,29 +14,29 @@ export interface IAccordionHeaderProps {
   ref: (node: HTMLButtonElement) => void;
 }
 
-export type TGetAccordionHeaderProps = (id: string, index: number) => IAccordionHeaderProps;
+export type GetAccordionHeaderProps = (id: string, index: number) => AccordionHeaderProps;
 
-interface IAccordionSectionStyles {
+interface AccordionSectionStyles {
   overflow: string;
   transition: string;
   height: string;
 }
 
-export interface IAccordionSectionProps {
+export interface AccordionSectionProps {
   'aria-hidden': boolean;
   'aria-labelledby': string;
   id: string;
   key: string;
   ref: (node: HTMLDivElement) => void;
   role: string;
-  style: IAccordionSectionStyles;
+  style: AccordionSectionStyles;
 }
 
-export type TGetAccordionSectionProps = (id: string, index: number) => IAccordionSectionProps;
+export type GetAccordionSectionProps = (id: string, index: number) => AccordionSectionProps;
 
-export type TIsActiveAccordionSection = (index: number) => boolean;
+export type IsActiveAccordionSection = (index: number) => boolean;
 
-type TActiveSections = number[];
+type ActiveSections = number[];
 
 export const useAccordion = () => {
   const headersRefs = useRef<RefObject<HTMLButtonElement>['current'][]>([]).current;
@@ -59,8 +59,8 @@ export const useAccordion = () => {
     }
   };
 
-  const [activeSections, updateActiveSections] = useState<TActiveSections>([]);
-  const isActiveSection: TIsActiveAccordionSection = index => activeSections.includes(index);
+  const [activeSections, updateActiveSections] = useState<ActiveSections>([]);
+  const isActiveSection: IsActiveAccordionSection = index => activeSections.includes(index);
 
   const getSectionStyle = (index: number) => {
     const sectionRef = sectionsRefs[index];
@@ -113,7 +113,7 @@ export const useAccordion = () => {
     }
   };
 
-  const getHeaderProps: TGetAccordionHeaderProps = (id, index) => ({
+  const getHeaderProps: GetAccordionHeaderProps = (id, index) => ({
     'aria-controls': getLinkingId(id),
     'aria-disabled': isActiveSection(index),
     'aria-expanded': isActiveSection(index),
@@ -125,7 +125,7 @@ export const useAccordion = () => {
     ref: getHeaderRef(index),
   });
 
-  const getSectionProps: TGetAccordionSectionProps = (id, index) => ({
+  const getSectionProps: GetAccordionSectionProps = (id, index) => ({
     'aria-hidden': !isActiveSection(index),
     'aria-labelledby': id,
     id: getLinkingId(id),

--- a/src/components/organisms/Accordion/index.tsx
+++ b/src/components/organisms/Accordion/index.tsx
@@ -1,15 +1,15 @@
 import React, { FC } from 'react';
 
-import AccordionComponent, { IAccordion } from './Accordion/Accordion';
+import AccordionComponent, { AccordionProps } from './Accordion/Accordion';
 import AccordionHeader from './AccordionHeader/AccordionHeader';
 import AccordionSection from './AccordionSection/AccordionSection';
 
-interface IAccordionStatic {
+interface AccordionStatic {
   Header: typeof AccordionHeader;
   Section: typeof AccordionSection;
 }
 
-export const Accordion: IAccordionStatic & FC<IAccordion> = props => <AccordionComponent {...props} />;
+export const Accordion: AccordionStatic & FC<AccordionProps> = props => <AccordionComponent {...props} />;
 
 Accordion.Header = AccordionHeader;
 Accordion.Section = AccordionSection;

--- a/src/components/organisms/Form/FormButton/FormButton.tsx
+++ b/src/components/organisms/Form/FormButton/FormButton.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import { useFormikContext } from 'formik';
-import Button, { IButtonProps } from '../../../atoms/Button/Button';
+import Button, { ButtonProps } from '../../../atoms/Button/Button';
 
-export interface FromButtonProps extends IButtonProps {
+export interface FromButtonProps extends ButtonProps {
   type?: 'button' | 'reset' | 'submit';
   disabled?: boolean;
 }

--- a/src/components/organisms/Form/FormCheckboxField/FormCheckboxField.tsx
+++ b/src/components/organisms/Form/FormCheckboxField/FormCheckboxField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
-import CheckboxField, { ICheckboxFieldProps } from '../../../molecules/CheckboxField/CheckboxField';
+import CheckboxField, { CheckboxFieldProps } from '../../../molecules/CheckboxField/CheckboxField';
 
-export type FormCheckboxFieldProps = Pick<FieldHookConfig<boolean>, 'validate' | 'name'> & ICheckboxFieldProps;
+export type FormCheckboxFieldProps = Pick<FieldHookConfig<boolean>, 'validate' | 'name'> & CheckboxFieldProps;
 
 const FormCheckboxField = ({ name, validate, ...rest }: FormCheckboxFieldProps) => {
   const [{ value, onChange, onBlur }, { error, touched }] = useField<boolean>({ name, validate });

--- a/src/components/organisms/Form/FormCheckboxGroupField/FormCheckboxGroupField.tsx
+++ b/src/components/organisms/Form/FormCheckboxGroupField/FormCheckboxGroupField.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
-import CheckboxGroupField, { ICheckboxGroupFieldProps } from '../../../molecules/CheckboxGroupField/CheckboxGroupField';
+import CheckboxGroupField, { CheckboxGroupFieldProps } from '../../../molecules/CheckboxGroupField/CheckboxGroupField';
 
 export type FormCheckboxGroupFieldProps<Val extends Record<string, boolean>> = Pick<
   FieldHookConfig<Val>,
   'validate' | 'name'
 > &
-  ICheckboxGroupFieldProps<Val>;
+  CheckboxGroupFieldProps<Val>;
 
 const FormCheckboxGroupField = <Val extends Record<string, boolean>>({
   name,

--- a/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
+++ b/src/components/organisms/Form/FormDropdownField/FormDropdownField.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { useField, FieldHookConfig } from 'formik';
-import DropdownField, { IDropdownFieldProps } from '../../../molecules/DropdownField/DropdownField';
+import DropdownField, { DropdownFieldProps } from '../../../molecules/DropdownField/DropdownField';
 
 type FormDropdownOption = {
   label: string;
@@ -8,7 +8,7 @@ type FormDropdownOption = {
 };
 
 export type FormDropdownFieldProps = Pick<FieldHookConfig<string>, 'validate' | 'name'> &
-  IDropdownFieldProps & {
+  DropdownFieldProps & {
     options: FormDropdownOption[];
   };
 

--- a/src/components/organisms/Form/FormDropdownFilteredField/FormDropdownFilteredField.tsx
+++ b/src/components/organisms/Form/FormDropdownFilteredField/FormDropdownFilteredField.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
-import DropdownFiltered, { IDropdownFilteredProps } from '../../../molecules/DropdownFiltered/DropdownFiltered';
+import DropdownFiltered, { DropdownFilteredProps } from '../../../molecules/DropdownFiltered/DropdownFiltered';
 
-export type FormDropdownFilteredFieldProps = Pick<FieldHookConfig<string>, 'validate' | 'name'> &
-  IDropdownFilteredProps;
+export type FormDropdownFilteredFieldProps = Pick<FieldHookConfig<string>, 'validate' | 'name'> & DropdownFilteredProps;
 
 const FormDropdownFilteredField = ({ name, validate, items, ...rest }: FormDropdownFilteredFieldProps) => {
   const [{ onBlur }, { error, touched }, helpers] = useField({ name, validate });

--- a/src/components/organisms/Form/FormRadioGroupField/FormRadioGroupField.tsx
+++ b/src/components/organisms/Form/FormRadioGroupField/FormRadioGroupField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
-import RadioGroupField, { IRadioGroupFieldProps } from '../../../molecules/RadioGroupField/RadioGroupField';
+import RadioGroupField, { RadioGroupFieldProps } from '../../../molecules/RadioGroupField/RadioGroupField';
 
 export type FormRadioGroupFieldProps = Pick<FieldHookConfig<string>, 'validate' | 'name'> &
-  Omit<IRadioGroupFieldProps, 'onChange' | 'value'>;
+  Omit<RadioGroupFieldProps, 'onChange' | 'value'>;
 
 const FormRadioGroupField = ({ name, validate, ...rest }: FormRadioGroupFieldProps) => {
   const [{ value }, , { setValue }] = useField<string>({ name, validate });

--- a/src/components/organisms/Form/FormTextField/FormTextField.tsx
+++ b/src/components/organisms/Form/FormTextField/FormTextField.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react';
 import { useField, FieldHookConfig } from 'formik';
-import TextField, { ITextFieldProps } from '../../../molecules/TextField/TextField';
+import TextField, { TextFieldProps } from '../../../molecules/TextField/TextField';
 
-export type FormTextFieldProps = Pick<FieldHookConfig<string>, 'validate' | 'name'> & ITextFieldProps;
+export type FormTextFieldProps = Pick<FieldHookConfig<string>, 'validate' | 'name'> & TextFieldProps;
 
 const FormTextField = forwardRef<HTMLInputElement, FormTextFieldProps>(({ name, validate, ...rest }, ref) => {
   const [{ value, onChange, onBlur }, { error, touched }] = useField({ name, validate });

--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -6,12 +6,12 @@ import { navbarHeight } from '../../../../constants/components';
 import useScrollThreshold from '../useScrollThreshold/useScrollThreshold';
 import FlexContainer from '../../../layout/FlexContainer/FlexContainer';
 
-export interface ILayoutOuterProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface LayoutOuterProps extends React.HTMLAttributes<HTMLDivElement> {
   backgroundColor: string;
   overlap: boolean;
 }
 
-const LayoutOuter = styled.div<ILayoutOuterProps>`
+const LayoutOuter = styled.div<LayoutOuterProps>`
   position: fixed;
   top: 0;
   left: 0;
@@ -43,7 +43,7 @@ const Container = styled(FlexContainer)`
   height: inherit;
 `;
 
-export interface INavbarProps {
+export interface NavbarProps {
   /**
    * background color
    */
@@ -62,7 +62,7 @@ export interface INavbarProps {
   right?: React.ReactNode;
 }
 
-const Navbar = ({ backgroundColor = colors.white, left, center, right }: INavbarProps) => {
+const Navbar = ({ backgroundColor = colors.white, left, center, right }: NavbarProps) => {
   const overThreshold = useScrollThreshold();
 
   return (

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
@@ -9,16 +9,16 @@ const NavbarDropdownContainer = styled.div`
   display: inline-block;
 `;
 
-export type TButtonLinkElement = HTMLButtonElement | HTMLAnchorElement;
+export type ButtonLinkElement = HTMLButtonElement | HTMLAnchorElement;
 
-export type TAlignedTo = 'left' | 'right';
+export type AlignedTo = 'left' | 'right';
 
-export interface INavbarDropdownListContainer extends React.HTMLAttributes<HTMLDivElement> {
+export interface NavbarDropdownListContainer extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
-  alignedTo: TAlignedTo;
+  alignedTo: AlignedTo;
 }
 
-const NavbarDropdownListContainer = styled.div<INavbarDropdownListContainer>`
+const NavbarDropdownListContainer = styled.div<NavbarDropdownListContainer>`
   position: absolute;
   ${({ alignedTo }) => alignedTo}: 0;
   ${({ open }) =>
@@ -37,68 +37,68 @@ const NavbarDropdownListContainer = styled.div<INavbarDropdownListContainer>`
         `}
 `;
 
-export interface IOpenerProps {
+export interface OpenerProps {
   'aria-expanded': boolean;
   'aria-haspopup': true;
-  ref: React.RefObject<TButtonLinkElement>;
+  ref: React.RefObject<ButtonLinkElement>;
   onClick: React.EventHandler<React.MouseEvent>;
   onKeyDown: React.EventHandler<React.KeyboardEvent>;
   role: string;
   tabIndex: number;
 }
 
-export type IItem = any;
+export type Item = any;
 
-export type TGetOpenerProps = () => IOpenerProps;
+export type GetOpenerProps = () => OpenerProps;
 
-export interface IRenderOpenerProps {
+export interface RenderOpenerProps {
   open: boolean;
-  getOpenerProps: TGetOpenerProps;
+  getOpenerProps: GetOpenerProps;
 }
 
-export interface IItemProps {
+export interface ItemProps {
   ref: React.RefObject<HTMLLIElement>;
   onKeyDown: React.EventHandler<React.KeyboardEvent>;
   role: string;
   tabIndex: number;
 }
 
-export type TGetItemProps = () => IItemProps;
+export type GetItemProps = () => ItemProps;
 
-export type TClose = () => void;
+export type Close = () => void;
 
-export interface IRenderItemProps {
-  item: IItem;
-  getItemProps: TGetItemProps;
-  close: TClose;
+export interface RenderItemProps {
+  item: Item;
+  getItemProps: GetItemProps;
+  close: Close;
 }
 
-export interface INavbarDropdownProps {
+export interface NavbarDropdownProps {
   /** unique id */
   id: string;
   /** Short description of the navbar component */
   ariaLabel: string;
   /** Function getting all the props and aria attributes meant to be spread on the opener button/link */
-  renderOpener: ({ open, getOpenerProps }: IRenderOpenerProps) => React.ReactNode;
+  renderOpener: ({ open, getOpenerProps }: RenderOpenerProps) => React.ReactNode;
   /** Function getting all the props and aria attributes meant to be spread on the dropdown item links */
-  renderItem: ({ item, getItemProps, close }: IRenderItemProps) => React.ReactNode;
+  renderItem: ({ item, getItemProps, close }: RenderItemProps) => React.ReactNode;
   /** Array of data representing the dropdown items (e.g links) */
-  items: IItem[];
+  items: Item[];
 }
 
-export interface INavbarDropdownState {
+export interface NavbarDropdownState {
   cursor: number;
   right: number;
   open: boolean;
 }
 
-export default class NavbarDropdown extends React.Component<INavbarDropdownProps, INavbarDropdownState> {
+export default class NavbarDropdown extends React.Component<NavbarDropdownProps, NavbarDropdownState> {
   private readonly dropdownRef = React.createRef<HTMLDivElement>();
   private readonly dropdownListRef = React.createRef<HTMLUListElement>();
   private readonly openerRef = React.createRef<HTMLAnchorElement | HTMLButtonElement>();
   private readonly itemsRefs: React.RefObject<HTMLLIElement>[] = [];
 
-  public constructor(props: INavbarDropdownProps) {
+  public constructor(props: NavbarDropdownProps) {
     super(props);
     this.itemsRefs = props.items.map(() => React.createRef<HTMLLIElement>());
     this.state = {
@@ -123,7 +123,7 @@ export default class NavbarDropdown extends React.Component<INavbarDropdownProps
     document.removeEventListener('keydown', this.handleEscapeKey, true);
   }
 
-  public getOpenerProps = (): IOpenerProps => ({
+  public getOpenerProps = (): OpenerProps => ({
     'aria-expanded': this.state.open,
     'aria-haspopup': true,
     onClick: this.handleOpenerClick,
@@ -169,7 +169,7 @@ export default class NavbarDropdown extends React.Component<INavbarDropdownProps
     this.setState({ open: false });
   };
 
-  private handleOpenerKeyDown = (e: React.KeyboardEvent<TButtonLinkElement>) => {
+  private handleOpenerKeyDown = (e: React.KeyboardEvent<ButtonLinkElement>) => {
     if (isArrowUp(e)) {
       e.preventDefault();
       this.setState(
@@ -191,7 +191,7 @@ export default class NavbarDropdown extends React.Component<INavbarDropdownProps
     }
   };
 
-  private handleItemKeyDown = (e: React.KeyboardEvent<TButtonLinkElement>) => {
+  private handleItemKeyDown = (e: React.KeyboardEvent<ButtonLinkElement>) => {
     const { length } = this.itemsRefs;
     if (isArrowUp(e)) {
       e.preventDefault();

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../../../constants/colors';
 
-export type TAlignedTo = 'left' | 'right';
+export type AlignedTo = 'left' | 'right';
 
-export interface INavbarDropdownListProps extends React.HTMLAttributes<HTMLUListElement> {
+export interface NavbarDropdownListProps extends React.HTMLAttributes<HTMLUListElement> {
   /**
    * Determines whether it's aligned to left or right
    */
-  alignedTo: TAlignedTo;
+  alignedTo: AlignedTo;
 }
 
-const NavbarDropdownList = styled.ul<INavbarDropdownListProps>`
+const NavbarDropdownList = styled.ul<NavbarDropdownListProps>`
   position: relative;
   list-style-type: none;
   margin: 0;

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
@@ -1,16 +1,16 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../../constants/colors';
-import Link, { ILinkProps } from '../../../atoms/Link/Link';
+import Link, { LinkProps } from '../../../atoms/Link/Link';
 import Icon from '../../../atoms/Icon/Icon';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
-export interface IStyledNavbarLinkProps extends ILinkProps {
+export interface StyledNavbarLinkProps extends LinkProps {
   active: boolean;
   withChevron: boolean;
 }
 
-const StyledNavbarLink = styled(Link)<IStyledNavbarLinkProps>`
+const StyledNavbarLink = styled(Link)<StyledNavbarLinkProps>`
   display: inline-flex;
   align-items: center;
   color: ${({ color }) => color};
@@ -21,11 +21,11 @@ const StyledNavbarLink = styled(Link)<IStyledNavbarLinkProps>`
   }
 `;
 
-export interface IChevronContainerProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface ChevronContainerProps extends React.HTMLAttributes<HTMLSpanElement> {
   open: boolean;
 }
 
-const ChevronContainer = styled.span<IChevronContainerProps>`
+const ChevronContainer = styled.span<ChevronContainerProps>`
   display: inline-flex;
   align-items: center;
   margin-left: 8px;
@@ -33,15 +33,15 @@ const ChevronContainer = styled.span<IChevronContainerProps>`
   transform: rotate(${({ open }) => (open ? 180 : 0)}deg);
 `;
 
-export interface INavbarLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface NavbarLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   active?: boolean;
   withChevron?: boolean;
   open?: boolean;
-  color?: ILinkProps['color'];
-  target?: ILinkProps['target'];
+  color?: LinkProps['color'];
+  target?: LinkProps['target'];
 }
 
-const NavbarLink: FC<INavbarLinkProps> = React.forwardRef<HTMLAnchorElement, INavbarLinkProps>(
+const NavbarLink: FC<NavbarLinkProps> = React.forwardRef<HTMLAnchorElement, NavbarLinkProps>(
   ({ active = false, children, open = false, withChevron = false, color = colors.actionPlain, ...rest }, ref) => (
     <StyledNavbarLink active={active} withChevron={withChevron} color={color} ref={ref} {...rest}>
       {children}

--- a/src/components/organisms/Navbar/index.tsx
+++ b/src/components/organisms/Navbar/index.tsx
@@ -1,15 +1,15 @@
 import React, { FC } from 'react';
 
-import Navbar, { INavbarProps } from './Navbar/Navbar';
+import Navbar, { NavbarProps } from './Navbar/Navbar';
 import NavbarDropdown from './NavbarDropdown/NavbarDropdown';
 import NavbarLink from './NavbarLink/NavbarLink';
 
-interface INavbarStatic {
+interface NavbarStatic {
   Dropdown: typeof NavbarDropdown;
   Link: typeof NavbarLink;
 }
 
-const NavbarWrapper: INavbarStatic & FC<INavbarProps> = props => <Navbar {...props} />;
+const NavbarWrapper: NavbarStatic & FC<NavbarProps> = props => <Navbar {...props} />;
 
 NavbarWrapper.Dropdown = NavbarDropdown;
 NavbarWrapper.Link = NavbarLink;

--- a/src/components/styles/Spacing.ts
+++ b/src/components/styles/Spacing.ts
@@ -1,10 +1,10 @@
 import { css } from 'styled-components';
 import { spacing as sizes } from '../../constants/spacing';
-import grid, { TGridBreakpoints } from '../../constants/grid';
+import grid, { GridBreakpoints } from '../../constants/grid';
 
-type TSpacingTypes = 'margin' | 'padding';
+type SpacingTypes = 'margin' | 'padding';
 
-const createTopLevelSizes = (type: TSpacingTypes) =>
+const createTopLevelSizes = (type: SpacingTypes) =>
   Object.keys(sizes).reduce(
     (classNames, size) => ({
       ...classNames,
@@ -35,13 +35,13 @@ const createTopLevelSizes = (type: TSpacingTypes) =>
     {},
   );
 
-const createResponsiveSizes = (type: TSpacingTypes) =>
+const createResponsiveSizes = (type: SpacingTypes) =>
   Object.keys(grid.breakpoints)
     .filter(v => v !== 'xs')
     .reduce(
       (mediaQueries, breakpoint) => ({
         ...mediaQueries,
-        [`@media screen and (min-width: ${grid.breakpoints[breakpoint as TGridBreakpoints]}px)`]: {
+        [`@media screen and (min-width: ${grid.breakpoints[breakpoint as GridBreakpoints]}px)`]: {
           ...Object.keys(sizes).reduce(
             (classNames, size) => ({
               ...classNames,

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -4,9 +4,9 @@ import { InputHTMLAttributes } from 'react';
  * GLOBAL TYPES ACROSS COMPONENTS
  */
 
-export type TContainerSizes = 'short' | 'medium' | 'long' | 'fullLength';
+export type ContainerSizes = 'short' | 'medium' | 'long' | 'fullLength';
 
-export interface IInputStatus {
+export interface InputStatus {
   /**
    * If set to true the border color would be green unless there's an error.
    */
@@ -18,21 +18,21 @@ export interface IInputStatus {
   hasError?: boolean;
 }
 
-export interface IInput extends IInputStatus, InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputStatus, InputHTMLAttributes<HTMLInputElement> {
   /**
-   * Attribute used for testing porpuses
+   * Attribute used for testing purposes
    */
   'data-automation'?: string;
 }
 
-export interface ISelect extends IInputStatus, InputHTMLAttributes<HTMLSelectElement> {
+export interface SelectProps extends InputStatus, InputHTMLAttributes<HTMLSelectElement> {
   /**
-   * Attribute used for testing porpuses
+   * Attribute used for testing purposes
    */
   'data-automation'?: string;
 }
 
-export interface IField {
+export interface FieldProps {
   /**
    * The text to be shown on the label. If this is not set it doesn't render the label.
    */
@@ -52,5 +52,5 @@ export interface IField {
   /**
    * Input size
    */
-  inputSize?: TContainerSizes;
+  inputSize?: ContainerSizes;
 }

--- a/src/constants/breakpoints.ts
+++ b/src/constants/breakpoints.ts
@@ -4,4 +4,4 @@ export const breakpoints = {
   tablet: 720,
 } as const;
 
-export type TDeviceSizes = keyof typeof breakpoints;
+export type DeviceSizes = keyof typeof breakpoints;

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -33,9 +33,9 @@ const notificationColors = {
   successLight: '#DDFDE5',
 } as const;
 
-export type TColors = typeof brandColors & typeof actionColors & typeof neutralColors & typeof notificationColors;
+export type Colors = typeof brandColors & typeof actionColors & typeof neutralColors & typeof notificationColors;
 
-const colors: TColors = {
+const colors: Colors = {
   ...brandColors,
   ...actionColors,
   ...neutralColors,

--- a/src/constants/grid.ts
+++ b/src/constants/grid.ts
@@ -1,14 +1,14 @@
-export type TGridBreakpoints = 'xs' | 's' | 'm' | 'l' | 'xl';
-export type TGridWidths = 's' | 'm' | 'l' | 'xl';
+export type GridBreakpoints = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type GridWidths = 's' | 'm' | 'l' | 'xl';
 
-interface IGrid {
-  breakpoints: Record<TGridBreakpoints, number>;
+interface Grid {
+  breakpoints: Record<GridBreakpoints, number>;
   cols: number;
   gutter: number;
-  width: Record<TGridWidths, number>;
+  width: Record<GridWidths, number>;
 }
 
-const grid: IGrid = {
+const grid: Grid = {
   breakpoints: {
     l: 992,
     m: 768,

--- a/src/constants/spacing.ts
+++ b/src/constants/spacing.ts
@@ -1,8 +1,6 @@
-interface ISpacing {
-  [key: string]: string;
-}
+type Spacing = Record<string, string>;
 
-export const spacing: ISpacing = {
+export const spacing: Spacing = {
   '0': '0',
   '1': '4px',
   '2': '8px',

--- a/src/content/Colors/Colors.tsx
+++ b/src/content/Colors/Colors.tsx
@@ -1,22 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-import {
-  colors,
-  TColors,
-  brandColors,
-  actionColors,
-  neutralColors,
-  notificationColors,
-} from './../../constants/colors';
+import { colors, Colors, brandColors, actionColors, neutralColors, notificationColors } from './../../constants/colors';
 
-type TColorVariants = keyof TColors;
+type ColorVariants = keyof Colors;
 
-interface ISColorProps {
+interface ColorProps {
   color: string;
-  colorName: TColorVariants;
+  colorName: ColorVariants;
 }
 
-interface IColorsProps {
+interface ColorsProps {
   /**
    * section of the default colors
    * @ignore
@@ -24,26 +17,26 @@ interface IColorsProps {
   variant: 'brand' | 'actions' | 'neutral' | 'notifications';
 }
 
-interface IColorGroups {
+interface ColorGroups {
   brand: Array<string>;
   actions: Array<string>;
   neutral: Array<string>;
   notifications: Array<string>;
 }
 
-const SColors = styled.div`
+const ColorsWrapper = styled.div`
   display: flex;
   flex-flow: row wrap;
 `;
 
-const colorGroups: IColorGroups = {
+const colorGroups: ColorGroups = {
   brand: Object.keys(brandColors),
   actions: Object.keys(actionColors),
   neutral: Object.keys(neutralColors),
   notifications: Object.keys(notificationColors),
 };
 
-const SColor = styled.div<ISColorProps>`
+const Color = styled.div<ColorProps>`
   background: ${({ color }) => color};
   margin: 5px;
   border: 1px solid #efefef;
@@ -59,26 +52,26 @@ const SColor = styled.div<ISColorProps>`
   }
 `;
 
-export default function Colors({ variant }: IColorsProps) {
+export default function Colors({ variant }: ColorsProps) {
   const colorGroup = colorGroups[variant] as string[];
   return (
-    <SColors>
+    <ColorsWrapper>
       {colorGroup.map((colorKey: string) => {
-        const colorName = colorKey as TColorVariants;
+        const colorName = colorKey as ColorVariants;
         const actualColor = colorName === 'action' ? `#4F5AD8 to ${colors.actionPlain}` : colors[colorName];
         return (
           <>
-            <SColor key={colorKey} color={colors[colorName]} colorName={colorName}>
+            <Color key={colorKey} color={colors[colorName]} colorName={colorName}>
               <p>
                 {colorName}
                 <br />
                 {actualColor}
               </p>
-            </SColor>
+            </Color>
           </>
         );
       })}
-    </SColors>
+    </ColorsWrapper>
   );
 }
 

--- a/src/helpers/keyboard-keys.ts
+++ b/src/helpers/keyboard-keys.ts
@@ -1,10 +1,8 @@
 import React from 'react';
 
-export interface IKeyCodesToKey {
-  [key: number]: string;
-}
+export type KeyCodesToKey = Record<number, string>;
 
-const keyCodesToKey: IKeyCodesToKey = {
+const keyCodesToKey: KeyCodesToKey = {
   13: 'Enter',
   27: 'Escape',
   32: ' ',
@@ -12,9 +10,9 @@ const keyCodesToKey: IKeyCodesToKey = {
   40: 'ArrowDown',
 };
 
-export type IEvent = KeyboardEvent | React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>;
+export type Event = KeyboardEvent | React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>;
 
-const isKey = (key: string) => (event: IEvent) => {
+const isKey = (key: string) => (event: Event) => {
   const eventKey = event.key || keyCodesToKey[event.keyCode];
   return key === eventKey;
 };

--- a/src/helpers/responsiveness.ts
+++ b/src/helpers/responsiveness.ts
@@ -1,15 +1,15 @@
 import { css } from 'styled-components';
-import { breakpoints, TDeviceSizes } from '../constants/breakpoints';
+import { breakpoints, DeviceSizes } from '../constants/breakpoints';
 
-type TMedia = Record<TDeviceSizes, ReturnType<typeof interpolate>>;
+type Media = Record<DeviceSizes, ReturnType<typeof interpolate>>;
 
-const maxMedia: TMedia = {
+const maxMedia: Media = {
   phone: interpolate('phone', 'max'),
   tablet: interpolate('tablet', 'max'),
   desktop: interpolate('desktop', 'max'),
 };
 
-const minMedia: TMedia = {
+const minMedia: Media = {
   phone: interpolate('phone', 'min'),
   tablet: interpolate('tablet', 'min'),
   desktop: interpolate('desktop', 'min'),

--- a/src/helpers/test/date.ts
+++ b/src/helpers/test/date.ts
@@ -1,9 +1,9 @@
-export interface IMockDate {
+export interface MockDate {
   startMocking(): void;
   finishMocking(): void;
 }
 
-export function mockDate(date: Date): IMockDate {
+export function mockDate(date: Date): MockDate {
   const RealDate = Date;
 
   return {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,7 +1,7 @@
-import { IInputStatus } from '../components/types';
+import { InputStatus } from '../components/types';
 import { colors } from '../constants/colors';
 
 export const mod = (x: number, n: number) => ((x % n) + n) % n;
 
-export const getBorderColorByStatus = ({ hasError, isValid }: IInputStatus) =>
+export const getBorderColorByStatus = ({ hasError, isValid }: InputStatus) =>
   hasError ? colors.alert : isValid ? colors.success : colors.greyLight;

--- a/src/hooks/useViewport/ViewportProvider.tsx
+++ b/src/hooks/useViewport/ViewportProvider.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useViewport, IUseViewportOptions } from './useViewport';
+import { useViewport, UseViewportOptions } from './useViewport';
 import { ViewportContext } from './context';
 
-const ViewportProvider: React.FC<IUseViewportOptions> = ({ children, ...rest }) => {
+const ViewportProvider: React.FC<UseViewportOptions> = ({ children, ...rest }) => {
   const size = useViewport(rest);
   return <ViewportContext.Provider value={size}>{children}</ViewportContext.Provider>;
 };

--- a/src/hooks/useViewport/context.ts
+++ b/src/hooks/useViewport/context.ts
@@ -1,4 +1,4 @@
 import { createContext } from 'react';
-import { IViewportSize } from './types';
+import { ViewportSize } from './types';
 
-export const ViewportContext = createContext<IViewportSize>({ width: undefined, height: undefined });
+export const ViewportContext = createContext<ViewportSize>({ width: undefined, height: undefined });

--- a/src/hooks/useViewport/types.ts
+++ b/src/hooks/useViewport/types.ts
@@ -1,4 +1,4 @@
-export interface IViewportSize {
+export interface ViewportSize {
   width: number | undefined;
   height: number | undefined;
 }

--- a/src/hooks/useViewport/useViewport.ts
+++ b/src/hooks/useViewport/useViewport.ts
@@ -1,16 +1,16 @@
 import { useLayoutEffect, useState, useContext } from 'react';
 import throttle from 'lodash.throttle';
 import { ViewportContext } from './context';
-import { IViewportSize } from './types';
+import { ViewportSize } from './types';
 
-export interface IUseViewportOptions {
+export interface UseViewportOptions {
   /**
    * The timeout supplied to `lodash.throttle` in case the viewport dimensions are read directly.
    */
   timeout?: number;
 }
 
-function readViewport(): IViewportSize {
+function readViewport(): ViewportSize {
   const width = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
   const height = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
@@ -20,9 +20,11 @@ function readViewport(): IViewportSize {
   };
 }
 
-export function useViewport({ timeout = 300 }: IUseViewportOptions = {}): IViewportSize {
+export function useViewport({ timeout = 300 }: UseViewportOptions = {}): ViewportSize {
   const contextSize = useContext(ViewportContext);
-  if (contextSize.width !== undefined) return contextSize;
+  if (contextSize.width !== undefined) {
+    return contextSize;
+  }
 
   const [size, setSize] = useState(readViewport());
   const onResize = throttle(() => setSize(readViewport()), timeout);


### PR DESCRIPTION
- Enforce naming convention with eslint.
- Remove all the "I" and "T" prefixes (hungarian notation)
- I had to change some types/interfaces names Like `Input` to `InputProps`