### PR TITLE
fix(expiry modal): do not show the cross button

### DIFF
--- a/src/components/molecules/ExpiryModal/ExpiryModal.tsx
+++ b/src/components/molecules/ExpiryModal/ExpiryModal.tsx
@@ -16,7 +16,7 @@ interface ExpiryModalProps extends Omit<ModalProps, 'children'> {
 
 export default function ExpiryModal({ onEndSession, onKeepSession, ...rest }: ExpiryModalProps) {
   return (
-    <Modal {...rest}>
+    <Modal showCloseButton={false} {...rest}>
       <Card styling="primary">
         <Card.Content>
           <Card.Heading>Your session is about to expire</Card.Heading>


### PR DESCRIPTION
As mentioned in the issue there's no need to show the cross icon in `ExpiryModal`
Fixes #502