### PR TITLE
feat(help): allow help line prop and email address fix

### DIFF
--- a/src/components/molecules/Help/Help.md
+++ b/src/components/molecules/Help/Help.md
@@ -6,8 +6,18 @@ Its aim is to give the customer information about Zopa's customer service openin
 
 ### Example
 
+When no HelpLine is specified it defaults to the borrowers one.
+
 ```tsx
 import { Help } from '@zopauk/react-components';
 
-<Help email="savings@zopa.com" />;
+<Help />;
+```
+
+For investors helpline use `HelpLine.investors`
+
+```tsx
+import { Help, HelpLine } from '@zopauk/react-components';
+
+<Help helpLine={HelpLine.investors} />;
 ```

--- a/src/components/molecules/Help/Help.tsx
+++ b/src/components/molecules/Help/Help.tsx
@@ -28,7 +28,14 @@ const ButtonAsLink = styled.a`
   ${buttonStyle}
 `;
 
-const Help: React.FC = () => (
+export enum HelpLine {
+  borrowers = '020 7580 6060',
+  investors = '020 7291 8331',
+}
+
+type HelpProps = { helpLine?: HelpLine };
+
+const Help: React.FC<HelpProps> = ({ helpLine = HelpLine.borrowers }) => (
   <HelpWrap className="pt-4">
     <HelpContent>
       <FlexRow>
@@ -51,12 +58,12 @@ const Help: React.FC = () => (
                   <Icon variant={faPhone} color={colors.brand} size="3x" />
                 </FlexColCenter>
                 <FlexCol xs={9}>
-                  <Card.Heading>020 7580 6060</Card.Heading>
+                  <Card.Heading>{helpLine}</Card.Heading>
                   <Card.Text>Monday to Thursday (8am to 8pm), Friday (8am to 5pm)</Card.Text>
                 </FlexCol>
               </FlexRow>
               <Card.Actions>
-                <ButtonAsLink styling="secondary" fullWidth href="tel:020 7580 6060">
+                <ButtonAsLink styling="secondary" fullWidth href={`tel:${helpLine}`}>
                   Call us
                 </ButtonAsLink>
               </Card.Actions>
@@ -71,12 +78,12 @@ const Help: React.FC = () => (
                   <Icon variant={faEnvelope} color={colors.brand} size="3x" />
                 </FlexColCenter>
                 <FlexCol xs={9}>
-                  <Card.Heading>contact@zopa.com</Card.Heading>
+                  <Card.Heading>contactus@zopa.com</Card.Heading>
                   <Card.Text>If your query is urgent, please contact our Team via phone.</Card.Text>
                 </FlexCol>
               </FlexRow>
               <Card.Actions>
-                <ButtonAsLink styling="secondary" fullWidth href="mailto:contact@zopa.com">
+                <ButtonAsLink styling="secondary" fullWidth href="mailto:contactus@zopa.com">
                   Email us
                 </ButtonAsLink>
               </Card.Actions>

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
                 <h6
                   class="c12 c13"
                 >
-                  contact@zopa.com
+                  contactus@zopa.com
                 </h6>
                 <p
                   class="c14 c15"
@@ -454,7 +454,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
             >
               <a
                 class="c17"
-                href="mailto:contact@zopa.com"
+                href="mailto:contactus@zopa.com"
               >
                 Email us
               </a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export { default as Logo } from './components/atoms/Logo/Logo';
 export { default as Modal } from './components/molecules/Modal/Modal';
 export { default as ExpiryModal } from './components/molecules/ExpiryModal/ExpiryModal';
 export { default as ZopaFooter } from './components/molecules/ZopaFooter/ZopaFooter';
-export { default as Help } from './components/molecules/Help/Help';
+export { default as Help, HelpLine } from './components/molecules/Help/Help';
 export { default as Tooltip } from './components/molecules/Tooltip/Tooltip';
 export { default as CheckboxField } from './components/molecules/CheckboxField/CheckboxField';
 export { default as CheckboxGroupField } from './components/molecules/CheckboxGroupField/CheckboxGroupField';


### PR DESCRIPTION
## Summary

Fixes email address and allows choice between borrowers and investors help line ☎️ 

## 💻 

If `helpLine` is omitted it defaults to `HelpLine.borrowers`.

```tsx
import { Help, HelpLine } from '@zopauk/react-components';

<Help helpLine={HelpLine.investors} />;
```

