### PR TITLE
fix(accordion): add type='button' to header

### DIFF
--- a/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.tsx
+++ b/src/components/organisms/Accordion/AccordionHeader/AccordionHeader.tsx
@@ -70,7 +70,7 @@ const AccordionHeader: FC<AccordionHeader> = ({ children, id, index, textSize = 
   };
 
   return (
-    <StyledButton ref={ref} onClick={handleClick} {...headerPropsRest} {...rest}>
+    <StyledButton type="button" ref={ref} onClick={handleClick} {...headerPropsRest} {...rest}>
       <TitleContainer>
         <Title weight="bold" size={textSize}>
           {children}

--- a/src/components/organisms/Accordion/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/src/components/organisms/Accordion/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`<AccordionHeader /> renders the component with no a11y violations 1`] =
   class="c0"
   data-automation="header"
   id="one"
+  type="button"
 >
   <div
     class="c1"


### PR DESCRIPTION
Add `type="button"` to `AccordionHeader` to prevent submission of forms when clicking on accordion

https://github.com/formium/formik/issues/1610