### PR TITLE
relaxes typescript peer range to be >= 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "styled-components": "^4.4.0",
-    "typescript": ">=3.x <4"
+    "typescript": ">=3.x"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
Relaxing the range as this is currently needlessly restrictive as TypeScript does not follow semver and there is nothing here that should break TypeScript clients. Its arguable if TypeScript should even be a peer - but this is for another issue.