### PR TITLE
Change external links attributes to improve screen-readers experience

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -101,10 +101,30 @@ const ZopaFooter = ({
           {renderLink({ href: baseUrl, title: 'Logo', children: <Logo width="165px" height="30px" /> })}
         </LogoBlock>
         <SocialBlock>
-          <SocialLink href="https://facebook.com/zopa" title="Facebook" variant={facebook} />
-          <SocialLink href="https://twitter.com/zopa" title="Twitter" variant={twitter} />
-          <SocialLink href="https://www.instagram.com/Zopamoney/" title="Instagram" variant={instagram} />
-          <SocialLink href="https://www.linkedin.com/company/zopa/" title="Linkedin" variant={linkedin} />
+          <SocialLink
+            href="https://facebook.com/zopa"
+            aria-label="Facebook"
+            title="Facebook opens in a new tab"
+            variant={facebook}
+          />
+          <SocialLink
+            href="https://twitter.com/zopa"
+            aria-label="Twitter"
+            title="Twitter opens in a new tab"
+            variant={twitter}
+          />
+          <SocialLink
+            href="https://www.instagram.com/Zopamoney/"
+            aria-label="Instagram"
+            title="Instagram"
+            variant={instagram}
+          />
+          <SocialLink
+            href="https://www.linkedin.com/company/zopa/"
+            aria-label="Linkedin"
+            title="Linkedin opens in a new tab"
+            variant={linkedin}
+          />
         </SocialBlock>
         <LegalBlock>
           <Text as="p" color={colors.greyDark} size="small" className="mb-4">

--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -116,7 +116,7 @@ const ZopaFooter = ({
           <SocialLink
             href="https://www.instagram.com/Zopamoney/"
             aria-label="Instagram"
-            title="Instagram"
+            title="Instagram opens in a new tab"
             variant={instagram}
           />
           <SocialLink

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -762,7 +762,7 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
           href="https://www.instagram.com/Zopamoney/"
           rel="noopener"
           target="_blank"
-          title="Instagram"
+          title="Instagram opens in a new tab"
         >
           <span
             class="c16"

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -730,30 +730,33 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
         cols="12"
       >
         <a
+          aria-label="Facebook"
           class="c6 c13"
           color="#3B46C4"
           href="https://facebook.com/zopa"
           rel="noopener"
           target="_blank"
-          title="Facebook"
+          title="Facebook opens in a new tab"
         >
           <span
             class="c14"
           />
         </a>
         <a
+          aria-label="Twitter"
           class="c6 c13"
           color="#3B46C4"
           href="https://twitter.com/zopa"
           rel="noopener"
           target="_blank"
-          title="Twitter"
+          title="Twitter opens in a new tab"
         >
           <span
             class="c15"
           />
         </a>
         <a
+          aria-label="Instagram"
           class="c6 c13"
           color="#3B46C4"
           href="https://www.instagram.com/Zopamoney/"
@@ -766,12 +769,13 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
           />
         </a>
         <a
+          aria-label="Linkedin"
           class="c6 c13"
           color="#3B46C4"
           href="https://www.linkedin.com/company/zopa/"
           rel="noopener"
           target="_blank"
-          title="Linkedin"
+          title="Linkedin opens in a new tab"
         >
           <span
             class="c17"


### PR DESCRIPTION
- Add aria-label to announce the link purpose for screen readers
- Use title to warn a user that link opens in a new tab

The link will be announced like e.g. `Link, Twitter. Twitter opens in a new tab. You are currently on a Link.`