### PR TITLE
Fix disabled input styling on safari

### DIFF
--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -37,6 +37,7 @@ const StyledDropdown = styled.select<DropdownProps>`
 
   &:focus,
   &:hover {
+    outline: none;
     outline-width: 0;
     border: 1px solid ${colors.brand};
     box-shadow: 0 0 4px 0 ${colors.brand};

--- a/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`<Dropdown /> renders the Dropdown with one option 1`] = `
 
 .c0:focus,
 .c0:hover {
+  outline: none;
   outline-width: 0;
   border: 1px solid #00D9C5;
   box-shadow: 0 0 4px 0 #00D9C5;
@@ -82,6 +83,7 @@ exports[`<Dropdown /> renders the Dropdown with options 1`] = `
 
 .c0:focus,
 .c0:hover {
+  outline: none;
   outline-width: 0;
   border: 1px solid #00D9C5;
   box-shadow: 0 0 4px 0 #00D9C5;
@@ -141,6 +143,7 @@ exports[`<Dropdown /> renders the Dropdown with options and a default selected v
 
 .c0:focus,
 .c0:hover {
+  outline: none;
   outline-width: 0;
   border: 1px solid #00D9C5;
   box-shadow: 0 0 4px 0 #00D9C5;
@@ -201,6 +204,7 @@ exports[`<Dropdown /> renders the Dropdown with options passed through an array.
 
 .c0:focus,
 .c0:hover {
+  outline: none;
   outline-width: 0;
   border: 1px solid #00D9C5;
   box-shadow: 0 0 4px 0 #00D9C5;

--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -67,6 +67,8 @@ const Input = styled.input<InputProps>`
   }
 
   &:disabled {
+    -webkit-text-fill-color: ${colors.grey};
+    opacity: 1;
     border: 1px solid ${getBorderColorByStatus};
     box-shadow: 0 0 4px 0 transparent;
     background-color: transparent;

--- a/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
@@ -50,6 +50,8 @@ exports[`<InputText /> renders the component disabled 1`] = `
 }
 
 .c1:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #D4D7D9;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -142,6 +144,8 @@ exports[`<InputText /> renders the component with an icon on the left 1`] = `
 }
 
 .c2:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -239,6 +243,8 @@ exports[`<InputText /> renders the component with an icon on the right 1`] = `
 }
 
 .c1:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -312,6 +318,8 @@ exports[`<InputText /> renders the component with error 1`] = `
 }
 
 .c1:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #FF4539;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -378,6 +386,8 @@ exports[`<InputText /> renders the component with focus 1`] = `
 }
 
 .c1:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -444,6 +454,8 @@ exports[`<InputText /> renders the component with isValid set as true 1`] = `
 }
 
 .c1:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #3EBC64;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -510,6 +522,8 @@ exports[`<InputText /> renders the component with the required props 1`] = `
 }
 
 .c1:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -92,6 +92,8 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
 }
 
 .c5:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -251,6 +253,8 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
 }
 
 .c4:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -50,6 +50,8 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
 }
 
 .c2:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #3EBC64;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -128,6 +130,8 @@ exports[`<TextField /> renders the component with error 1`] = `
 }
 
 .c2:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #FF4539;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -251,6 +255,8 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
 }
 
 .c2:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -329,6 +335,8 @@ exports[`<TextField /> renders the component with prefix 1`] = `
 }
 
 .c3:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;
@@ -439,6 +447,8 @@ exports[`<TextField /> renders the component with size 1`] = `
 }
 
 .c2:disabled {
+  -webkit-text-fill-color: #818F9B;
+  opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
   background-color: transparent;


### PR DESCRIPTION
- fix disabled input styling on safari
- remove safari's default outline in `<Dropdown />`

Before:

![Screenshot 2020-07-09 at 22 19 11](https://user-images.githubusercontent.com/14250944/87092755-ecc9f300-c233-11ea-8a13-8d08abbe1465.png)

![Screenshot 2020-07-09 at 22 26 03](https://user-images.githubusercontent.com/14250944/87092718-d754c900-c233-11ea-929e-6ce564cbf45e.png)

After:

![Screenshot 2020-07-09 at 22 22 58](https://user-images.githubusercontent.com/14250944/87092733-e2a7f480-c233-11ea-9a56-0a04ab070518.png)

![Screenshot 2020-07-09 at 22 26 29](https://user-images.githubusercontent.com/14250944/87092702-cf952480-c233-11ea-8c3d-86286ac2a901.png)


