### PR TITLE
refactor(constants): fix import issue with constants

### DIFF
--- a/src/components/atoms/Alert/Alert.tsx
+++ b/src/components/atoms/Alert/Alert.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 import { faCheckCircle, faExclamationCircle, faInfoCircle, faMinusCircle } from '@fortawesome/free-solid-svg-icons';
 import Icon from '../Icon/Icon';
-import { typography } from '../../../constants/typography';
+import { typography } from '../../../constants';
 
 type Severity = 'info' | 'alert' | 'warning' | 'success';
 

--- a/src/components/atoms/Badge/Badge.tsx
+++ b/src/components/atoms/Badge/Badge.tsx
@@ -1,8 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 import Text from '../Text/Text';
-import { typography } from '../../../constants/typography';
 
 type Styling = 'confirmed' | 'default' | 'invalid' | 'waiting';
 type ColorMapField = { bg: string; text: string };

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,8 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
-import { colors } from '../../../constants/colors';
-import { typography } from '../../../constants/typography';
-import { spacing } from '../../../constants/spacing';
+import { colors, typography, spacing } from '../../../constants';
 import Spinner from '../Spinner/Spinner';
 
 export type Styling = 'primary' | 'secondary' | 'link';

--- a/src/components/atoms/Dropdown/Dropdown.test.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import Dropdown, { Option } from './Dropdown';
 
 describe('<Dropdown />', () => {

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -1,8 +1,7 @@
 import React, { forwardRef } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 import { getBorderColorByStatus } from '../../../helpers/utils';
-import { typography } from '../../../constants/typography';
 import chevronDown from '../../../content/images/chevron-down.svg';
 
 export interface DropdownProps extends React.SelectHTMLAttributes<HTMLSelectElement> {

--- a/src/components/atoms/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/atoms/ErrorMessage/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import Text from '../Text/Text';
 import Icon from '../Icon/Icon';
 

--- a/src/components/atoms/Heading/Heading.test.tsx
+++ b/src/components/atoms/Heading/Heading.test.tsx
@@ -1,8 +1,7 @@
 import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { colors } from '../../../constants/colors';
-import { typography } from '../../../constants/typography';
+import { colors, typography } from '../../../constants';
 import Heading from './Heading';
 const {
   sizes: { heading: headingSizes },

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -1,8 +1,7 @@
 import React, { FC } from 'react';
 import styled, { css } from 'styled-components';
-import { typography } from '../../../constants/typography';
-import { colors, Colors } from '../../../constants/colors';
-import grid from '../../../constants/grid';
+import { colors, grid, typography } from '../../../constants';
+import { Colors } from '../../../constants/colors';
 
 type HeadingTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
 

--- a/src/components/atoms/InputLabel/InputLabel.tsx
+++ b/src/components/atoms/InputLabel/InputLabel.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes, FC } from 'react';
 import styled from 'styled-components';
-import { typography } from '../../../constants/typography';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 
 export interface InputLabelProps extends HTMLAttributes<HTMLLabelElement> {
   /**

--- a/src/components/atoms/InputRange/styles/Button.tsx
+++ b/src/components/atoms/InputRange/styles/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import grid from '../../../../constants/grid';
+import { grid } from '../../../../constants';
 import { ButtonProps, buttonStyle } from '../../Button/Button';
 
 const ButtonWrapper = styled.div`

--- a/src/components/atoms/InputRange/styles/Icon.tsx
+++ b/src/components/atoms/InputRange/styles/Icon.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import ZopaIcon from '../../Icon/Icon';
-import grid from '../../../../constants/grid';
+import { grid } from '../../../../constants';
 
 export const Icon = styled(ZopaIcon)`
   display: block;

--- a/src/components/atoms/InputRange/styles/Input.tsx
+++ b/src/components/atoms/InputRange/styles/Input.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent } from 'react';
 import styled, { css } from 'styled-components';
-import { colors } from '../../../../constants/colors';
-import grid from '../../../../constants/grid';
+import { colors, grid } from '../../../../constants';
 import arrowsAltH from '../../../../content/images/arrows-alt-h.svg';
 import { InputRange } from '../InputRange';
 

--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
-import { typography } from '../../../constants/typography';
+import { colors, typography } from '../../../constants';
 import { getBorderColorByStatus } from '../../../helpers/utils';
 import { InputProps } from '../../types';
 

--- a/src/components/atoms/Link/Link.test.tsx
+++ b/src/components/atoms/Link/Link.test.tsx
@@ -1,7 +1,7 @@
 import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import Link from './Link';
 
 describe('<Link />', () => {

--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { colors } from '../../../constants/colors';
-import { typography } from '../../../constants/typography';
+import { colors, typography } from '../../../constants';
 
 export interface LinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement>,

--- a/src/components/atoms/Logo/Logo.tsx
+++ b/src/components/atoms/Logo/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 
 export interface LogoProps extends React.SVGProps<SVGSVGElement> {
   width?: string;

--- a/src/components/atoms/SidekickCard/SidekickCard.tsx
+++ b/src/components/atoms/SidekickCard/SidekickCard.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import alert from '../../../content/images/alert-icon.svg';
 import triumph from '../../../content/images/triumph-icon.svg';
 import verified from '../../../content/images/valid-icon.svg';

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 
 export interface SpinnerProps {
   /**

--- a/src/components/atoms/Text/Text.test.tsx
+++ b/src/components/atoms/Text/Text.test.tsx
@@ -2,7 +2,7 @@ import { axe } from 'jest-axe';
 import React from 'react';
 import { render } from '@testing-library/react';
 import Text from './Text';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 
 describe('<Text />', () => {
   it('renders without  a11y violations', async () => {

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -1,8 +1,8 @@
 import React, { HTMLAttributes } from 'react';
 import { FC } from 'react';
 import styled from 'styled-components';
-import { typography } from '../../../constants/typography';
-import { colors, Colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
+import { Colors } from '../../../constants/colors';
 
 export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
   /**

--- a/src/components/layout/FlexCol/FlexCol.tsx
+++ b/src/components/layout/FlexCol/FlexCol.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import styled, { css } from 'styled-components';
-import grid, { GridBreakpoints } from '../../../constants/grid';
+import { grid } from '../../../constants';
+import { GridBreakpoints } from '../../../constants/grid';
 
 export type AlignSelf = 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'auto';
 export type ColWidth = number | 'fill' | 'auto' | 'hidden';

--- a/src/components/layout/FlexContainer/FlexContainer.tsx
+++ b/src/components/layout/FlexContainer/FlexContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import grid from '../../../constants/grid';
+import { grid } from '../../../constants';
 
 export interface FlexContainerGutter {
   gutter?: number;

--- a/src/components/layout/FlexRow/FlexRow.tsx
+++ b/src/components/layout/FlexRow/FlexRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import grid from '../../../constants/grid';
+import { grid } from '../../../constants';
 
 export type FlexAlignmentValues = 'stretch' | 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'initial' | 'inherit';
 

--- a/src/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/src/components/molecules/CheckboxField/CheckboxField.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 import tealCheckMark from '../../../content/images/teal-check-mark.svg';
 import greyCheckMark from '../../../content/images/grey-check-mark.svg';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
-import { typography } from '../../../constants/typography';
 import { getBorderColorByStatus } from '../../../helpers/utils';
 import { FieldProps, InputProps } from '../../types';
 

--- a/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
+++ b/src/components/molecules/DropdownFiltered/DropdownFiltered.tsx
@@ -1,7 +1,7 @@
 import Downshift, { ControllerStateAndHelpers, DownshiftProps } from 'downshift';
 import React from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';

--- a/src/components/molecules/DropdownFiltered/Option.ts
+++ b/src/components/molecules/DropdownFiltered/Option.ts
@@ -1,5 +1,4 @@
-import { typography } from '../../../constants/typography';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 import styled, { css } from 'styled-components';
 
 interface OptionProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/src/components/molecules/DropdownFiltered/Options.ts
+++ b/src/components/molecules/DropdownFiltered/Options.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 
 export interface OptionsListProps {
   optionsListMaxHeight?: string;

--- a/src/components/molecules/DropdownFiltered/SearchInput.ts
+++ b/src/components/molecules/DropdownFiltered/SearchInput.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import InputText from '../../atoms/InputText/InputText';
 import { InputProps } from '../../types';
 

--- a/src/components/molecules/Help/Help.tsx
+++ b/src/components/molecules/Help/Help.tsx
@@ -5,8 +5,7 @@ import Text from '../../atoms/Text/Text';
 import Heading from '../../atoms/Heading/Heading';
 import FlexCol from '../../layout/FlexCol/FlexCol';
 import FlexRow from '../../layout/FlexRow/FlexRow';
-import { colors } from '../../../constants/colors';
-import grid from '../../../constants/grid';
+import { colors, grid } from '../../../constants';
 
 const HelpWrap = styled.div`
   background: ${colors.white};

--- a/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
+++ b/src/components/molecules/Modal/ModalStyles/ModalStyles.tsx
@@ -1,6 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
-
-import { colors } from '../../../../constants/colors';
+import { colors } from '../../../../constants';
 
 export interface ModalStylesProps {
   /**

--- a/src/components/molecules/Progress/Progress.tsx
+++ b/src/components/molecules/Progress/Progress.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties, HTMLAttributes } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../constants/colors';
-import { typography } from '../../../constants/typography';
+import { colors, typography } from '../../../constants';
 import Text from '../../atoms/Text/Text';
 
 export interface ProgressionStyleProps {

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 import { getBorderColorByStatus } from '../../../helpers/utils';
-import { typography } from '../../../constants/typography';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
 import { FieldProps, InputStatus, InputProps } from '../../types';

--- a/src/components/molecules/TextField/TextField.tsx
+++ b/src/components/molecules/TextField/TextField.tsx
@@ -5,8 +5,7 @@ import Text from '../../atoms/Text/Text';
 import InputText from '../../atoms/InputText/InputText';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
-import { typography } from '../../../constants/typography';
-import { colors } from '../../../constants/colors';
+import { colors, typography } from '../../../constants';
 import { FieldProps, InputProps } from '../../types';
 
 export interface TextFieldProps extends FieldProps, InputProps {

--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -4,7 +4,7 @@ import FlexRow from '../../layout/FlexRow/FlexRow';
 import FlexCol from '../../layout/FlexCol/FlexCol';
 import Text from '../../atoms/Text/Text';
 import { Footer, Heading, LegalBlock, List, ListLink, LogoBlock, SocialBlock, SocialLink } from './styles';
-import { colors } from '../../../constants/colors';
+import { colors } from '../../../constants';
 import facebook from '../../../content/images/social/facebook.svg';
 import twitter from '../../../content/images/social/twitter.svg';
 import instagram from '../../../content/images/social/instagram.svg';

--- a/src/components/molecules/ZopaFooter/styles/Footer.tsx
+++ b/src/components/molecules/ZopaFooter/styles/Footer.tsx
@@ -1,7 +1,5 @@
 import styled from 'styled-components';
-import { spacing } from '../../../../constants/spacing';
-import grid from '../../../../constants/grid';
-import { colors } from '../../../../constants/colors';
+import { colors, grid, spacing } from '../../../../constants';
 
 export const Footer = styled.footer`
   background-color: ${colors.white};

--- a/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import FlexCol from '../../../layout/FlexCol/FlexCol';
-import grid from '../../../../constants/grid';
+import { grid } from '../../../../constants';
 
 export const LegalBlock = styled(FlexCol).attrs({ xs: 12, l: 5 })`
   order: 3;

--- a/src/components/molecules/ZopaFooter/styles/ListLink.tsx
+++ b/src/components/molecules/ZopaFooter/styles/ListLink.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Link, { LinkProps } from '../../../atoms/Link/Link';
-import { typography } from '../../../../constants/typography';
-import { spacing } from '../../../../constants/spacing';
+import { spacing, typography } from '../../../../constants';
 
 const ListItem = styled.li`
   margin-bottom: ${spacing[4]};

--- a/src/components/molecules/ZopaFooter/styles/LogoBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/LogoBlock.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import FlexCol from '../../../layout/FlexCol/FlexCol';
-import { spacing } from '../../../../constants/spacing';
-import grid from '../../../../constants/grid';
+import { grid, spacing } from '../../../../constants';
 
 export const LogoBlock = styled(FlexCol).attrs({ xs: 12, l: 3 })`
   margin-bottom: ${spacing[8]};

--- a/src/components/molecules/ZopaFooter/styles/SocialBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/SocialBlock.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import FlexCol from '../../../layout/FlexCol/FlexCol';
-import { spacing } from '../../../../constants/spacing';
-import grid from '../../../../constants/grid';
+import { grid, spacing } from '../../../../constants';
 
 export const SocialBlock = styled(FlexCol).attrs({ xs: 12, l: 4 })`
   margin-bottom: ${spacing[7]};

--- a/src/components/molecules/ZopaFooter/styles/SocialLink.tsx
+++ b/src/components/molecules/ZopaFooter/styles/SocialLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Link, { LinkProps } from '../../../atoms/Link/Link';
 import { Icon } from './Icon';
-import { spacing } from '../../../../constants/spacing';
+import { spacing } from '../../../../constants';
 
 interface SocialLink extends LinkProps {
   variant: string;

--- a/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.tsx
+++ b/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.tsx
@@ -1,9 +1,8 @@
 import React, { FC, HTMLAttributes } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../../constants/colors';
+import { colors, spacing } from '../../../../constants';
 import Text from '../../../atoms/Text/Text';
 import { useAccordionContext } from '../hooks';
-import { spacing } from '../../../../constants/spacing';
 
 export interface AccordionHeader extends Omit<HTMLAttributes<HTMLButtonElement>, 'onClick'> {
   id: string;

--- a/src/components/organisms/Card/Card/Card.tsx
+++ b/src/components/organisms/Card/Card/Card.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-import { typography } from '../../../../constants/typography';
-import { colors } from '../../../../constants/colors';
+import { colors, typography } from '../../../../constants';
 import { CardImageContainer } from '../CardImage/CardImage';
 import CardHeading from '../CardHeading/CardHeading';
 import CardText from '../CardText/CardText';

--- a/src/components/organisms/Card/CardHeading/CardHeading.tsx
+++ b/src/components/organisms/Card/CardHeading/CardHeading.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-import { colors } from '../../../../constants/colors';
-import { typography } from '../../../../constants/typography';
+import { colors, typography } from '../../../../constants';
 
 const CardHeading = styled.h6`
   color: ${colors.greyDark};

--- a/src/components/organisms/Card/CardText/CardText.tsx
+++ b/src/components/organisms/Card/CardText/CardText.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-import { colors } from '../../../../constants/colors';
-import { typography } from '../../../../constants/typography';
+import { colors, typography } from '../../../../constants';
 
 const CardText = styled.p`
   color: ${colors.grey};

--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { colors } from '../../../../constants/colors';
-import { navbarHeight } from '../../../../constants/components';
+import { colors, navbarHeight } from '../../../../constants';
 import useScrollThreshold from '../useScrollThreshold/useScrollThreshold';
 import FlexContainer from '../../../layout/FlexContainer/FlexContainer';
 

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../../../constants/colors';
+import { colors } from '../../../../../constants';
 
 export type AlignedTo = 'left' | 'right';
 

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../../../constants/colors';
+import { colors } from '../../../../constants';
 import Link, { LinkProps } from '../../../atoms/Link/Link';
 import Icon from '../../../atoms/Icon/Icon';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';

--- a/src/components/styles/GlobalStyles.tsx
+++ b/src/components/styles/GlobalStyles.tsx
@@ -1,6 +1,6 @@
 import { createGlobalStyle, css } from 'styled-components';
 import { normalize } from 'styled-normalize';
-import { typography } from '../../constants/typography';
+import { typography } from '../../constants';
 import { spacing } from './Spacing';
 
 // Universal box sizing with Inheritance. More info: https://css-tricks.com/box-sizing/#article-header-id-6

--- a/src/components/styles/Spacing.ts
+++ b/src/components/styles/Spacing.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
-import { spacing as sizes } from '../../constants/spacing';
-import grid, { GridBreakpoints } from '../../constants/grid';
+import { spacing as sizes, grid } from '../../constants';
+import { GridBreakpoints } from '../../constants/grid';
 
 type SpacingTypes = 'margin' | 'padding';
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,6 @@
+export { breakpoints } from './breakpoints';
+export { colors } from './colors';
+export { default as grid } from './grid';
+export { spacing } from './spacing';
+export { typography } from './typography';
+export { navbarHeight } from './components';

--- a/src/content/Colors/Colors.tsx
+++ b/src/content/Colors/Colors.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-import { colors, Colors, brandColors, actionColors, neutralColors, notificationColors } from './../../constants/colors';
+import { colors } from '../../constants';
+import {
+  Colors as ColorsType,
+  brandColors,
+  actionColors,
+  neutralColors,
+  notificationColors,
+} from '../../constants/colors';
 
-type ColorVariants = keyof Colors;
+type ColorVariants = keyof ColorsType;
 
 interface ColorProps {
   color: string;

--- a/src/content/Spacing/Spacing.tsx
+++ b/src/content/Spacing/Spacing.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import styled from 'styled-components';
-import { colors } from '../../constants/colors';
+import { colors } from '../../constants';
 
 const Square = styled.div`
   background-color: ${colors.greyLightest};

--- a/src/helpers/responsiveness.ts
+++ b/src/helpers/responsiveness.ts
@@ -1,5 +1,6 @@
 import { css } from 'styled-components';
-import { breakpoints, DeviceSizes } from '../constants/breakpoints';
+import { breakpoints } from '../constants';
+import { DeviceSizes } from '../constants/breakpoints';
 
 type Media = Record<DeviceSizes, ReturnType<typeof interpolate>>;
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { InputStatus } from '../components/types';
-import { colors } from '../constants/colors';
+import { colors } from '../constants';
 
 export const mod = (x: number, n: number) => ((x % n) + n) % n;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,7 @@
  */
 
 // Global (colors, fonts, ...)
-export { typography } from './constants/typography';
-export { colors } from './constants/colors';
-export { breakpoints } from './constants/breakpoints';
-export * from './constants/components';
-export { default as grid } from './constants/grid';
+export { breakpoints, colors, grid, spacing, typography, navbarHeight } from './constants';
 export { default as GlobalStyles } from './components/styles/GlobalStyles';
 
 // Atoms


### PR DESCRIPTION
Some times our IDEs had an issue like this `import colors from ../../../`,  and this triggers a circular dependency error.

I created a `constants/index.ts` (exporting the constants) file to avoid this issue in the future.
