### PR TITLE
fix(alert): set radius to 4px

### DIFF
--- a/src/components/atoms/Alert/Alert.tsx
+++ b/src/components/atoms/Alert/Alert.tsx
@@ -75,7 +75,7 @@ const Wrapper = styled.div<{ severity: Severity; inline: boolean; hasRoundedCorn
   line-height: 20px;
   font-family: ${typography.primary};
   font-weight: 400;
-  border-radius: ${({ hasRoundedCorners }) => (hasRoundedCorners ? 12 : 0)}px;
+  border-radius: ${({ hasRoundedCorners }) => (hasRoundedCorners ? 4 : 0)}px;
 
   a {
     color: ${({ severity }) => MAP_BY_SEVERITY[severity].text} !important;

--- a/src/components/molecules/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/components/molecules/Notification/__snapshots__/Notification.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Notification renders the component with no props and no a11y violations
   line-height: 20px;
   font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
   font-weight: 400;
-  border-radius: 12px;
+  border-radius: 4px;
 }
 
 .c0 a {


### PR DESCRIPTION
Rounded corners in the Alert component are **too** round - reducing from 12px to 4px.