### PR TITLE
fix[numberText]: fix alignment in number text

### DIFF
--- a/src/components/molecules/NumberText/NumberText.test.tsx
+++ b/src/components/molecules/NumberText/NumberText.test.tsx
@@ -22,33 +22,37 @@ describe('<NumberText />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should position the numerical value to the right', () => {
+  it('should position the numerical value to the right and vertically align the text in the center', () => {
     const value = '100,000';
     const { container } = renderComponent({ numberPosition: 'right' });
     expect(container.firstChild).toHaveStyleRule('flex-direction', 'row');
     expect(container.firstChild).toHaveStyleRule('justify-content', 'space-between');
+    expect(container.firstChild).toHaveStyleRule('align-items', 'center');
     expect(screen.getByText(value)).toHaveStyleRule('order', '2');
   });
 
-  it('should position the numerical value to the left', () => {
+  it('should position the numerical value to the left and vertically align the text in the center', () => {
     const value = '100,000';
     const { container } = renderComponent({ numberPosition: 'left' });
     expect(container.firstChild).toHaveStyleRule('flex-direction', 'row');
     expect(container.firstChild).toHaveStyleRule('justify-content', 'space-between');
+    expect(container.firstChild).toHaveStyleRule('align-items', 'center');
     expect(screen.getByText(value)).toHaveStyleRule('order', '1');
   });
 
-  it('should position the numerical value to the right', () => {
+  it('should position the numerical value at the top and vertically align the text in the center', () => {
     const value = '100,000';
     const { container } = renderComponent({ numberPosition: 'top' });
     expect(container.firstChild).toHaveStyleRule('flex-direction', 'column');
+    expect(container.firstChild).toHaveStyleRule('justify-content', 'center');
     expect(screen.getByText(value)).toHaveStyleRule('order', '1');
   });
 
-  it('should position the numerical value to the left', () => {
+  it('should position the numerical value at the bottom and vertically align the text in the center', () => {
     const value = '100,000';
     const { container } = renderComponent({ numberPosition: 'bottom' });
     expect(container.firstChild).toHaveStyleRule('flex-direction', 'column');
+    expect(container.firstChild).toHaveStyleRule('justify-content', 'center');
     expect(screen.getByText(value)).toHaveStyleRule('order', '2');
   });
 
@@ -70,7 +74,7 @@ describe('<NumberText />', () => {
     expect(screen.getByText(value)).toHaveStyleRule('font-weight', '600');
   });
 
-  it('renders without  a11y violations', async () => {
+  it('renders without a11y violations', async () => {
     const { container } = renderComponent();
     const results = await axe(container.innerHTML);
 

--- a/src/components/molecules/NumberText/NumberText.tsx
+++ b/src/components/molecules/NumberText/NumberText.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import classnames from 'classnames';
 
 import Text from '../../atoms/Text/Text';
@@ -30,7 +30,7 @@ interface StyleProps {
    * Where the rendered text should be aligned to.
    * @default 'center'
    */
-  align?: 'left' | 'right' | 'center';
+  align?: 'left' | 'right' | 'center' | 'flex-start' | 'flex-end';
 }
 
 type ContainerProps = Pick<StyleProps, 'numberPosition' | 'align'>;
@@ -52,17 +52,28 @@ export interface NumberTextProps extends HTMLAttributes<HTMLDivElement>, StylePr
 
 const Container = styled.div<Required<ContainerProps>>`
   display: flex;
-  align-items: ${({ align }) => align};
+  align-items: ${({ align }) => {
+    switch (align) {
+      case 'left':
+        return 'flex-start';
+      case 'right':
+        return 'flex-end';
+      default:
+        return align;
+    }
+  }};
 
   ${({ numberPosition }) => {
     if (numberPosition === 'left' || numberPosition === 'right') {
-      return `
+      return css`
         flex-direction: row;
         justify-content: space-between;
+        align-items: center;
       `;
     } else {
-      return `
+      return css`
         flex-direction: column;
+        justify-content: center;
       `;
     }
   }}
@@ -77,8 +88,6 @@ const Value = styled(Heading).attrs(({ numberFontSize = 'main' }: NumberProps) =
 }))<Required<NumberProps>>`
   order: ${({ numberPosition }) => (numberPosition === 'top' || numberPosition === 'left' ? 1 : 2)};
   ${({ semiBold }) => (semiBold ? 'font-weight: 600' : null)}
-
-  }
 `;
 
 const NumberText: React.FC<NumberTextProps> = ({

--- a/src/components/molecules/NumberText/NumberText.tsx
+++ b/src/components/molecules/NumberText/NumberText.tsx
@@ -30,7 +30,7 @@ interface StyleProps {
    * Where the rendered text should be aligned to.
    * @default 'center'
    */
-  align?: 'left' | 'right' | 'center' | 'flex-start' | 'flex-end';
+  align?: 'left' | 'right' | 'center';
 }
 
 type ContainerProps = Pick<StyleProps, 'numberPosition' | 'align'>;

--- a/src/components/molecules/NumberText/__snapshots__/NumberText.test.tsx.snap
+++ b/src/components/molecules/NumberText/__snapshots__/NumberText.test.tsx.snap
@@ -27,6 +27,10 @@ exports[`<NumberText /> renders without errors 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c2 {


### PR DESCRIPTION
Make it possible to have left aligned text that is vertically centered in the NumberText component.