### PR TITLE
fix: Updating the Blog url to /blog

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -71,7 +71,7 @@ const ZopaFooter = ({
             </li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/about/awards`, children: 'Awards' })}</li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/about/careers`, children: 'Careers' })}</li>
-            <li className="mb-4">{renderLink({ href: 'https://blog.zopa.com', children: 'Blog' })}</li>
+            <li className="mb-4">{renderLink({ href: `${baseUrl}/blog`, children: 'Blog' })}</li>
             <li>{renderLink({ href: `${baseUrl}/feelgood`, children: 'New products' })}</li>
           </List>
         </FlexCol>

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -559,7 +559,7 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
             <a
               class="c6 c7"
               color="#3B46C4"
-              href="https://blog.zopa.com"
+              href="https://www.zopa.com/blog"
             >
               Blog
             </a>


### PR DESCRIPTION
Changing the blog url in the footer from blog.zopa.com to zopa.com/blog