### PR TITLE
Fix spinner on mobile view

### DIFF
--- a/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -181,6 +181,8 @@ exports[`<Button /> renders disabled 1`] = `
 
 exports[`<Button /> renders loading as "primary" 1`] = `
 .c1 {
+  min-width: 20px;
+  min-height: 20px;
   width: 20px;
   height: 20px;
   border: 3px solid #FFFFFF;
@@ -259,6 +261,8 @@ exports[`<Button /> renders loading as "primary" 1`] = `
 
 exports[`<Button /> renders loading as "secondary" 1`] = `
 .c1 {
+  min-width: 20px;
+  min-height: 20px;
   width: 20px;
   height: 20px;
   border: 3px solid #00D9C5;
@@ -337,6 +341,8 @@ exports[`<Button /> renders loading as "secondary" 1`] = `
 
 exports[`<Button /> renders loading as "secondary" 2`] = `
 .c1 {
+  min-width: 20px;
+  min-height: 20px;
   width: 20px;
   height: 20px;
   border: 3px solid #00D9C5;

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -26,6 +26,8 @@ const spin = keyframes`
 
 const StyledSpinner = styled.div<SpinnerProps>`
   ${({ size = 'standard', negative = false }) => css`
+    min-width: ${size === 'small' ? 20 : 40}px;
+    min-height: ${size === 'small' ? 20 : 40}px;
     width: ${size === 'small' ? 20 : 40}px;
     height: ${size === 'small' ? 20 : 40}px;
     border: ${size === 'small' ? 3 : 6}px solid ${negative ? colors.white : colors.brand}};

--- a/src/components/atoms/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/src/components/atoms/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`<Spinner /> renders a spinner 1`] = `
 .c0 {
+  min-width: 40px;
+  min-height: 40px;
   width: 40px;
   height: 40px;
   border: 6px solid #00D9C5;
@@ -18,6 +20,8 @@ exports[`<Spinner /> renders a spinner 1`] = `
 
 exports[`<Spinner /> renders negative 1`] = `
 .c0 {
+  min-width: 40px;
+  min-height: 40px;
   width: 40px;
   height: 40px;
   border: 6px solid #FFFFFF;
@@ -34,6 +38,8 @@ exports[`<Spinner /> renders negative 1`] = `
 
 exports[`<Spinner /> renders small 1`] = `
 .c0 {
+  min-width: 20px;
+  min-height: 20px;
   width: 20px;
   height: 20px;
   border: 3px solid #00D9C5;

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -4,7 +4,6 @@ import { colors, typography } from '../../../constants';
 import { getBorderColorByStatus } from '../../../helpers/utils';
 import InputLabel from '../../atoms/InputLabel/InputLabel';
 import SizedContainer from '../../layout/SizedContainer/SizedContainer';
-import Spinner from '../../atoms/Spinner/Spinner';
 import { FieldProps, InputStatus, InputProps } from '../../types';
 import deprecate from 'util-deprecate';
 
@@ -124,23 +123,9 @@ const Input = styled.input<InputStatus>`
   }
 `;
 
-const Loader = styled(Spinner)`
-  margin-left: auto;
-`;
-
 export interface RadioField extends FieldProps, InputProps {}
 
-const RadioField = ({
-  label,
-  hasError,
-  errorMessage,
-  isValid,
-  value,
-  inputSize,
-  showLoader,
-  className,
-  ...rest
-}: RadioField) => {
+const RadioField = ({ label, hasError, errorMessage, isValid, value, inputSize, className, ...rest }: RadioField) => {
   if (!value) throw Error('Value must be set in inputProps. Check the docs.');
 
   return (
@@ -148,7 +133,6 @@ const RadioField = ({
       <Input id={`radio-id-${value}`} hasError={hasError} isValid={isValid} value={value} type="radio" {...rest} />
       <Label htmlFor={`radio-id-${value}`} hasError={hasError} isValid={isValid}>
         {label}
-        {showLoader && <Loader size={'small'} />}
       </Label>
     </FieldContainer>
   );

--- a/src/components/molecules/RadioGroupField/RadioGroupField.md
+++ b/src/components/molecules/RadioGroupField/RadioGroupField.md
@@ -118,7 +118,11 @@ import { RadioGroupField } from '@zopauk/react-components';
 <RadioGroupField
   items={[
     { value: 'twelve', label: 'label twelve' },
-    { value: 'thirteen', label: 'label thirteen' },
+    {
+      value: 'thirteen',
+      label:
+        'Zopa decides the interest rate for loans and sets up the loan contract with the borrower before transferring the rights to the loan over to you.',
+    },
   ]}
   onChange={(value) => console.log(value)}
   label="Radio group field label"

--- a/src/components/molecules/RadioGroupField/RadioGroupField.md
+++ b/src/components/molecules/RadioGroupField/RadioGroupField.md
@@ -110,22 +110,6 @@ import { RadioGroupField } from '@zopauk/react-components';
 />;
 ```
 
-- With loader (when selected)
-
-```jsx
-import { RadioGroupField } from '@zopauk/react-components';
-
-<RadioGroupField
-  items={[
-    { value: 'twelve', label: 'label twelve' },
-    { value: 'thirteen', label: 'label thirteen' },
-  ]}
-  onChange={(value) => console.log(value)}
-  label="Radio group field label"
-  showLoader={true}
-/>;
-```
-
 - Responsive
 
 ```jsx

--- a/src/components/molecules/RadioGroupField/RadioGroupField.md
+++ b/src/components/molecules/RadioGroupField/RadioGroupField.md
@@ -118,11 +118,7 @@ import { RadioGroupField } from '@zopauk/react-components';
 <RadioGroupField
   items={[
     { value: 'twelve', label: 'label twelve' },
-    {
-      value: 'thirteen',
-      label:
-        'Zopa decides the interest rate for loans and sets up the loan contract with the borrower before transferring the rights to the loan over to you.',
-    },
+    { value: 'thirteen', label: 'label thirteen' },
   ]}
   onChange={(value) => console.log(value)}
   label="Radio group field label"

--- a/src/components/molecules/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/molecules/RadioGroupField/RadioGroupField.tsx
@@ -14,10 +14,9 @@ const RadioWrapper = styled.div`
 
 type RadioGroupFieldItem = {
   value: string;
-  label?: string;
+  label?: string | React.ReactNode;
   defaultChecked?: boolean;
   disabled?: boolean;
-  showLoader?: boolean;
 };
 
 export type RadioGroupFieldProps = {
@@ -26,7 +25,6 @@ export type RadioGroupFieldProps = {
   onChange: (value: string) => void;
   onBlur?: () => void;
   disabled?: boolean;
-  showLoader?: boolean;
   value?: string;
   isValid?: boolean;
   errorMessage?: string;
@@ -42,7 +40,6 @@ const RadioGroupField = ({
   onBlur,
   value,
   disabled,
-  showLoader = false,
   isValid = false,
   errorMessage,
   className,
@@ -85,7 +82,6 @@ const RadioGroupField = ({
                   label={item.label}
                   checked={checked}
                   isValid={checked && isValid}
-                  showLoader={checked && showLoader}
                 />
               </RadioWrapper>
             </FlexCol>

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -61,8 +61,4 @@ export interface FieldProps {
    * Input size
    */
   inputSize?: ContainerSizes;
-  /**
-   * Shows a loading icon if true
-   */
-  showLoader?: boolean;
 }


### PR DESCRIPTION
- Fixes spinner on mobile view
- Removes loader on radio field
- Allows a react node to be passed in for an item label on radio field

![image](https://user-images.githubusercontent.com/10133018/88067686-35a07680-cb67-11ea-80de-0ea3c1a189c8.png)
