### PR TITLE
fix(inputs): add background color on disabled state

### DIFF
--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -46,7 +46,7 @@ const StyledDropdown = styled.select<DropdownProps>`
   &:disabled {
     border: 1px solid ${getBorderColorByStatus};
     box-shadow: 0 0 4px 0 transparent;
-    background-color: transparent;
+    background-color: ${colors.greyLightest};
     cursor: not-allowed;
   }
 `;

--- a/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/atoms/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<Dropdown /> renders the Dropdown with one option 1`] = `
 .c0:disabled {
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -92,7 +92,7 @@ exports[`<Dropdown /> renders the Dropdown with options 1`] = `
 .c0:disabled {
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -152,7 +152,7 @@ exports[`<Dropdown /> renders the Dropdown with options and a default selected v
 .c0:disabled {
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -213,7 +213,7 @@ exports[`<Dropdown /> renders the Dropdown with options passed through an array.
 .c0:disabled {
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 

--- a/src/components/atoms/InputText/InputText.tsx
+++ b/src/components/atoms/InputText/InputText.tsx
@@ -71,7 +71,7 @@ const Input = styled.input<InputProps>`
     opacity: 1;
     border: 1px solid ${getBorderColorByStatus};
     box-shadow: 0 0 4px 0 transparent;
-    background-color: transparent;
+    background-color: ${colors.greyLightest};
     cursor: not-allowed;
   }
 `;

--- a/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/src/components/atoms/InputText/__snapshots__/InputText.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`<InputText /> renders the component disabled 1`] = `
   opacity: 1;
   border: 1px solid #D4D7D9;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -148,7 +148,7 @@ exports[`<InputText /> renders the component with an icon on the left 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -247,7 +247,7 @@ exports[`<InputText /> renders the component with an icon on the right 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -322,7 +322,7 @@ exports[`<InputText /> renders the component with error 1`] = `
   opacity: 1;
   border: 1px solid #FF4539;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -390,7 +390,7 @@ exports[`<InputText /> renders the component with focus 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -458,7 +458,7 @@ exports[`<InputText /> renders the component with isValid set as true 1`] = `
   opacity: 1;
   border: 1px solid #3EBC64;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -526,7 +526,7 @@ exports[`<InputText /> renders the component with the required props 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 

--- a/src/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/src/components/molecules/CheckboxField/CheckboxField.tsx
@@ -103,6 +103,7 @@ const Input = styled.input<InputProps & GroupingControlsProps>`
   &:disabled + label {
     cursor: not-allowed;
     color: ${colors.grey};
+    background-color: ${colors.greyLightest};
   }
   &:disabled:not(:checked) + label {
     border-color: ${colors.greyLight};

--- a/src/components/molecules/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
+++ b/src/components/molecules/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`<CheckboxField /> renders the component with no control icon and no a11
 .c1:disabled + label {
   cursor: not-allowed;
   color: #818F9B;
+  background-color: #F7F7F7;
 }
 
 .c1:disabled:not(:checked) + label {
@@ -257,6 +258,7 @@ exports[`<CheckboxField /> renders the component with props with no a11y violati
 .c1:disabled + label {
   cursor: not-allowed;
   color: #818F9B;
+  background-color: #F7F7F7;
 }
 
 .c1:disabled:not(:checked) + label {

--- a/src/components/molecules/CheckboxGroupField/__snapshots__/CheckboxGroupField.test.tsx.snap
+++ b/src/components/molecules/CheckboxGroupField/__snapshots__/CheckboxGroupField.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`<CheckboxGroupField /> renders the component with no control icon and n
 .c6:disabled + label {
   cursor: not-allowed;
   color: #818F9B;
+  background-color: #F7F7F7;
 }
 
 .c6:disabled:not(:checked) + label {
@@ -372,6 +373,7 @@ exports[`<CheckboxGroupField /> renders the component with props with no a11y vi
 .c6:disabled + label {
   cursor: not-allowed;
   color: #818F9B;
+  background-color: #F7F7F7;
 }
 
 .c6:disabled:not(:checked) + label {

--- a/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
+++ b/src/components/molecules/DropdownFiltered/__snapshots__/DropdownFiltered.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`<DropdownFiltered /> renders the Dropdown with options with no a11y vio
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -257,7 +257,7 @@ exports[`<DropdownFiltered /> renders the DropdownFiltered with options and a de
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -103,6 +103,7 @@ const Input = styled.input<InputStatus & GroupingControlsProps>`
   &:disabled + label {
     cursor: not-allowed;
     color: ${colors.grey};
+    background-color: ${colors.greyLightest};
   }
   &:disabled:not(:checked) + label {
     border-color: ${colors.greyLight};

--- a/src/components/molecules/RadioGroupField/__snapshots__/RadioGroupField.test.tsx.snap
+++ b/src/components/molecules/RadioGroupField/__snapshots__/RadioGroupField.test.tsx.snap
@@ -144,6 +144,7 @@ exports[`<RadioGroupField /> renders the component with no control icon and no a
 .c7:disabled + label {
   cursor: not-allowed;
   color: #818F9B;
+  background-color: #F7F7F7;
 }
 
 .c7:disabled:not(:checked) + label {
@@ -412,6 +413,7 @@ exports[`<RadioGroupField /> renders the component with props with no a11y viola
 .c7:disabled + label {
   cursor: not-allowed;
   color: #818F9B;
+  background-color: #F7F7F7;
 }
 
 .c7:disabled:not(:checked) + label {

--- a/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/molecules/TextField/__snapshots__/TextField.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`<TextField /> renders the component and isValid set to true 1`] = `
   opacity: 1;
   border: 1px solid #3EBC64;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -134,7 +134,7 @@ exports[`<TextField /> renders the component with error 1`] = `
   opacity: 1;
   border: 1px solid #FF4539;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -259,7 +259,7 @@ exports[`<TextField /> renders the component with no a11y violations 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -339,7 +339,7 @@ exports[`<TextField /> renders the component with prefix 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 
@@ -451,7 +451,7 @@ exports[`<TextField /> renders the component with size 1`] = `
   opacity: 1;
   border: 1px solid #818F9B;
   box-shadow: 0 0 4px 0 transparent;
-  background-color: transparent;
+  background-color: #F7F7F7;
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
### Context
Add greyLightest  background  color to disable state for
- Dropdown
- InputText
- RadioField
- CheckBoxField 

<img width="500" alt="Screenshot 2020-08-24 at 10 38 24" src="https://user-images.githubusercontent.com/1150925/91029358-90117480-e5f6-11ea-8602-fd4b3740e161.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 39 46" src="https://user-images.githubusercontent.com/1150925/91029372-9273ce80-e5f6-11ea-93f9-1c1eae541a8e.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 38 48" src="https://user-images.githubusercontent.com/1150925/91029362-90aa0b00-e5f6-11ea-80e9-814017406a18.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 38 54" src="https://user-images.githubusercontent.com/1150925/91029365-9142a180-e5f6-11ea-9cc8-3fb5bf570885.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 39 09" src="https://user-images.githubusercontent.com/1150925/91029367-91db3800-e5f6-11ea-82d8-e0b48d5d0d02.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 39 20" src="https://user-images.githubusercontent.com/1150925/91029370-9273ce80-e5f6-11ea-9cdd-8283d8b0add8.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 44 05" src="https://user-images.githubusercontent.com/1150925/91029526-c818b780-e5f6-11ea-8f22-492f427f0b96.png">
<img width="500" alt="Screenshot 2020-08-24 at 10 44 15" src="https://user-images.githubusercontent.com/1150925/91029530-c8b14e00-e5f6-11ea-88c2-01bc3f3824ac.png">

