### PR TITLE
Navbar headroom

### DIFF
--- a/src/components/organisms/Navbar/Navbar/Navbar.md
+++ b/src/components/organisms/Navbar/Navbar/Navbar.md
@@ -8,7 +8,7 @@ Navbar will render an array of links provided using a dropdown which works on cl
 
 - Default theme
 
-```ts
+```ts { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#FFFFFF", "overflow": "hidden", "height": "500px", "padding": "0" } } }
 import { Navbar } from '@zopauk/react-components';
 
 const NAV_ITEMS = [

--- a/src/components/organisms/Navbar/Navbar/Navbar.md
+++ b/src/components/organisms/Navbar/Navbar/Navbar.md
@@ -8,7 +8,7 @@ Navbar will render an array of links provided using a dropdown which works on cl
 
 - Default theme
 
-```ts { "props": { "style": { "transform": "translate3d(0, 0, 0)", "backgroundColor": "#FFFFFF", "overflow": "hidden", "height": "500px", "padding": "0" } } }
+```ts
 import { Navbar } from '@zopauk/react-components';
 
 const NAV_ITEMS = [

--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -316,7 +316,11 @@ const NavbarWrapper: React.FC<NavbarProps> = ({
   return (
     <>
       <PageNavigation role="banner" overlap={overThreshold} collapsed={collapsed}>
-        <Headroom disableInlineStyles disable={open || !!(width && width >= breakpoints.desktop)}>
+        <Headroom
+          wrapperStyle={{ maxHeight: navbarClosedHeight }}
+          disableInlineStyles
+          disable={open || !!(width && width >= breakpoints.desktop)}
+        >
           <LargeDeviceNavbar>
             <LayoutInner overlap={overThreshold}>
               <LogoContainer overlap={overThreshold || collapsed}>

--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -317,7 +317,7 @@ const NavbarWrapper: React.FC<NavbarProps> = ({
     <>
       <PageNavigation role="banner" overlap={overThreshold} collapsed={collapsed}>
         <Headroom
-          wrapperStyle={{ maxHeight: navbarClosedHeight }}
+          wrapperStyle={{ maxHeight: overThreshold ? `${navbarClosedHeight}px` : `${navbarOpenHeight}px` }}
           disableInlineStyles
           disable={open || !!(width && width >= breakpoints.desktop)}
         >

--- a/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
+++ b/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
@@ -611,6 +611,7 @@ exports[`<Navbar /> should render component with all the props 1`] = `
   >
     <div
       class="headroom-wrapper"
+      style="max-height: 76px;"
     >
       <div
         class="headroom headroom--unfixed"
@@ -1725,6 +1726,7 @@ exports[`<Navbar /> should render large device navigation with default props 1`]
   >
     <div
       class="headroom-wrapper"
+      style="max-height: 76px;"
     >
       <div
         class="headroom headroom--unfixed"
@@ -2832,6 +2834,7 @@ exports[`<Navbar /> should render small device navigation with default props 1`]
   >
     <div
       class="headroom-wrapper"
+      style="max-height: 76px;"
     >
       <div
         class="headroom headroom--unfixed"
@@ -3996,6 +3999,7 @@ exports[`<Navbar /> should render the collapsed styled on large device navigatio
   >
     <div
       class="headroom-wrapper"
+      style="max-height: 76px;"
     >
       <div
         class="headroom headroom--unfixed"

--- a/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
+++ b/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
@@ -611,7 +611,7 @@ exports[`<Navbar /> should render component with all the props 1`] = `
   >
     <div
       class="headroom-wrapper"
-      style="max-height: 76px;"
+      style="max-height: 120px;"
     >
       <div
         class="headroom headroom--unfixed"
@@ -1726,7 +1726,7 @@ exports[`<Navbar /> should render large device navigation with default props 1`]
   >
     <div
       class="headroom-wrapper"
-      style="max-height: 76px;"
+      style="max-height: 120px;"
     >
       <div
         class="headroom headroom--unfixed"
@@ -2834,7 +2834,7 @@ exports[`<Navbar /> should render small device navigation with default props 1`]
   >
     <div
       class="headroom-wrapper"
-      style="max-height: 76px;"
+      style="max-height: 120px;"
     >
       <div
         class="headroom headroom--unfixed"
@@ -3999,7 +3999,7 @@ exports[`<Navbar /> should render the collapsed styled on large device navigatio
   >
     <div
       class="headroom-wrapper"
-      style="max-height: 76px;"
+      style="max-height: 120px;"
     >
       <div
         class="headroom headroom--unfixed"


### PR DESCRIPTION
**The issue**
react-headroom adds a height to the navbar wrapper and only updates when a user resizes the screen. this would cause it to have a height of 120px on page load and not change after scrolling, preventing users from click up to 50px under the navbar

**The solution**
add max-height on navbar-wrapper