### PR TITLE
Fix error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@zopauk/react-components",
   "sideEffects": false,
   "description": "Shared react styled components for all the Zopa projects.",
-  "version": "4.0.0--beta.28",
+  "version": "4.0.0--beta.29",
   "license": "MIT",
   "author": "Zopa Ltd <frontend-opensource@zopa.com> (https://zopa.com)",
   "main": "cjs/src/index.js",

--- a/src/components/atoms/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/atoms/ErrorMessage/ErrorMessage.tsx
@@ -21,6 +21,7 @@ const StyledErrorMessage = styled(Text).attrs({
   line-height: 20px;
   font-family: ${typography.primary};
   font-weight: 400;
+  max-width: 336px;
 
   a {
     font-size: 15px;
@@ -34,7 +35,6 @@ const StyledErrorMessage = styled(Text).attrs({
 `;
 
 const IconWrapper = styled.div`
-  margin-right: 8px;
   font-size: 20px;
 
   svg {

--- a/src/components/atoms/ErrorMessage/__snapshots__/ErrorMessage.test.tsx.snap
+++ b/src/components/atoms/ErrorMessage/__snapshots__/ErrorMessage.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`<ErrorMessage /> renders the component with props with no a11y violatio
   line-height: 20px;
   font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
   font-weight: 400;
+  max-width: 336px;
 }
 
 .c1 a {
@@ -45,7 +46,6 @@ exports[`<ErrorMessage /> renders the component with props with no a11y violatio
 }
 
 .c2 {
-  margin-right: 8px;
   font-size: 20px;
 }
 


### PR DESCRIPTION
Fixes the error messages for small widths and also add max-width like it was before

<img width="194" alt="React_components" src="https://user-images.githubusercontent.com/7198934/82681423-04cac080-9c4e-11ea-9fae-82b58f1d2818.png">

Before:
<img width="317" alt="Zopa (1)" src="https://user-images.githubusercontent.com/7198934/82681555-3cd20380-9c4e-11ea-8eb5-b59e507e2155.png">


