### PR TITLE
fix(navbar): close hamburger menu on link click

### DIFF
--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -20,6 +20,7 @@ import useScrollThreshold from '../useScrollThreshold/useScrollThreshold';
 import NavbarLink, { NavbarLinkProps } from '../NavbarLink/NavbarLink';
 import NavbarAction from '../NavbarAction/NavbarAction';
 import NavbarLinksList from '../NavbarLinksList/NavbarLinksList';
+import { useOpen } from '../OpenProvider';
 
 export interface NavigationItem {
   label: string;
@@ -284,7 +285,7 @@ const NavbarWrapper: React.FC<NavbarProps> = ({
 }) => {
   const { width } = useViewport();
   const overThreshold = useScrollThreshold(20);
-  const [open, setOpen] = useState<boolean>(false);
+  const { open, setOpen } = useOpen();
   const [height, setHeight] = useState(0);
 
   useEffect(() => {

--- a/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
+++ b/src/components/organisms/Navbar/NavbarLink/NavbarLink.tsx
@@ -7,6 +7,7 @@ import { minMedia, maxEqualToMedia } from '../../../../helpers/responsiveness';
 
 import Link, { LinkProps } from '../../../atoms/Link/Link';
 import Icon from '../../../atoms/Icon/Icon';
+import { useOpen } from '../OpenProvider';
 
 export interface NavbarLinkStyleProps {
   active?: boolean;
@@ -133,26 +134,37 @@ const NavbarLink: FC<NavbarLinkProps> = React.forwardRef<HTMLAnchorElement, Navb
       withChevron = false,
       isDropdownLink = false,
       isDropdownHeading = false,
+      onClick,
       ...rest
     },
     ref,
-  ) => (
-    <StyledNavbarLink
-      active={active}
-      withChevron={withChevron}
-      isDropdownLink={isDropdownLink}
-      isDropdownHeading={isDropdownHeading}
-      ref={ref}
-      {...rest}
-    >
-      {withChevron ? <LinkContainer>{children}</LinkContainer> : children}
-      {withChevron && (
-        <ChevronContainer open={open}>
-          <Icon variant={faChevronDown} color={colors.grey} height="12px" width="12px" />
-        </ChevronContainer>
-      )}
-    </StyledNavbarLink>
-  ),
+  ) => {
+    const { setOpen } = useOpen();
+
+    const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+      setOpen(false);
+      onClick && onClick(e);
+    };
+
+    return (
+      <StyledNavbarLink
+        active={active}
+        withChevron={withChevron}
+        isDropdownLink={isDropdownLink}
+        isDropdownHeading={isDropdownHeading}
+        onClick={handleClick}
+        ref={ref}
+        {...rest}
+      >
+        {withChevron ? <LinkContainer>{children}</LinkContainer> : children}
+        {withChevron && (
+          <ChevronContainer open={open}>
+            <Icon variant={faChevronDown} color={colors.grey} height="12px" width="12px" />
+          </ChevronContainer>
+        )}
+      </StyledNavbarLink>
+    );
+  },
 );
 
 export default NavbarLink;

--- a/src/components/organisms/Navbar/OpenProvider.tsx
+++ b/src/components/organisms/Navbar/OpenProvider.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, Dispatch, FC, SetStateAction, useState } from 'react';
+
+interface OpenContextType {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+const OpenContext = createContext<OpenContextType>({
+  open: false,
+  setOpen: () => {
+    /* Empty method to enable typing for useState */
+  },
+});
+
+const OpenProvider: FC = ({ children }) => {
+  const [open, setOpen] = useState(false);
+
+  return <OpenContext.Provider value={{ open, setOpen }}>{children}</OpenContext.Provider>;
+};
+
+const useOpen = () => React.useContext(OpenContext);
+
+export { OpenProvider, useOpen };

--- a/src/components/organisms/Navbar/index.tsx
+++ b/src/components/organisms/Navbar/index.tsx
@@ -2,12 +2,17 @@ import React, { FC } from 'react';
 
 import Navbar, { NavbarProps } from './Navbar/Navbar';
 import NavbarAction from './NavbarAction/NavbarAction';
+import { OpenProvider } from './OpenProvider';
 
 interface NavbarStatic {
   Action: typeof NavbarAction;
 }
 
-const NavbarWrapper: NavbarStatic & FC<NavbarProps> = (props) => <Navbar {...props} />;
+const NavbarWrapper: NavbarStatic & FC<NavbarProps> = (props) => (
+  <OpenProvider>
+    <Navbar {...props} />
+  </OpenProvider>
+);
 
 NavbarWrapper.Action = NavbarAction;
 


### PR DESCRIPTION
Design/UX asked to let the user close the hamburger menu when clicking the same link as the current page.

This PR is to do this tricky logic.