### PR TITLE
feat(text): as includes figcaption

### DIFF
--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -19,7 +19,7 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
    * The HTML5 tag you want to render your text on, currently only `<span>` and `<p>` are supported.
    * @default 'span'
    */
-  as?: 'span' | 'p';
+  as?: 'span' | 'p' | 'figcaption';
   /**
    * Whether to render the text in all caps or not.
    * @default false


### PR DESCRIPTION
A component I'm working on requires a `<figcaption>` element within a `<figure>` element, which contains an image and a string of text. This small PR add the appropriate type to the `<Text/>` component