### PR TITLE
fix(navbar): remove renderOpener and rename ariaLabel to just label

### DIFF
--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.md
@@ -2,7 +2,7 @@
 
 The purpose of `<Navbar.Dropdown />` is to handle the visibility state of a dropdown within the main navigation bar.
 
-It also handles all the accessibility attributes internally and passes them down through render props:`renderOpener` and `renderItem`.
+It also handles all the accessibility attributes internally and passes them down through render props: `renderItem`.
 
 The dropdown contents are up to you but by default will render [`<Navbar.Link />`](#/Components/Organisms/Navbar/NavbarLink)
 
@@ -17,47 +17,32 @@ import { Navbar } from '@zopauk/react-components';
 
 <Navbar.Dropdown
   id="basic-example-id"
-  ariaLabel="test"
+  label="test"
   items={[
     { label: 'one', href: '#' },
     { label: 'two', href: '#' },
     { label: 'three', href: '#' },
   ]}
-  renderOpener={({ open, getOpenerProps }) => (
-    <div style={{ padding: 8 }}>
-      <Navbar.Link href="#" {...getOpenerProps()}>
-        opener
-      </Navbar.Link>
-    </div>
-  )}
 />;
 ```
 
-<!--
 - With custom components
 
 ```ts { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#FFFFFF", "border": "2px solid #efefef" } } }
-import { Navbar, Link, HamburgerIcon, colors } from '@zopauk/react-components';
+import { Navbar, Link } from '@zopauk/react-components';
 
 <Navbar.Dropdown
   id="custom-example-id"
-  ariaLabel="test"
+  label="test"
   items={[
     { label: 'one', href: '#' },
     { label: 'two', href: '#' },
     { label: 'three', href: '#' },
   ]}
-  renderOpener={({ open, getOpenerProps }) => (
-    <div style={{ padding: 8 }}>
-      <Navbar.Link href="#" {...getOpenerProps()}>
-        <HamburgerIcon size="30px" activeColor={colors.actionDark} inactiveColor={colors.actionPlain} />
-      </Navbar.Link>
-    </div>
-  )}
   renderItem={({ item: { label, href }, getItemProps }) => (
     <Link href={href} {...getItemProps()}>
       {label}
     </Link>
   )}
 />;
-``` -->
+```

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.test.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.test.tsx
@@ -7,7 +7,6 @@ describe('<Navbar.Dropdown />', () => {
     { label: 'one', href: '#' },
     { label: 'two', href: '#' },
   ];
-  const renderOpener = ({ getOpenerProps }) => <button {...getOpenerProps()}>opener</button>;
   const renderItem = ({ item: { label, href }, getItemProps }) => (
     <a href={href} {...getItemProps()}>
       {label}
@@ -17,13 +16,7 @@ describe('<Navbar.Dropdown />', () => {
   const renderComponent = () =>
     render(
       <>
-        <Navbar.Dropdown
-          id="unique-dropdown-id"
-          ariaLabel="test"
-          items={items}
-          renderOpener={renderOpener}
-          renderItem={renderItem}
-        />
+        <Navbar.Dropdown id="unique-dropdown-id" label="test" items={items} renderItem={renderItem} />
         <button>button</button>
       </>,
     );

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
@@ -5,8 +5,7 @@ import { isArrowDown, isArrowUp, isEnter, isEscape, isSpace } from '../../../../
 import { mod } from '../../../../helpers/utils';
 import { minMedia } from '../../../../helpers/responsiveness';
 import NavbarDropdownList from './NavbarDropdownList/NavbarDropdownList';
-
-import Navbar from '../';
+import NavbarLink from '../NavbarLink/NavbarLink';
 
 const NavbarDropdownContainer = styled.div`
   position: relative;
@@ -14,8 +13,6 @@ const NavbarDropdownContainer = styled.div`
 `;
 
 export type ButtonLinkElement = HTMLButtonElement | HTMLAnchorElement;
-
-export type AlignedTo = 'left' | 'right';
 
 export interface NavbarDropdownListContainer extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
@@ -59,11 +56,6 @@ export type Item = any;
 
 export type GetOpenerProps = () => OpenerProps;
 
-export interface RenderOpenerProps {
-  open: boolean;
-  getOpenerProps: GetOpenerProps;
-}
-
 export interface ItemProps {
   ref: React.RefObject<HTMLLIElement>;
   onKeyDown: React.EventHandler<React.KeyboardEvent>;
@@ -80,18 +72,16 @@ export interface RenderItemProps {
   getItemProps: GetItemProps;
   close: Close;
 }
-interface DefaultNavbarDropdownProps {
+export interface DefaultNavbarDropdownProps {
   /** Function getting all the props and aria attributes meant to be spread on the dropdown item links */
   renderItem: ({ item, getItemProps, close }: RenderItemProps) => React.ReactNode;
 }
 export interface NavbarDropdownProps extends DefaultNavbarDropdownProps {
   /** unique id */
   id: string;
-  /** Short description of the navbar component */
-  ariaLabel: string;
-  /** Function getting all the props and aria attributes meant to be spread on the opener button/link */
-  renderOpener: ({ open, getOpenerProps }: RenderOpenerProps) => React.ReactNode;
-  /** Array of data representing the dropdown items (e.g links) */
+  /** dropdown label */
+  label: string;
+  /** array of data representing the dropdown items (e.g links) */
   items: Item[];
 }
 
@@ -103,9 +93,9 @@ export interface NavbarDropdownState {
 export default class NavbarDropdown extends React.Component<NavbarDropdownProps, NavbarDropdownState> {
   static defaultProps: DefaultNavbarDropdownProps = {
     renderItem: ({ item: { label, href }, getItemProps }) => (
-      <Navbar.Link href={href} {...getItemProps()} isDropdownLink>
+      <NavbarLink href={href} {...getItemProps()} isDropdownLink>
         {label}
-      </Navbar.Link>
+      </NavbarLink>
     ),
   };
 
@@ -154,14 +144,16 @@ export default class NavbarDropdown extends React.Component<NavbarDropdownProps,
 
   public render() {
     const { getOpenerProps, close } = this;
-    const { renderOpener, renderItem, items, ariaLabel, id } = this.props;
+    const { renderItem, items, label, id } = this.props;
     const { open } = this.state;
 
     return (
       <NavbarDropdownContainer ref={this.dropdownRef}>
-        {renderOpener({ open, getOpenerProps })}
+        <NavbarLink open={open} withChevron={true} href="#" {...getOpenerProps()}>
+          {label}
+        </NavbarLink>
         <NavbarDropdownListContainer open={open}>
-          <NavbarDropdownList ref={this.dropdownListRef} role="menu" aria-label={ariaLabel}>
+          <NavbarDropdownList ref={this.dropdownListRef} role="menu" aria-label={label}>
             {items.map((item, index) => (
               <li key={`${id}-${index}`} role="none">
                 {renderItem({

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.test.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.test.tsx
@@ -5,11 +5,7 @@ import NavbarDropdownList from './NavbarDropdownList';
 describe('NavbarDropdownList', () => {
   it('renders the component with props', () => {
     const ref = React.createRef<HTMLUListElement>();
-    const { container } = render(
-      <NavbarDropdownList alignedTo="left" ref={ref}>
-        list
-      </NavbarDropdownList>,
-    );
+    const { container } = render(<NavbarDropdownList ref={ref}>list</NavbarDropdownList>);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
@@ -3,8 +3,6 @@ import styled, { css } from 'styled-components';
 import { colors, spacing } from '../../../../../constants';
 import { minMedia } from '../../../../../helpers/responsiveness';
 
-export type AlignedTo = 'left' | 'right';
-
 const NavbarDropdownList = styled.ul`
   margin: ${spacing[3]} 0 ${spacing[3]};
   padding: 0;

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/NavbarDropdownList.tsx
@@ -4,6 +4,8 @@ import { colors, spacing } from '../../../../../constants';
 import { minMedia } from '../../../../../helpers/responsiveness';
 
 const NavbarDropdownList = styled.ul`
+  position: relative;
+  z-index: 1;
   margin: ${spacing[3]} 0 ${spacing[3]};
   padding: 0;
 
@@ -21,8 +23,7 @@ const NavbarDropdownList = styled.ul`
       margin: 0;
       padding: ${spacing[2]};
 
-      &:after {
-        z-index: 1;
+      &:before {
         content: '';
         top: 1px;
         left: 50%;

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/__snapshots__/NavbarDropdownList.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdownList/__snapshots__/NavbarDropdownList.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`NavbarDropdownList renders the component with props 1`] = `
 .c0 {
+  position: relative;
+  z-index: 1;
   margin: 12px 0 12px;
   padding: 0;
   list-style-type: none;
@@ -19,8 +21,7 @@ exports[`NavbarDropdownList renders the component with props 1`] = `
     padding: 8px;
   }
 
-  .c0:after {
-    z-index: 1;
+  .c0:before {
     content: '';
     top: 1px;
     left: 50%;

--- a/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
@@ -1,11 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Navbar.Dropdown /> should render component 1`] = `
-.c2 {
+.c6 {
   margin: 12px 0 12px;
   padding: 0;
   list-style-type: none;
   border-bottom: 1px solid #EFEFEF;
+}
+
+.c1 {
+  background-color: transparent;
+  font-size: inherit;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 600;
+  line-height: inherit;
+  color: #3B46C4;
+  cursor: pointer;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-user-select: auto;
+  -moz-user-select: auto;
+  -ms-user-select: auto;
+  user-select: auto;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 0;
+  border: none;
+}
+
+.c1:hover,
+.c1:active {
+  color: #21247F;
+}
+
+.c1:hover svg path,
+.c1:active svg path {
+  fill: #21247F;
+}
+
+.c2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  padding: 12px 16px 16px;
+}
+
+.c2:active,
+.c2:hover {
+  opacity: 0.88;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-right: 8px;
+}
+
+.c4 {
+  display: none;
 }
 
 .c0 {
@@ -14,7 +76,7 @@ exports[`<Navbar.Dropdown /> should render component 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c6 {
     background-color: #FFFFFF;
     box-shadow: 0px 1px 0px 1px #D4D7D9;
     border: 1px solid #EFEFEF;
@@ -24,7 +86,7 @@ exports[`<Navbar.Dropdown /> should render component 1`] = `
     padding: 8px;
   }
 
-  .c2:after {
+  .c6:after {
     z-index: 1;
     content: '';
     top: 1px;
@@ -40,8 +102,37 @@ exports[`<Navbar.Dropdown /> should render component 1`] = `
   }
 }
 
+@media (max-width:1280px) {
+  .c2 {
+    color: #2C3236;
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+}
+
 @media (min-width:1280px) {
-  .c1 {
+  .c4 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    font-size: 12px;
+    -webkit-transition: -webkit-transform 0.3s;
+    -webkit-transition: transform 0.3s;
+    transition: transform 0.3s;
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+}
+
+@media (min-width:1280px) {
+  .c5 {
     position: absolute;
     left: 50%;
     top: 50px;
@@ -59,20 +150,47 @@ exports[`<Navbar.Dropdown /> should render component 1`] = `
 <div
   class="c0"
 >
-  <button
+  <a
     aria-expanded="false"
     aria-haspopup="true"
+    class="c1 c2"
+    color="#3B46C4"
+    href="#"
     role="menuitem"
     tabindex="0"
   >
-    opener
-  </button>
+    <span
+      class="c3"
+    >
+      test
+    </span>
+    <span
+      class="c4"
+    >
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-chevron-down fa-w-14 fa-fw "
+        color="#818F9B"
+        data-icon="chevron-down"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        viewBox="0 0 448 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+  </a>
   <div
-    class="c1"
+    class="c5"
   >
     <ul
       aria-label="test"
-      class="c2"
+      class="c6"
       role="menu"
     >
       <li

--- a/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`<Navbar.Dropdown /> should render component 1`] = `
 .c6 {
+  position: relative;
+  z-index: 1;
   margin: 12px 0 12px;
   padding: 0;
   list-style-type: none;
@@ -86,8 +88,7 @@ exports[`<Navbar.Dropdown /> should render component 1`] = `
     padding: 8px;
   }
 
-  .c6:after {
-    z-index: 1;
+  .c6:before {
     content: '';
     top: 1px;
     left: 50%;

--- a/src/components/organisms/Navbar/NavbarLinksList/NavbarLinksList.md
+++ b/src/components/organisms/Navbar/NavbarLinksList/NavbarLinksList.md
@@ -1,6 +1,6 @@
 ### Summary
 
-[`<Navbar.LinksList />`](#/Components/Organisms/Navbar/NavbarLinksList) is responsible for rendering navbar links. By default it will render [`<Navbar.Dropdown />`](#/Components/Organisms/Navbar/NavbarDropdown) for `links` with `children` and [`<Navbar.Link />`](#/Components/Organisms/Navbar/NavbarLink) for `links` within a dropdown (if using `<Navbar.Dropdown />`) or `links` without `children`. These can be changed using the `renderDropdown` and `renderLink` props.
+[`<Navbar.LinksList />`](#/Components/Organisms/Navbar/NavbarLinksList) is responsible for rendering navbar links. By default it will render [`<Navbar.Dropdown />`](#/Components/Organisms/Navbar/NavbarDropdown) for `links` with `children` and [`<Navbar.Link />`](#/Components/Organisms/Navbar/NavbarLink) for `links` within a dropdown (if using `<Navbar.Dropdown />`) or `links` without `children`. These can be changed using the `renderLink` props.
 
 ### Examples
 
@@ -12,7 +12,6 @@ import { Navbar } from '@zopauk/react-components';
 const NAV_ITEMS = [
   {
     label: 'About',
-    href: '/about',
     qadata: 'About.topBar.Menu',
     children: [
       {
@@ -70,7 +69,6 @@ import { Navbar, Link } from '@zopauk/react-components';
 const NAV_ITEMS = [
   {
     label: 'About',
-    href: '/about',
     qadata: 'About.topBar.Menu',
     children: [
       {
@@ -119,12 +117,6 @@ const NAV_ITEMS = [
 
 <Navbar.LinksList
   links={NAV_ITEMS}
-  renderDropdown={(item, index) => (
-    <div>
-      Custom Dropdown
-      <br /> {item.children.map(link => `${link.label} `)}
-    </div>
-  )}
   renderLink={(item, props) => (
     <Link href={item.href} target="_blank" {...props}>
       {item.label}

--- a/src/components/organisms/Navbar/NavbarLinksList/NavbarLinksList.test.tsx
+++ b/src/components/organisms/Navbar/NavbarLinksList/NavbarLinksList.test.tsx
@@ -7,7 +7,6 @@ describe('<Navbar.LinksList />', () => {
     const NAV_ITEMS = [
       {
         label: 'About',
-        href: '/about',
         qadata: 'About.topBar.Menu',
         children: [
           {

--- a/src/components/organisms/Navbar/NavbarLinksList/NavbarLinksList.tsx
+++ b/src/components/organisms/Navbar/NavbarLinksList/NavbarLinksList.tsx
@@ -13,11 +13,10 @@ export interface NavigationItem {
 
 export interface NavbarLinksList {
   links?: NavigationItem[];
-  renderDropdown?: (item: NavigationItem, index: number) => React.ReactNode;
   renderLink?: (item: NavigationItem, index: number, props?: any) => React.ReactNode;
 }
 
-interface NavbarLinksListLinkProps extends NavbarLinkProps {
+export interface NavbarLinksListLinkProps extends NavbarLinkProps {
   'data-automation'?: string;
 }
 
@@ -27,61 +26,40 @@ export interface NavbarLinksListLink {
   props: NavbarLinksListLinkProps;
 }
 
-const NavbarLinksListLink = ({ item: { label, href, onClick }, index, props }: NavbarLinksListLink) => {
-  return (
-    <Navbar.Link key={`navbar-link-${index}`} href={href} onClick={onClick} {...props}>
-      {label}
-    </Navbar.Link>
-  );
-};
+const NavbarLinksListLink = ({ item: { label, href, onClick }, index, props }: NavbarLinksListLink) => (
+  <Navbar.Link key={`navbar-link-${index}`} href={href} onClick={onClick} {...props}>
+    {label}
+  </Navbar.Link>
+);
 
 const NavbarLinksList: React.FC<NavbarLinksList> = ({
   links,
   renderLink = (item: NavigationItem, index: number, props) => (
     <NavbarLinksListLink item={item} index={index} props={props} />
   ),
-  renderDropdown = (item: NavigationItem, index: number) => (
-    <Navbar.Dropdown
-      id={`navbar-dropdown-${index}`}
-      ariaLabel={item.label}
-      items={item.children!}
-      renderOpener={({ open, getOpenerProps }) => {
-        return (
-          <NavbarLinksListLink
-            item={item}
-            index={index}
-            props={{
-              href: '#',
-              ...getOpenerProps(),
-              withChevron: true,
-              open,
-              'data-automation': item.qadata ?? `ZA.${item.qadata}`,
-            }}
+}) => (
+  <>
+    {links &&
+      links.map((item: NavigationItem, index: number) =>
+        !!item.children ? (
+          <Navbar.Dropdown
+            key={`dropdown-${index}`}
+            id={`navbar-dropdown-${index}`}
+            label={item.label}
+            items={item.children!}
+            renderItem={({ item, getItemProps }) =>
+              renderLink(item, index, {
+                ...getItemProps(),
+                isDropdownLink: true,
+                'data-automation': item.qadata ?? `ZA.${item.qadata}`,
+              })
+            }
           />
-        );
-      }}
-      renderItem={({ item, getItemProps }) => {
-        return renderLink(item, index, {
-          ...getItemProps(),
-          isDropdownLink: true,
-          'data-automation': item.qadata ?? `ZA.${item.qadata}`,
-        });
-      }}
-    />
-  ),
-}) => {
-  return (
-    <>
-      {links &&
-        links.map((item: NavigationItem, index: number) => {
-          return !!item.children ? (
-            <Fragment key={`dropdown-${index}`}>{renderDropdown(item, index)}</Fragment>
-          ) : (
-            <Fragment key={`link-${index}`}>{renderLink(item, index)}</Fragment>
-          );
-        })}
-    </>
-  );
-};
+        ) : (
+          <Fragment key={`link-${index}`}>{renderLink(item, index)}</Fragment>
+        ),
+      )}
+  </>
+);
 
 export default NavbarLinksList;

--- a/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
@@ -10,11 +10,6 @@ Object {
   border-bottom: 1px solid #EFEFEF;
 }
 
-.c0 {
-  position: relative;
-  display: inline-block;
-}
-
 .c1 {
   background-color: transparent;
   font-size: inherit;
@@ -115,6 +110,11 @@ Object {
   display: none;
 }
 
+.c0 {
+  position: relative;
+  display: inline-block;
+}
+
 @media (min-width:1280px) {
   .c6 {
     background-color: #FFFFFF;
@@ -139,22 +139,6 @@ Object {
     transform: translate(-50%,-50%) rotate(135deg);
     background-color: inherit;
     box-shadow: -1px 1px 0 0 #EFEFEF;
-  }
-}
-
-@media (min-width:1280px) {
-  .c5 {
-    position: absolute;
-    left: 50%;
-    top: 50px;
-    -webkit-transition: opacity 0.3s,-webkit-transform 0.3s,visibility 0.3s 0.3s;
-    -webkit-transition: opacity 0.3s,transform 0.3s,visibility 0.3s 0.3s;
-    transition: opacity 0.3s,transform 0.3s,visibility 0.3s 0.3s;
-    opacity: 0;
-    visibility: hidden;
-    -webkit-transform: translate(-50%,-10%);
-    -ms-transform: translate(-50%,-10%);
-    transform: translate(-50%,-10%);
   }
 }
 
@@ -199,6 +183,22 @@ Object {
   }
 }
 
+@media (min-width:1280px) {
+  .c5 {
+    position: absolute;
+    left: 50%;
+    top: 50px;
+    -webkit-transition: opacity 0.3s,-webkit-transform 0.3s,visibility 0.3s 0.3s;
+    -webkit-transition: opacity 0.3s,transform 0.3s,visibility 0.3s 0.3s;
+    transition: opacity 0.3s,transform 0.3s,visibility 0.3s 0.3s;
+    opacity: 0;
+    visibility: hidden;
+    -webkit-transform: translate(-50%,-10%);
+    -ms-transform: translate(-50%,-10%);
+    transform: translate(-50%,-10%);
+  }
+}
+
 <body>
     <div>
       <div
@@ -209,7 +209,6 @@ Object {
           aria-haspopup="true"
           class="c1 c2"
           color="#3B46C4"
-          data-automation="About.topBar.Menu"
           href="#"
           role="menuitem"
           tabindex="0"
@@ -360,25 +359,24 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-dnqmqq ghmWLu"
+      class="sc-jTzLTM dahxmI"
     >
       <a
         aria-expanded="false"
         aria-haspopup="true"
-        class="sc-gZMcBi lfByGy sc-VigVT cFxqPO"
+        class="sc-dnqmqq erwKhR sc-gZMcBi heSWSQ"
         color="#3B46C4"
-        data-automation="About.topBar.Menu"
         href="#"
         role="menuitem"
         tabindex="0"
       >
         <span
-          class="sc-jTzLTM edgmm"
+          class="sc-gqjmRU kyarqY"
         >
           About
         </span>
         <span
-          class="sc-fjdhpX dHfski"
+          class="sc-VigVT jqhKcv"
         >
           <svg
             aria-hidden="true"
@@ -399,7 +397,7 @@ Object {
         </span>
       </a>
       <div
-        class="sc-iwsKbI gPniSp"
+        class="sc-fjdhpX iozrnZ"
       >
         <ul
           aria-label="About"
@@ -410,7 +408,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="About.About.topBar.Menu"
               href="/about"
@@ -424,7 +422,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="Story.About.topBar.Menu"
               href="/about/our-story"
@@ -438,7 +436,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="Our_Board.About.topBar.Menu"
               href="/about/board"
@@ -452,7 +450,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="Our_Leadership.About.topBar.Menu"
               href="/about/leadership"
@@ -466,7 +464,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="Awards.About.topBar.Menu"
               href="/about/awards"
@@ -480,7 +478,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="Careers.About.topBar.Menu"
               href="/about/careers"
@@ -494,7 +492,7 @@ Object {
             role="none"
           >
             <a
-              class="sc-gZMcBi lfByGy sc-VigVT dOFmME"
+              class="sc-dnqmqq erwKhR sc-gZMcBi kbmNoe"
               color="#3B46C4"
               data-automation="Press_office.About.topBar.Menu"
               href="/about/press"
@@ -508,7 +506,7 @@ Object {
       </div>
     </div>
     <a
-      class="sc-gZMcBi lfByGy sc-VigVT iPuNjo"
+      class="sc-dnqmqq erwKhR sc-gZMcBi iSkvpf"
       color="#3B46C4"
       href="/contact"
     >

--- a/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`<Navbar.LinksList /> should render component with default props 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": .c6 {
+  position: relative;
+  z-index: 1;
   margin: 12px 0 12px;
   padding: 0;
   list-style-type: none;
@@ -126,8 +128,7 @@ Object {
     padding: 8px;
   }
 
-  .c6:after {
-    z-index: 1;
+  .c6:before {
     content: '';
     top: 1px;
     left: 50%;
@@ -401,7 +402,7 @@ Object {
       >
         <ul
           aria-label="About"
-          class="sc-htoDjs bUBjUg"
+          class="sc-htoDjs kRCWub"
           role="menu"
         >
           <li


### PR DESCRIPTION
There is no need to keep the `renderOpener` prop as the navbar dropdowns should always be consistent when it comes to toggle buttons