### PR TITLE
fix(navbarlink): force color to navbar links

### DIFF
--- a/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
+++ b/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`<Navbar /> should render component with all the props 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -67,6 +68,7 @@ exports[`<Navbar /> should render component with all the props 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -88,6 +90,7 @@ exports[`<Navbar /> should render component with all the props 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1011,6 +1014,7 @@ exports[`<Navbar /> should render large device navigation with default props 1`]
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1032,6 +1036,7 @@ exports[`<Navbar /> should render large device navigation with default props 1`]
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1053,6 +1058,7 @@ exports[`<Navbar /> should render large device navigation with default props 1`]
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1971,6 +1977,7 @@ exports[`<Navbar /> should render small device navigation with default props 1`]
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1992,6 +1999,7 @@ exports[`<Navbar /> should render small device navigation with default props 1`]
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2013,6 +2021,7 @@ exports[`<Navbar /> should render small device navigation with default props 1`]
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2936,6 +2945,7 @@ exports[`<Navbar /> should render the collapsed styled on large device navigatio
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2957,6 +2967,7 @@ exports[`<Navbar /> should render the collapsed styled on large device navigatio
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2978,6 +2989,7 @@ exports[`<Navbar /> should render the collapsed styled on large device navigatio
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`<NavbarDropdown /> should render component 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
@@ -30,7 +30,8 @@ export interface ChevronContainerProps extends React.HTMLAttributes<HTMLSpanElem
 export const navbarLinkStyles = css<StyledNavbarLinkProps>`
   align-items: center;
   text-decoration: none;
-  font-weight: ${typography.weights.semiBold}
+  font-weight: ${typography.weights.semiBold};
+  color: ${colors.actionPlain};
 
   display: inline-flex;
   padding: ${spacing[3]} ${spacing[4]} ${spacing[4]};

--- a/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`<Navbar.Link /> should render component with default props 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -99,6 +100,7 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
@@ -51,6 +51,7 @@ Object {
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 600;
+  color: #3B46C4;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -282,7 +283,7 @@ Object {
       <a
         aria-expanded="false"
         aria-haspopup="true"
-        class="sc-bwzfXH haaJDm sc-bxivhb eXaLSp"
+        class="sc-bwzfXH haaJDm sc-bxivhb bfHzAc"
         color="#3B46C4"
         href="#"
         role="menuitem"


### PR DESCRIPTION
Issue (in Shopfront) with `:active` links:

<img width="275" alt="Screenshot 2020-06-09 at 16 37 43" src="https://user-images.githubusercontent.com/337955/84161491-a1bf9300-aa6f-11ea-9da0-be3cc8fb9ca5.png">
