### PR TITLE
feat(number text): deal with 0 values

### DIFF
--- a/src/components/molecules/NumberText/NumberText.test.tsx
+++ b/src/components/molecules/NumberText/NumberText.test.tsx
@@ -58,6 +58,12 @@ describe('<NumberText />', () => {
     expect(screen.getByText(fallback)).toHaveTextContent('N/A');
   });
 
+  it('renders the value when it is zero', () => {
+    const value = '0';
+    render(<NumberText title="Overall Balance" value={0} className="mb-6 m:mb-7" />);
+    expect(screen.getByText(value)).toHaveTextContent('0');
+  });
+
   it('renders without  a11y violations', async () => {
     const { container } = renderComponent();
     const results = await axe(container.innerHTML);

--- a/src/components/molecules/NumberText/NumberText.tsx
+++ b/src/components/molecules/NumberText/NumberText.tsx
@@ -136,7 +136,7 @@ const NumberText: React.FC<NumberTextProps> = ({
         </Title>
       ) : null}
       <Value className={valueClassNames} numberPosition={numberPosition} numberFontSize={numberFontSize}>
-        {value ? numberFormatter(value) : fallback}
+        {value !== undefined && value >= 0 ? numberFormatter(value) : fallback}
       </Value>
     </Container>
   );


### PR DESCRIPTION
When a value of 0 is passed as a value prop it should render as £0.00