### PR TITLE
Update navbar label for hotjar suppression

### DIFF
--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -28,6 +28,7 @@ export interface NavigationItem {
   onClick?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
   isDropdownHeading?: boolean;
   children?: Exclude<NavigationItem, 'children'>[];
+  'aria-label'?: string;
 }
 export interface NavbarLinksListProps {
   /**

--- a/src/components/organisms/Navbar/Navbar/Navbar.tsx
+++ b/src/components/organisms/Navbar/Navbar/Navbar.tsx
@@ -22,7 +22,7 @@ import NavbarAction from '../NavbarAction/NavbarAction';
 import NavbarLinksList from '../NavbarLinksList/NavbarLinksList';
 
 export interface NavigationItem {
-  label: string;
+  label: string | React.ReactNode;
   href?: string;
   'data-automation'?: string;
   onClick?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
@@ -81,6 +81,7 @@ export interface NavbarDropdownProps extends DefaultNavbarDropdownProps {
   label: string | React.ReactNode;
   /** array of data representing the dropdown items (e.g links) */
   items: Item[];
+  'aria-label'?: string;
 }
 
 export interface NavbarDropdownState {
@@ -139,7 +140,7 @@ export default class NavbarDropdown extends React.Component<NavbarDropdownProps,
 
   public render() {
     const { getOpenerProps, close } = this;
-    const { renderItem, items, label, id } = this.props;
+    const { renderItem, items, label, id, 'aria-label': ariaLabel } = this.props;
     const { open } = this.state;
 
     return (
@@ -148,7 +149,9 @@ export default class NavbarDropdown extends React.Component<NavbarDropdownProps,
           {label}
         </NavbarLink>
         <NavbarDropdownListContainer open={open}>
-          <NavbarDropdownList aria-label={label}>
+          {/* To avoid an undefined aria-label the fallback to label was added when aria-label property is not defined */}
+          {/* TODO remove fallback to label */}
+          <NavbarDropdownList aria-label={ariaLabel ? ariaLabel : typeof label === 'string' ? label : undefined}>
             {items.map((item, index) => (
               <li key={`${id}-${index}`}>
                 {renderItem({

--- a/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
+++ b/src/components/organisms/Navbar/NavbarDropdown/NavbarDropdown.tsx
@@ -78,7 +78,7 @@ export interface NavbarDropdownProps extends DefaultNavbarDropdownProps {
   /** unique id */
   id: string;
   /** dropdown label */
-  label: string;
+  label: string | React.ReactNode;
   /** array of data representing the dropdown items (e.g links) */
   items: Item[];
 }


### PR DESCRIPTION
Currently HotJar cannot suppress user names in the navbar. This change means we can now add the suppression tag in react-libs to do so and hide all user information in screen recordings.

It's quite clunky, but `aria-lable` can only take a string type, we've added a new property `aria-label` which will be set to `undefined` if it receives a label which isn't of type string. 