### PR TITLE
feat(product template): render ProductTemplate without title

### DIFF
--- a/src/components/molecules/Progress/Progress.tsx
+++ b/src/components/molecules/Progress/Progress.tsx
@@ -27,6 +27,12 @@ export interface ProgressionProps extends ProgressionStyleProps {
 export interface ProgressPointProps extends ProgressionStyleProps, ProgressionProps {
   completed: boolean;
 }
+const PROGRESS_POINT_RADIUS = 6;
+
+const ProgressWrapper = styled.div`
+  margin-left: ${PROGRESS_POINT_RADIUS}px;
+  margin-right: ${PROGRESS_POINT_RADIUS}px;
+`;
 
 const ProgressBar = styled.div`
   position: relative;
@@ -61,8 +67,8 @@ const ProgressPoint = styled.span<ProgressPointProps>`
   left: ${({ position }) => `${position}%`};
 
   display: block;
-  width: 12px;
-  height: 12px;
+  width: ${PROGRESS_POINT_RADIUS * 2}px;
+  height: ${PROGRESS_POINT_RADIUS * 2}px;
 
   background: ${({ completed, progressColor = colors.brand }) => (completed ? progressColor : colors.greyLighter)};
   border-radius: 100%;
@@ -95,16 +101,18 @@ const Progress: React.FC<ProgressProps> = ({ totalSteps, currentStep, withStep =
   };
 
   return (
-    <ProgressBar {...rest}>
-      {renderPoints()}
-      <Progression position={getStepPosition(totalSteps, currentStep - 0.5)} progressColor={progressColor}>
-        {withStep && (
-          <Text size="small">
-            Step {currentStep} of {totalSteps}
-          </Text>
-        )}
-      </Progression>
-    </ProgressBar>
+    <ProgressWrapper>
+      <ProgressBar {...rest}>
+        {renderPoints()}
+        <Progression position={getStepPosition(totalSteps, currentStep - 0.5)} progressColor={progressColor}>
+          {withStep && (
+            <Text size="small">
+              Step {currentStep} of {totalSteps}
+            </Text>
+          )}
+        </Progression>
+      </ProgressBar>
+    </ProgressWrapper>
   );
 };
 

--- a/src/components/molecules/Progress/__snapshots__/Progress.test.tsx.snap
+++ b/src/components/molecules/Progress/__snapshots__/Progress.test.tsx.snap
@@ -2,6 +2,11 @@
 
 exports[`<Progress /> Accessibility renders the component with props with no a11y violations 1`] = `
 .c0 {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.c1 {
   position: relative;
   width: 100%;
   border-radius: 100px;
@@ -9,7 +14,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   height: 4px;
 }
 
-.c6 {
+.c7 {
   width: 37.5%;
   position: relative;
   border-radius: 100px;
@@ -20,7 +25,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   transition: width 0.5s ease-in-out;
 }
 
-.c6 > span {
+.c7 > span {
   position: absolute;
   top: 10px;
   right: 0;
@@ -30,7 +35,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   color: #2C3236;
 }
 
-.c1 {
+.c2 {
   position: absolute;
   top: 50%;
   left: 0%;
@@ -44,7 +49,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   transform: translate(-50%,-50%);
 }
 
-.c2 {
+.c3 {
   position: absolute;
   top: 50%;
   left: 25%;
@@ -58,7 +63,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   transform: translate(-50%,-50%);
 }
 
-.c3 {
+.c4 {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -72,7 +77,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   transform: translate(-50%,-50%);
 }
 
-.c4 {
+.c5 {
   position: absolute;
   top: 50%;
   left: 75%;
@@ -86,7 +91,7 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   transform: translate(-50%,-50%);
 }
 
-.c5 {
+.c6 {
   position: absolute;
   top: 50%;
   left: 100%;
@@ -104,9 +109,143 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
   <div
     class="c0"
   >
-    <span
+    <div
       class="c1"
-    />
+    >
+      <span
+        class="c2"
+      />
+      <span
+        class="c3"
+      />
+      <span
+        class="c4"
+      />
+      <span
+        class="c5"
+      />
+      <span
+        class="c6"
+      />
+      <div
+        class="c7"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Progress /> Props renders empty progress bar 1`] = `
+.c0 {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+  border-radius: 100px;
+  background: #EFEFEF;
+  height: 4px;
+}
+
+.c7 {
+  width: 0%;
+  position: relative;
+  border-radius: 100px;
+  height: 4px;
+  display: block;
+  background: #00D9C5;
+  -webkit-transition: width 0.5s ease-in-out;
+  transition: width 0.5s ease-in-out;
+}
+
+.c7 > span {
+  position: absolute;
+  top: 10px;
+  right: 0;
+  font-size: 13px;
+  line-height: 16px;
+  font-weight: 600;
+  color: #2C3236;
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: #EFEFEF;
+  border-radius: 100%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c5 {
+  position: absolute;
+  top: 50%;
+  left: 75%;
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: #EFEFEF;
+  border-radius: 100%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c6 {
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: #EFEFEF;
+  border-radius: 100%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c2 {
+  position: absolute;
+  top: 50%;
+  left: 0%;
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: #EFEFEF;
+  border-radius: 100%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 25%;
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: #EFEFEF;
+  border-radius: 100%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
     <span
       class="c2"
     />
@@ -119,139 +258,23 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
     <span
       class="c5"
     />
-    <div
+    <span
       class="c6"
+    />
+    <div
+      class="c7"
     />
   </div>
 </div>
 `;
 
-exports[`<Progress /> Props renders empty progress bar 1`] = `
-.c0 {
-  position: relative;
-  width: 100%;
-  border-radius: 100px;
-  background: #EFEFEF;
-  height: 4px;
-}
-
-.c6 {
-  width: 0%;
-  position: relative;
-  border-radius: 100px;
-  height: 4px;
-  display: block;
-  background: #00D9C5;
-  -webkit-transition: width 0.5s ease-in-out;
-  transition: width 0.5s ease-in-out;
-}
-
-.c6 > span {
-  position: absolute;
-  top: 10px;
-  right: 0;
-  font-size: 13px;
-  line-height: 16px;
-  font-weight: 600;
-  color: #2C3236;
-}
-
-.c3 {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  display: block;
-  width: 12px;
-  height: 12px;
-  background: #EFEFEF;
-  border-radius: 100%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.c4 {
-  position: absolute;
-  top: 50%;
-  left: 75%;
-  display: block;
-  width: 12px;
-  height: 12px;
-  background: #EFEFEF;
-  border-radius: 100%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.c5 {
-  position: absolute;
-  top: 50%;
-  left: 100%;
-  display: block;
-  width: 12px;
-  height: 12px;
-  background: #EFEFEF;
-  border-radius: 100%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.c1 {
-  position: absolute;
-  top: 50%;
-  left: 0%;
-  display: block;
-  width: 12px;
-  height: 12px;
-  background: #EFEFEF;
-  border-radius: 100%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-.c2 {
-  position: absolute;
-  top: 50%;
-  left: 25%;
-  display: block;
-  width: 12px;
-  height: 12px;
-  background: #EFEFEF;
-  border-radius: 100%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-}
-
-<div
-  class="c0"
->
-  <span
-    class="c1"
-  />
-  <span
-    class="c2"
-  />
-  <span
-    class="c3"
-  />
-  <span
-    class="c4"
-  />
-  <span
-    class="c5"
-  />
-  <div
-    class="c6"
-  />
-</div>
-`;
-
 exports[`<Progress /> Props renders full progress bar 1`] = `
 .c0 {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.c1 {
   position: relative;
   width: 100%;
   border-radius: 100px;
@@ -259,7 +282,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   height: 4px;
 }
 
-.c6 {
+.c7 {
   width: 100%;
   position: relative;
   border-radius: 100px;
@@ -270,7 +293,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   transition: width 0.5s ease-in-out;
 }
 
-.c6 > span {
+.c7 > span {
   position: absolute;
   top: 10px;
   right: 0;
@@ -280,7 +303,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   color: #2C3236;
 }
 
-.c1 {
+.c2 {
   position: absolute;
   top: 50%;
   left: 0%;
@@ -294,7 +317,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c2 {
+.c3 {
   position: absolute;
   top: 50%;
   left: 25%;
@@ -308,7 +331,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c3 {
+.c4 {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -322,7 +345,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c4 {
+.c5 {
   position: absolute;
   top: 50%;
   left: 75%;
@@ -336,7 +359,7 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c5 {
+.c6 {
   position: absolute;
   top: 50%;
   left: 100%;
@@ -353,23 +376,27 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
 <div
   class="c0"
 >
-  <span
-    class="c1"
-  />
-  <span
-    class="c2"
-  />
-  <span
-    class="c3"
-  />
-  <span
-    class="c4"
-  />
-  <span
-    class="c5"
-  />
   <div
-    class="c6"
-  />
+    class="c1"
+  >
+    <span
+      class="c2"
+    />
+    <span
+      class="c3"
+    />
+    <span
+      class="c4"
+    />
+    <span
+      class="c5"
+    />
+    <span
+      class="c6"
+    />
+    <div
+      class="c7"
+    />
+  </div>
 </div>
 `;

--- a/src/components/organisms/Tabs/TabButtons/__snapshots__/TabButtons.test.tsx.snap
+++ b/src/components/organisms/Tabs/TabButtons/__snapshots__/TabButtons.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`<TabButtons /> renders the buttons on big screens 1`] = `
         <button
           aria-controls="pineapple-content"
           aria-expanded="true"
-          class="c2 c3 py-2 sc-iujRgT c3 py-2"
+          class="c2 c3 py-2 sc-exAgwC c3 py-2"
           id="pineapple"
         >
           🍍 Pineapple
@@ -157,7 +157,7 @@ exports[`<TabButtons /> renders the buttons on big screens 1`] = `
         <button
           aria-controls="kiwi-content"
           aria-expanded="false"
-          class="c2 c4 py-2 sc-iujRgT c4 py-2"
+          class="c2 c4 py-2 sc-exAgwC c4 py-2"
           id="kiwi"
         >
           🥝 Kiwi
@@ -169,7 +169,7 @@ exports[`<TabButtons /> renders the buttons on big screens 1`] = `
         <button
           aria-controls="watermelon-content"
           aria-expanded="false"
-          class="c2 c4 py-2 sc-iujRgT c4 py-2"
+          class="c2 c4 py-2 sc-exAgwC c4 py-2"
           id="watermelon"
         >
           🍉 Watermelon

--- a/src/components/organisms/Tabs/TabsContainer/__snapshots__/TabsContainer.test.tsx.snap
+++ b/src/components/organisms/Tabs/TabsContainer/__snapshots__/TabsContainer.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`<TabContainer /> renders the component with no a11y violations 1`] = `
       <button
         aria-controls="pineapple-content"
         aria-expanded="true"
-        class="c2 c3 py-2 sc-iujRgT c3 py-2"
+        class="c2 c3 py-2 sc-exAgwC c3 py-2"
         id="pineapple"
       >
         🍍 Pineapple
@@ -164,7 +164,7 @@ exports[`<TabContainer /> renders the component with no a11y violations 1`] = `
       <button
         aria-controls="kiwi-content"
         aria-expanded="false"
-        class="c2 c4 py-2 sc-iujRgT c4 py-2"
+        class="c2 c4 py-2 sc-exAgwC c4 py-2"
         id="kiwi"
       >
         🥝 Kiwi
@@ -176,7 +176,7 @@ exports[`<TabContainer /> renders the component with no a11y violations 1`] = `
       <button
         aria-controls="watermelon-content"
         aria-expanded="false"
-        class="c2 c4 py-2 sc-iujRgT c4 py-2"
+        class="c2 c4 py-2 sc-exAgwC c4 py-2"
         id="watermelon"
       >
         🍉 Watermelon

--- a/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplate.test.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplate.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, screen, render } from '@testing-library/react';
 import ProductTemplate from '..';
 
 describe('<ProductTemplate />', () => {
   it('renders with all props and content', () => {
     const mockOnBackPressed = jest.fn();
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <ProductTemplate
         title="Product title"
         subtitle="Product subtitle"
@@ -17,17 +17,60 @@ describe('<ProductTemplate />', () => {
         <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
       </ProductTemplate>,
     );
-    fireEvent.click(getByLabelText('Back'));
-    expect(mockOnBackPressed).toHaveBeenCalled();
     expect(container).toMatchSnapshot();
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(mockOnBackPressed).toHaveBeenCalled();
   });
 
   it('renders without ProductTemplateHeader if no prevStep, onBackPressed or progress props supplied', () => {
-    const { queryByTestId } = render(
+    render(
       <ProductTemplate title="Product title" subtitle="Product subtitle">
         <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
       </ProductTemplate>,
     );
-    expect(queryByTestId('ZA.ProductTemplateHeader')).toBeNull();
+    expect(screen.queryByTestId('ZA.ProductTemplateHeader')).toBeNull();
+  });
+
+  it('renders without title', () => {
+    render(
+      <ProductTemplate prevStep="prevStep" progress={{ currentStep: 2, totalSteps: 4 }} contentWidth={10}>
+        <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
+      </ProductTemplate>,
+    );
+    expect(screen.queryByRole('h1')).toBeNull();
+  });
+
+  it('renders without prevstep', () => {
+    render(
+      <ProductTemplate
+        title="Product title"
+        subtitle="Product subtitle"
+        progress={{ currentStep: 2, totalSteps: 4 }}
+        contentWidth={10}
+      >
+        <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
+      </ProductTemplate>,
+    );
+    expect(screen.queryByLabelText('Back')).toBeNull();
+  });
+
+  it('renders without progress', () => {
+    render(
+      <ProductTemplate title="Product title" subtitle="Product subtitle" prevStep="prevStep" contentWidth={10}>
+        <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
+      </ProductTemplate>,
+    );
+    const navigationElement = screen.getByTestId('ZA.ProductTemplateNavigation');
+    expect(navigationElement).toBeInTheDocument();
+  });
+
+  it('renders with neither prevstep nor progress', () => {
+    render(
+      <ProductTemplate title="Product title" subtitle="Product subtitle" contentWidth={10}>
+        <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
+      </ProductTemplate>,
+    );
+    const navigationElement = screen.queryByTestId('ZA.ProductTemplateNavigation');
+    expect(navigationElement).toBeNull();
   });
 });

--- a/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplate.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplate.tsx
@@ -7,16 +7,31 @@ import { ProductTemplateHeader } from '../ProductTemplateHeader/ProductTemplateH
 import FlexContainer from '../../../layout/FlexContainer/FlexContainer';
 import FlexRow from '../../../layout/FlexRow/FlexRow';
 import FlexCol from '../../../layout/FlexCol/FlexCol';
+import styled from 'styled-components';
+import grid from '../../../../constants/grid';
 
 export interface ProductTemplateProps {
   children: React.ReactNode;
-  title: string;
+  title?: string;
   subtitle?: string;
   prevStep?: ReactElement | string;
   progress?: Pick<ProgressProps, 'currentStep' | 'totalSteps'>;
   contentWidth?: number;
   onBackPressed?: MouseEventHandler<HTMLAnchorElement>;
 }
+
+function overlayElementAbove(marginTop: number) {
+  return `
+    margin-top: -${marginTop - 24}px; 
+    @media (min-width: ${grid.breakpoints.m}px) {
+      margin-top: -${marginTop}px; 
+    }
+    `;
+}
+
+const StyledFlexRow = styled(FlexRow)<{ hasTitle: boolean }>(({ hasTitle }) =>
+  hasTitle ? 'margin-top: -160px' : overlayElementAbove(227),
+);
 
 function ProductTemplate({
   title,
@@ -37,16 +52,20 @@ function ProductTemplate({
   return (
     <FlexContainer data-automation="ZA.ProductTemplate" className={containerClassnames} gutter={0}>
       <FlexRow gutter={0}>
-        <FlexCol>
-          {showHeader ? (
+        {showHeader ? (
+          <FlexCol>
             <ProductTemplateHeader prevStep={prevStep} progress={progress} onBackPressed={onBackPressed} />
-          ) : null}
+          </FlexCol>
+        ) : null}
+        <FlexCol>
           <ProductTemplateTitle title={title} subtitle={subtitle} />
-          <FlexRow justify="center" gutter={0}>
+        </FlexCol>
+        <FlexCol>
+          <StyledFlexRow hasTitle={!!title || !!subtitle} justify="center" gutter={0}>
             <FlexCol m={10} xl={contentWidth}>
               {children}
             </FlexCol>
-          </FlexRow>
+          </StyledFlexRow>
         </FlexCol>
       </FlexRow>
     </FlexContainer>

--- a/src/components/templates/ProductTemplate/ProductTemplate/__snapshots__/ProductTemplate.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplate/__snapshots__/ProductTemplate.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProductTemplate /> renders with all props and content 1`] = `
-.c23 {
+.c25 {
   height: 100%;
   width: 100%;
   display: -webkit-box;
@@ -18,27 +18,27 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   flex-direction: column;
 }
 
-.c23 > .c24 {
+.c25 > .c26 {
   -webkit-flex: 0 1 200px;
   -ms-flex: 0 1 200px;
   flex: 0 1 200px;
 }
 
-.c23 .c25 {
+.c25 .c27 {
   font-size: 15px;
 }
 
-.c23 .c26 {
+.c25 .c28 {
   font-size: 13px;
 }
 
-.c23 > .c27 {
+.c25 > .c29 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c19 {
+.c20 {
   font-size: 46px;
   line-height: 54px;
   -webkit-letter-spacing: -1.25px;
@@ -66,7 +66,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   text-align: inherit;
 }
 
-.c20 {
+.c21 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -80,17 +80,16 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   text-align: center;
 }
 
-.c16 {
+.c17 {
   background-color: #F7F7F7;
-  margin-bottom: -160px;
 }
 
-.c17 {
+.c18 {
   max-width: 612px;
   margin: 0 auto;
 }
 
-.c18 {
+.c19 {
   padding-bottom: 195px;
 }
 
@@ -143,6 +142,11 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
 }
 
 .c10 {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.c11 {
   position: relative;
   width: 100%;
   border-radius: 100px;
@@ -150,7 +154,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   height: 4px;
 }
 
-.c15 {
+.c16 {
   width: 50%;
   position: relative;
   border-radius: 100px;
@@ -161,7 +165,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   transition: width 0.5s ease-in-out;
 }
 
-.c15 > span {
+.c16 > span {
   position: absolute;
   top: 10px;
   right: 0;
@@ -171,7 +175,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   color: #2C3236;
 }
 
-.c11 {
+.c12 {
   position: absolute;
   top: 50%;
   left: 0%;
@@ -185,7 +189,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c12 {
+.c13 {
   position: absolute;
   top: 50%;
   left: 33.333333333333336%;
@@ -199,7 +203,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c13 {
+.c14 {
   position: absolute;
   top: 50%;
   left: 66.66666666666667%;
@@ -213,7 +217,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c14 {
+.c15 {
   position: absolute;
   top: 50%;
   left: 100%;
@@ -268,7 +272,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   align-items: flex-start;
 }
 
-.c21 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -302,7 +306,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   align-self: auto;
 }
 
-.c22 {
+.c24 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -313,21 +317,25 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   align-self: auto;
 }
 
+.c23 {
+  margin-top: -160px;
+}
+
 @media (max-width:768px) {
-  .c23 {
+  .c25 {
     border-radius: 0;
     box-shadow: none;
     border: none;
   }
 
-  .c23:last-of-type {
+  .c25:last-of-type {
     box-shadow: 0 0 1px 0 #D4D7D9;
     border-bottom: 1px solid #EFEFEF;
   }
 }
 
 @media (min-width:1280px) {
-  .c16 {
+  .c17 {
     border-radius: 12px;
   }
 }
@@ -373,7 +381,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
 }
 
 @media (min-width:768px) {
-  .c22 {
+  .c24 {
     display: block;
     -webkit-flex: 0 0 83.33333333333334%;
     -ms-flex: 0 0 83.33333333333334%;
@@ -383,7 +391,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
 }
 
 @media (min-width:1300px) {
-  .c22 {
+  .c24 {
     display: block;
     -webkit-flex: 0 0 83.33333333333334%;
     -ms-flex: 0 0 83.33333333333334%;
@@ -450,58 +458,72 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
             <div
               class="c10"
             >
-              <span
-                class="c11"
-              />
-              <span
-                class="c12"
-              />
-              <span
-                class="c13"
-              />
-              <span
-                class="c14"
-              />
               <div
-                class="c15"
-              />
+                class="c11"
+              >
+                <span
+                  class="c12"
+                />
+                <span
+                  class="c13"
+                />
+                <span
+                  class="c14"
+                />
+                <span
+                  class="c15"
+                />
+                <div
+                  class="c16"
+                />
+              </div>
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="c2"
+        cols="12"
+      >
         <header
-          class="c16"
+          class="c17"
           data-automation="ZA.ProductTemplateTitle"
         >
           <div
-            class="c17 px-0 m:px-4"
+            class="c18 px-0 m:px-4"
           >
             <div
-              class="c18 pt-7 m:pt-9 mx-6 m:mx-0"
+              class="c19 pt-7 m:pt-9 mx-6 m:mx-0"
             >
               <h1
-                class="c19"
+                class="c20"
               >
                 Product title
               </h1>
               <p
-                class="c20 mt-4"
+                class="c21 mt-4"
               >
                 Product subtitle
               </p>
             </div>
           </div>
         </header>
+      </div>
+      <div
+        class="c2"
+        cols="12"
+      >
         <div
-          class="c21"
+          class="c22 c23"
           cols="12"
           direction="row"
         >
           <div
-            class="c22"
+            class="c24"
             cols="12"
           >
             <div
-              class="c23 px-4 py-6 m:p-8"
+              class="c25 px-4 py-6 m:p-8"
             >
               This is the body of the card
             </div>

--- a/src/components/templates/ProductTemplate/ProductTemplateHeader/ProductTemplateHeader.test.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplateHeader/ProductTemplateHeader.test.tsx
@@ -1,37 +1,37 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, screen, render } from '@testing-library/react';
 import { ProductTemplateHeader } from './ProductTemplateHeader';
 
 describe('<ProductTemplateHeader />', () => {
   it('renders with all the props', () => {
     const mockOnBackPressed = jest.fn();
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <ProductTemplateHeader
         prevStep="/prevStep"
         onBackPressed={mockOnBackPressed}
         progress={{ currentStep: 1, totalSteps: 2 }}
       />,
     );
-    fireEvent.click(getByLabelText('Back'));
+    fireEvent.click(screen.getByLabelText('Back'));
     expect(mockOnBackPressed).toHaveBeenCalled();
     expect(container).toMatchSnapshot();
   });
 
   it('renders with progress only', () => {
-    const { getByTestId } = render(<ProductTemplateHeader progress={{ currentStep: 1, totalSteps: 2 }} />);
-    const header = getByTestId('ZA.ProductTemplateHeader');
-    expect(header?.children).toHaveLength(1);
+    render(<ProductTemplateHeader progress={{ currentStep: 1, totalSteps: 2 }} />);
+    const header = screen.getByTestId('ZA.ProductTemplateHeader');
+    expect(header).toBeInTheDocument();
   });
 
   it('renders with prevStep only', () => {
-    const { getByLabelText } = render(<ProductTemplateHeader prevStep="/prevStep" />);
-    expect(getByLabelText('Back')).toHaveAttribute('href', '/prevStep');
+    render(<ProductTemplateHeader prevStep="/prevStep" />);
+    expect(screen.getByLabelText('Back')).toHaveAttribute('href', '/prevStep');
   });
 
   it('renders with onBackPressed only and fires callback onclick', () => {
     const mockOnBackPressed = jest.fn();
-    const { getByLabelText } = render(<ProductTemplateHeader onBackPressed={mockOnBackPressed} />);
-    const backButton = getByLabelText('Back');
+    render(<ProductTemplateHeader onBackPressed={mockOnBackPressed} />);
+    const backButton = screen.getByLabelText('Back');
     expect(backButton).not.toHaveAttribute('href');
     fireEvent.click(backButton);
     expect(mockOnBackPressed).toHaveBeenCalled();

--- a/src/components/templates/ProductTemplate/ProductTemplateHeader/__snapshots__/ProductTemplateHeader.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateHeader/__snapshots__/ProductTemplateHeader.test.tsx.snap
@@ -64,6 +64,11 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
 }
 
 .c7 {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.c8 {
   position: relative;
   width: 100%;
   border-radius: 100px;
@@ -71,7 +76,7 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
   height: 4px;
 }
 
-.c10 {
+.c11 {
   width: 50%;
   position: relative;
   border-radius: 100px;
@@ -82,7 +87,7 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
   transition: width 0.5s ease-in-out;
 }
 
-.c10 > span {
+.c11 > span {
   position: absolute;
   top: 10px;
   right: 0;
@@ -92,7 +97,7 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
   color: #2C3236;
 }
 
-.c8 {
+.c9 {
   position: absolute;
   top: 50%;
   left: 0%;
@@ -106,7 +111,7 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c9 {
+.c10 {
   position: absolute;
   top: 50%;
   left: 100%;
@@ -190,15 +195,19 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
       <div
         class="c7"
       >
-        <span
-          class="c8"
-        />
-        <span
-          class="c9"
-        />
         <div
-          class="c10"
-        />
+          class="c8"
+        >
+          <span
+            class="c9"
+          />
+          <span
+            class="c10"
+          />
+          <div
+            class="c11"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/templates/ProductTemplate/ProductTemplateNavigation/ProductTemplateNavigation.test.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplateNavigation/ProductTemplateNavigation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, screen, render } from '@testing-library/react';
 import { ProductTemplateNavigation } from './ProductTemplateNavigation';
 
 describe('<ProductTemplateNavigation />', () => {
@@ -15,8 +15,8 @@ describe('<ProductTemplateNavigation />', () => {
 
   it('invokes onBackPressed callback', () => {
     const mockOnBackPressed = jest.fn();
-    const { getByLabelText } = render(<ProductTemplateNavigation onBackPressed={mockOnBackPressed} />);
-    fireEvent.click(getByLabelText('Back'));
+    render(<ProductTemplateNavigation onBackPressed={mockOnBackPressed} />);
+    fireEvent.click(screen.getByLabelText('Back'));
     expect(mockOnBackPressed).toHaveBeenCalled();
   });
 });

--- a/src/components/templates/ProductTemplate/ProductTemplateProgress/__snapshots__/ProductTemplateProgress.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateProgress/__snapshots__/ProductTemplateProgress.test.tsx.snap
@@ -2,6 +2,11 @@
 
 exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
 .c1 {
+  margin-left: 6px;
+  margin-right: 6px;
+}
+
+.c2 {
   position: relative;
   width: 100%;
   border-radius: 100px;
@@ -9,7 +14,7 @@ exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
   height: 4px;
 }
 
-.c4 {
+.c5 {
   width: 50%;
   position: relative;
   border-radius: 100px;
@@ -20,7 +25,7 @@ exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
   transition: width 0.5s ease-in-out;
 }
 
-.c4 > span {
+.c5 > span {
   position: absolute;
   top: 10px;
   right: 0;
@@ -30,7 +35,7 @@ exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
   color: #2C3236;
 }
 
-.c2 {
+.c3 {
   position: absolute;
   top: 50%;
   left: 0%;
@@ -44,7 +49,7 @@ exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
   transform: translate(-50%,-50%);
 }
 
-.c3 {
+.c4 {
   position: absolute;
   top: 50%;
   left: 100%;
@@ -75,15 +80,19 @@ exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
     <div
       class="c1"
     >
-      <span
-        class="c2"
-      />
-      <span
-        class="c3"
-      />
       <div
-        class="c4"
-      />
+        class="c2"
+      >
+        <span
+          class="c3"
+        />
+        <span
+          class="c4"
+        />
+        <div
+          class="c5"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/templates/ProductTemplate/ProductTemplateTitle/ProductTemplateTitle.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplateTitle/ProductTemplateTitle.tsx
@@ -9,15 +9,13 @@ import Text from '../../../atoms/Text/Text';
 import { minMedia } from '../../../../helpers/responsiveness';
 
 interface ProductTemplateTitleProps {
-  title: string;
+  title?: string;
   subtitle?: string;
   dataAutomation?: string;
 }
 
 const ProductTemplateTitleBackground = styled.header`
   background-color: ${colors.greyLightest};
-  /* Make the following element overlay the ProductTitle by 160px */
-  margin-bottom: -160px;
   ${minMedia.desktop`
     ${css`
       border-radius: 12px;

--- a/src/components/templates/ProductTemplate/ProductTemplateTitle/__snapshots__/ProductTemplateTitle.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateTitle/__snapshots__/ProductTemplateTitle.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`<ProductTemplateTitle /> renders correct sized title on desktop 1`] = `
 
 .c0 {
   background-color: #F7F7F7;
-  margin-bottom: -160px;
 }
 
 .c1 {
@@ -74,7 +73,6 @@ exports[`<ProductTemplateTitle /> renders correct sized title on small screens 1
 
 .c0 {
   background-color: #F7F7F7;
-  margin-bottom: -160px;
 }
 
 .c1 {
@@ -145,7 +143,6 @@ exports[`<ProductTemplateTitle /> renders with all the props 1`] = `
 
 .c0 {
   background-color: #F7F7F7;
-  margin-bottom: -160px;
 }
 
 .c1 {


### PR DESCRIPTION
Updated `ProductTemplate` designs with optional title.

`title` now an optional property of `<ProductTemplate />`. Rendering without title will overlay the
content slightly higher leaving only 24px of margin.

### Desktop
#### With Title
<img width="1359" alt="desktop_with_title" src="https://user-images.githubusercontent.com/7081561/100232977-02109700-2f21-11eb-8bc7-20c0da94114d.png">

#### Without Title
<img width="1354" alt="desktop_without_title" src="https://user-images.githubusercontent.com/7081561/100234170-99c2b500-2f22-11eb-9688-597013d3702a.png">

### Mobile
#### With Title
![mobile_with_title](https://user-images.githubusercontent.com/7081561/100450380-737d5080-30ad-11eb-827a-011bf5a15dd3.png)

#### Without Title
![mobile_without_title](https://user-images.githubusercontent.com/7081561/100450407-7d9f4f00-30ad-11eb-986c-29363d9990b3.png)




