### PR TITLE
feat(producttemplate): add optional content to product template

### DIFF
--- a/src/components/organisms/Tabs/TabButtons/__snapshots__/TabButtons.test.tsx.snap
+++ b/src/components/organisms/Tabs/TabButtons/__snapshots__/TabButtons.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`<TabButtons /> renders the buttons on big screens 1`] = `
         <button
           aria-controls="pineapple-content"
           aria-expanded="true"
-          class="c2 c3 py-2 sc-exAgwC c3 py-2"
+          class="c2 c3 py-2 sc-cQFLBn c3 py-2"
           id="pineapple"
         >
           🍍 Pineapple
@@ -157,7 +157,7 @@ exports[`<TabButtons /> renders the buttons on big screens 1`] = `
         <button
           aria-controls="kiwi-content"
           aria-expanded="false"
-          class="c2 c4 py-2 sc-exAgwC c4 py-2"
+          class="c2 c4 py-2 sc-cQFLBn c4 py-2"
           id="kiwi"
         >
           🥝 Kiwi
@@ -169,7 +169,7 @@ exports[`<TabButtons /> renders the buttons on big screens 1`] = `
         <button
           aria-controls="watermelon-content"
           aria-expanded="false"
-          class="c2 c4 py-2 sc-exAgwC c4 py-2"
+          class="c2 c4 py-2 sc-cQFLBn c4 py-2"
           id="watermelon"
         >
           🍉 Watermelon

--- a/src/components/organisms/Tabs/TabsContainer/__snapshots__/TabsContainer.test.tsx.snap
+++ b/src/components/organisms/Tabs/TabsContainer/__snapshots__/TabsContainer.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`<TabContainer /> renders the component with no a11y violations 1`] = `
       <button
         aria-controls="pineapple-content"
         aria-expanded="true"
-        class="c2 c3 py-2 sc-exAgwC c3 py-2"
+        class="c2 c3 py-2 sc-cQFLBn c3 py-2"
         id="pineapple"
       >
         🍍 Pineapple
@@ -164,7 +164,7 @@ exports[`<TabContainer /> renders the component with no a11y violations 1`] = `
       <button
         aria-controls="kiwi-content"
         aria-expanded="false"
-        class="c2 c4 py-2 sc-exAgwC c4 py-2"
+        class="c2 c4 py-2 sc-cQFLBn c4 py-2"
         id="kiwi"
       >
         🥝 Kiwi
@@ -176,7 +176,7 @@ exports[`<TabContainer /> renders the component with no a11y violations 1`] = `
       <button
         aria-controls="watermelon-content"
         aria-expanded="false"
-        class="c2 c4 py-2 sc-exAgwC c4 py-2"
+        class="c2 c4 py-2 sc-cQFLBn c4 py-2"
         id="watermelon"
       >
         🍉 Watermelon

--- a/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplate.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplate/ProductTemplate.tsx
@@ -14,6 +14,7 @@ export interface ProductTemplateProps {
   children: React.ReactNode;
   title?: string;
   subtitle?: string;
+  content?: ReactElement;
   prevStep?: ReactElement | string;
   progress?: Pick<ProgressProps, 'currentStep' | 'totalSteps'>;
   contentWidth?: number;
@@ -36,6 +37,7 @@ const StyledFlexRow = styled(FlexRow)<{ hasTitle: boolean }>(({ hasTitle }) =>
 function ProductTemplate({
   title,
   subtitle,
+  content,
   children,
   prevStep,
   progress,
@@ -58,7 +60,7 @@ function ProductTemplate({
           </FlexCol>
         ) : null}
         <FlexCol>
-          <ProductTemplateTitle title={title} subtitle={subtitle} />
+          <ProductTemplateTitle title={title} subtitle={subtitle} content={content} />
         </FlexCol>
         <FlexCol>
           <StyledFlexRow hasTitle={!!title || !!subtitle} justify="center" gutter={0}>

--- a/src/components/templates/ProductTemplate/ProductTemplate/__snapshots__/ProductTemplate.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplate/__snapshots__/ProductTemplate.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProductTemplate /> renders with all props and content 1`] = `
-.c25 {
+.c26 {
   height: 100%;
   width: 100%;
   display: -webkit-box;
@@ -18,27 +18,27 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   flex-direction: column;
 }
 
-.c25 > .c26 {
+.c26 > .c27 {
   -webkit-flex: 0 1 200px;
   -ms-flex: 0 1 200px;
   flex: 0 1 200px;
 }
 
-.c25 .c27 {
+.c26 .c28 {
   font-size: 15px;
 }
 
-.c25 .c28 {
+.c26 .c29 {
   font-size: 13px;
 }
 
-.c25 > .c29 {
+.c26 > .c30 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c20 {
+.c21 {
   font-size: 46px;
   line-height: 54px;
   -webkit-letter-spacing: -1.25px;
@@ -66,7 +66,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   text-align: inherit;
 }
 
-.c21 {
+.c22 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -85,12 +85,16 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
 }
 
 .c18 {
-  max-width: 612px;
   margin: 0 auto;
 }
 
 .c19 {
   padding-bottom: 195px;
+}
+
+.c20 {
+  margin: 0 auto;
+  max-width: 612px;
 }
 
 .c5 {
@@ -272,7 +276,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   align-items: flex-start;
 }
 
-.c22 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -306,7 +310,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   align-self: auto;
 }
 
-.c24 {
+.c25 {
   position: relative;
   width: 100%;
   min-height: 1px;
@@ -317,18 +321,18 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
   align-self: auto;
 }
 
-.c23 {
+.c24 {
   margin-top: -160px;
 }
 
 @media (max-width:768px) {
-  .c25 {
+  .c26 {
     border-radius: 0;
     box-shadow: none;
     border: none;
   }
 
-  .c25:last-of-type {
+  .c26:last-of-type {
     box-shadow: 0 0 1px 0 #D4D7D9;
     border-bottom: 1px solid #EFEFEF;
   }
@@ -381,7 +385,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
 }
 
 @media (min-width:768px) {
-  .c24 {
+  .c25 {
     display: block;
     -webkit-flex: 0 0 83.33333333333334%;
     -ms-flex: 0 0 83.33333333333334%;
@@ -391,7 +395,7 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
 }
 
 @media (min-width:1300px) {
-  .c24 {
+  .c25 {
     display: block;
     -webkit-flex: 0 0 83.33333333333334%;
     -ms-flex: 0 0 83.33333333333334%;
@@ -495,16 +499,20 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
             <div
               class="c19 pt-7 m:pt-9 mx-6 m:mx-0"
             >
-              <h1
+              <div
                 class="c20"
               >
-                Product title
-              </h1>
-              <p
-                class="c21 mt-4"
-              >
-                Product subtitle
-              </p>
+                <h1
+                  class="c21"
+                >
+                  Product title
+                </h1>
+                <p
+                  class="c22 mt-4"
+                >
+                  Product subtitle
+                </p>
+              </div>
             </div>
           </div>
         </header>
@@ -514,16 +522,16 @@ exports[`<ProductTemplate /> renders with all props and content 1`] = `
         cols="12"
       >
         <div
-          class="c22 c23"
+          class="c23 c24"
           cols="12"
           direction="row"
         >
           <div
-            class="c24"
+            class="c25"
             cols="12"
           >
             <div
-              class="c25 px-4 py-6 m:p-8"
+              class="c26 px-4 py-6 m:p-8"
             >
               This is the body of the card
             </div>

--- a/src/components/templates/ProductTemplate/ProductTemplateTitle/ProductTemplateTitle.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplateTitle/ProductTemplateTitle.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
-
 import { breakpoints } from '../../../../constants/breakpoints';
 import { colors } from '../../../../constants/colors';
+import { minMedia } from '../../../../helpers/responsiveness';
 import { useViewport } from '../../../../hooks/useViewport';
 import Heading from '../../../atoms/Heading/Heading';
 import Text from '../../../atoms/Text/Text';
-import { minMedia } from '../../../../helpers/responsiveness';
 
 interface ProductTemplateTitleProps {
   title?: string;
   subtitle?: string;
+  content?: ReactElement;
   dataAutomation?: string;
 }
 
@@ -26,7 +26,6 @@ const ProductTemplateTitleBackground = styled.header`
 const ProductTemplateTitleContainer = styled.div.attrs({
   className: 'px-0 m:px-4',
 })`
-  max-width: 612px;
   margin: 0 auto;
 `;
 
@@ -34,9 +33,15 @@ const ProductTemplateTitleInnerContainer = styled.div`
   padding-bottom: 195px;
 `;
 
+const ProductTemplateTitleWrapper = styled.div`
+  margin: 0 auto;
+  max-width: 612px;
+`;
+
 export function ProductTemplateTitle({
   title,
   subtitle,
+  content,
   dataAutomation = 'ZA.ProductTemplateTitle',
 }: ProductTemplateTitleProps) {
   const { width = 0 } = useViewport();
@@ -44,16 +49,19 @@ export function ProductTemplateTitle({
     <ProductTemplateTitleBackground data-automation={dataAutomation}>
       <ProductTemplateTitleContainer>
         <ProductTemplateTitleInnerContainer className="pt-7 m:pt-9 mx-6 m:mx-0">
-          {title && (
-            <Heading as="h1" size={width > breakpoints.phone ? 'h1' : 'h2'} align="center">
-              {title}
-            </Heading>
-          )}
-          {subtitle && (
-            <Text as="p" size="lead" align="center" className="mt-4">
-              {subtitle}
-            </Text>
-          )}
+          <ProductTemplateTitleWrapper>
+            {title && (
+              <Heading as="h1" size={width > breakpoints.phone ? 'h1' : 'h2'} align="center">
+                {title}
+              </Heading>
+            )}
+            {subtitle && (
+              <Text as="p" size="lead" align="center" className="mt-4">
+                {subtitle}
+              </Text>
+            )}
+          </ProductTemplateTitleWrapper>
+          {content}
         </ProductTemplateTitleInnerContainer>
       </ProductTemplateTitleContainer>
     </ProductTemplateTitleBackground>

--- a/src/components/templates/ProductTemplate/ProductTemplateTitle/__snapshots__/ProductTemplateTitle.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateTitle/__snapshots__/ProductTemplateTitle.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProductTemplateTitle /> renders correct sized title on desktop 1`] = `
-.c3 {
+.c4 {
   font-size: 46px;
   line-height: 54px;
   -webkit-letter-spacing: -1.25px;
@@ -20,12 +20,16 @@ exports[`<ProductTemplateTitle /> renders correct sized title on desktop 1`] = `
 }
 
 .c1 {
-  max-width: 612px;
   margin: 0 auto;
 }
 
 .c2 {
   padding-bottom: 195px;
+}
+
+.c3 {
+  margin: 0 auto;
+  max-width: 612px;
 }
 
 @media (min-width:1280px) {
@@ -45,11 +49,15 @@ exports[`<ProductTemplateTitle /> renders correct sized title on desktop 1`] = `
       <div
         class="c2 pt-7 m:pt-9 mx-6 m:mx-0"
       >
-        <h1
+        <div
           class="c3"
         >
-          ProductTemplateTitle title
-        </h1>
+          <h1
+            class="c4"
+          >
+            ProductTemplateTitle title
+          </h1>
+        </div>
       </div>
     </div>
   </header>
@@ -57,7 +65,7 @@ exports[`<ProductTemplateTitle /> renders correct sized title on desktop 1`] = `
 `;
 
 exports[`<ProductTemplateTitle /> renders correct sized title on small screens 1`] = `
-.c3 {
+.c4 {
   font-size: 38px;
   line-height: 46px;
   -webkit-letter-spacing: -0.85px;
@@ -76,12 +84,16 @@ exports[`<ProductTemplateTitle /> renders correct sized title on small screens 1
 }
 
 .c1 {
-  max-width: 612px;
   margin: 0 auto;
 }
 
 .c2 {
   padding-bottom: 195px;
+}
+
+.c3 {
+  margin: 0 auto;
+  max-width: 612px;
 }
 
 @media (min-width:1280px) {
@@ -101,11 +113,15 @@ exports[`<ProductTemplateTitle /> renders correct sized title on small screens 1
       <div
         class="c2 pt-7 m:pt-9 mx-6 m:mx-0"
       >
-        <h1
+        <div
           class="c3"
         >
-          ProductTemplateTitle title
-        </h1>
+          <h1
+            class="c4"
+          >
+            ProductTemplateTitle title
+          </h1>
+        </div>
       </div>
     </div>
   </header>
@@ -113,7 +129,7 @@ exports[`<ProductTemplateTitle /> renders correct sized title on small screens 1
 `;
 
 exports[`<ProductTemplateTitle /> renders with all the props 1`] = `
-.c3 {
+.c4 {
   font-size: 46px;
   line-height: 54px;
   -webkit-letter-spacing: -1.25px;
@@ -127,7 +143,7 @@ exports[`<ProductTemplateTitle /> renders with all the props 1`] = `
   font-weight: 800;
 }
 
-.c4 {
+.c5 {
   margin: 0;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -146,12 +162,16 @@ exports[`<ProductTemplateTitle /> renders with all the props 1`] = `
 }
 
 .c1 {
-  max-width: 612px;
   margin: 0 auto;
 }
 
 .c2 {
   padding-bottom: 195px;
+}
+
+.c3 {
+  margin: 0 auto;
+  max-width: 612px;
 }
 
 @media (min-width:1280px) {
@@ -171,16 +191,20 @@ exports[`<ProductTemplateTitle /> renders with all the props 1`] = `
       <div
         class="c2 pt-7 m:pt-9 mx-6 m:mx-0"
       >
-        <h1
+        <div
           class="c3"
         >
-          ProductTemplateTitle title
-        </h1>
-        <p
-          class="c4 mt-4"
-        >
-          ProductTemplateTitle subtitle
-        </p>
+          <h1
+            class="c4"
+          >
+            ProductTemplateTitle title
+          </h1>
+          <p
+            class="c5 mt-4"
+          >
+            ProductTemplateTitle subtitle
+          </p>
+        </div>
       </div>
     </div>
   </header>

--- a/src/components/templates/ProductTemplate/README.md
+++ b/src/components/templates/ProductTemplate/README.md
@@ -4,6 +4,8 @@
 
 ### Example
 
+- Basic
+
 ```tsx { "props": { "style": {  "padding": "0" } } }
 import { ProductTemplate, Text } from '@zopauk/react-components';
 
@@ -22,6 +24,50 @@ const ProductTemplateExample = () => (
   >
     <ProductTemplate.Card>This is the body of the card</ProductTemplate.Card>
     <Text className="mt-4">You can also put content outside of a card</Text>
+  </ProductTemplate>
+);
+<ProductTemplateExample />;
+```
+
+- With additional content
+
+```tsx { "props": { "style": {  "padding": "0" } } }
+import { ProductTemplate, Text, Carousel, Trustpilot } from '@zopauk/react-components';
+import { faCar, faHeart, faPoundSign } from '@fortawesome/free-solid-svg-icons';
+
+const onBackPressed = (event) => {
+  event.preventDefault();
+  alert('Back button pressed');
+};
+
+const ProductTemplateExample = () => (
+  <ProductTemplate
+    title="Product title"
+    subtitle="Product subtitle"
+    content={
+      <div className="my-4">
+        <Carousel>
+          <Carousel.Slide>
+            <Carousel.SlideIcon variant={faCar} />
+            <Carousel.SlideText>We check your car and dealership so you can buy with confidence</Carousel.SlideText>
+          </Carousel.Slide>
+          <Carousel.Slide>
+            <Carousel.SlideIcon variant={faHeart} />
+            <Carousel.SlideText>Rated excellent based on 14,899 reviews</Carousel.SlideText>
+            <Trustpilot className="mt-6" />
+          </Carousel.Slide>
+          <Carousel.Slide>
+            <Carousel.SlideIcon variant={faPoundSign} />
+            <Carousel.SlideText>No fees now or later. Even if you repay early.</Carousel.SlideText>
+          </Carousel.Slide>
+        </Carousel>
+      </div>
+    }
+    prevStep="prevStep"
+    progress={{ currentStep: 2, totalSteps: 4 }}
+    onBackPressed={onBackPressed}
+  >
+    <ProductTemplate.Card>This is the body of the card.</ProductTemplate.Card>
   </ProductTemplate>
 );
 <ProductTemplateExample />;


### PR DESCRIPTION
## Summary 🍿 

Allow ProductTemplate to host optional product specific content.

## Usage 💻 

```tsx
<ProductTemplate
    title="Product title"
    subtitle="Product subtitle"
    content={<div>custom content here</div>}
>
    <ProductTemplate.Card>This is the body of the card.</ProductTemplate.Card>
</ProductTemplate>
```