### PR TITLE
Fix babel

### DIFF
--- a/etc/rollup/config.js
+++ b/etc/rollup/config.js
@@ -33,7 +33,7 @@ export default {
   plugins: [
     customResolveOptions({ extensions }),
     babel({
-      presets: [['react-app', { flow: false, typescript: true }]],
+      presets: [['react-app', { flow: false, typescript: true, absoluteRuntime: false }]],
       babelHelpers: 'runtime',
       extensions,
       exclude: 'node_modules',

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -91,37 +91,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   text-align: inherit;
 }
 
-.c7 {
-  background-color: transparent;
-  font-size: inherit;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 600;
-  line-height: inherit;
-  color: #3B46C4;
-  cursor: pointer;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  user-select: auto;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0;
-  border: none;
-}
-
-.c7:hover,
-.c7:active {
-  color: #21247F;
-}
-
-.c7:hover svg path,
-.c7:active svg path {
-  fill: #21247F;
-}
-
 .c0 {
   background-color: #FFFFFF;
   padding-bottom: 56px;
@@ -181,6 +150,37 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   margin: 0;
   padding: 0;
   list-style-type: none;
+}
+
+.c7 {
+  background-color: transparent;
+  font-size: inherit;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 600;
+  line-height: inherit;
+  color: #3B46C4;
+  cursor: pointer;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-user-select: auto;
+  -moz-user-select: auto;
+  -ms-user-select: auto;
+  user-select: auto;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 0;
+  border: none;
+}
+
+.c7:hover,
+.c7:active {
+  color: #21247F;
+}
+
+.c7:hover svg path,
+.c7:active svg path {
+  fill: #21247F;
 }
 
 .c6 {

--- a/src/components/molecules/ZopaFooter/styles/Footer.tsx
+++ b/src/components/molecules/ZopaFooter/styles/Footer.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { spacing } from '../../../../constants/spacing';
 import grid from '../../../../constants/grid';
-import { colors } from '../../../..';
+import { colors } from '../../../../constants/colors';
 
 export const Footer = styled.footer`
   background-color: ${colors.white};


### PR DESCRIPTION
## Context

For some reason I was gettting this error:

```ERROR in /Users/gerard.brull/DEV/payments-web/node_modules/@zopauk/react-components/es/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.js
Module not found: Error: Can't resolve '../../../../../../node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/esm/taggedTemplateLiteral.js'
```

As you see somehow the polifyll was taken in a wrong path.

## Solution

I added `absoluteRuntime: false` in the preset react-app. Which by default is `false` BUUUT for some reason I have different results if I add it:

Before:
```../../node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/esm/objectSpread2.js```
After
```../../node_modules/@babel/runtime/helpers/esm/objectSpread2.js```


From the docs:
> This allows users to run transform-runtime broadly across a whole project. By default, transform-runtime imports from @babel/runtime/foo directly, but that only works if @babel/runtime is in the node_modules of the file that is being compiled. This can be problematic for nested node_modules, npm-linked modules, or CLIs that reside outside the user's project, among other cases. To avoid worrying about how the runtime module's location is resolved, this allows users to resolve the runtime once up front, and then insert absolute paths to the runtime into the output code. Using absolute paths is not desirable if files are compiled for use at a later time, but in contexts where a file is compiled and then immediately consumed, they can be quite helpful.
