### PR TITLE
fix(producttemplatecard): adding bottom border for all cards

### DIFF
--- a/src/components/templates/ProductTemplate/ProductTemplateCard/ProductTemplateCard.tsx
+++ b/src/components/templates/ProductTemplate/ProductTemplateCard/ProductTemplateCard.tsx
@@ -13,13 +13,9 @@ interface ProductTemplateCardProps {
 const StyledCard = styled(Card)`
   @media (max-width: ${grid.breakpoints.m}px) {
     border-radius: 0;
-    box-shadow: none;
+    box-shadow: 0 0 1px 0 ${colors.greyLight};
     border: none;
-
-    &:last-of-type {
-      box-shadow: 0 0 1px 0 ${colors.greyLight};
-      border-bottom: 1px solid ${colors.greyLighter};
-    }
+    border-bottom: 1px solid ${colors.greyLighter};
   }
 `;
 

--- a/src/components/templates/ProductTemplate/ProductTemplateCard/__snapshots__/ProductTemplateCard.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateCard/__snapshots__/ProductTemplateCard.test.tsx.snap
@@ -41,12 +41,8 @@ exports[`<ProductTemplateCard /> renders with all the props 1`] = `
 @media (max-width:768px) {
   .c0 {
     border-radius: 0;
-    box-shadow: none;
-    border: none;
-  }
-
-  .c0:last-of-type {
     box-shadow: 0 0 1px 0 #D4D7D9;
+    border: none;
     border-bottom: 1px solid #EFEFEF;
   }
 }


### PR DESCRIPTION
**Motivation**

- according to the new Zopa designs for one of our projects, we need the the bottom border of each card to be visible in mobile 
- view instead of only the last one

**What has changed**

- applied the bottom border for each card item not only the last one