### PR TITLE
fix(a11y): accordion needs tab index -1 when aria hidden

### DIFF
--- a/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
+++ b/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
@@ -12,7 +12,9 @@ const AccordionSection: FC<AccordionSectionProps> = ({ children, id, index, ...r
   const { ref, ...sectionPropsRest } = getSectionProps(id, index);
   return (
     <div {...sectionPropsRest} {...rest}>
-      <div ref={ref}>{children}</div>
+      <div ref={ref} tabIndex={sectionPropsRest['aria-hidden'] ? -1 : undefined}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/components/organisms/Accordion/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/components/organisms/Accordion/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`<AccordionSection /> renders the component with no a11y violations 1`] 
   role="region"
   style="overflow: hidden; transition: height 200ms linear; height: 0px;"
 >
-  <div>
+  <div
+    tabindex="-1"
+  >
     Content
   </div>
 </div>


### PR DESCRIPTION
As per this axe rule content inside of aria-hidden should not be focusable.

https://dequeuniversity.com/rules/axe/4.2/aria-hidden-focus?application=axeAPI