### PR TITLE
relax @babel/runtime dependency to avoid pinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",
-    "@babel/runtime": "7.10.4",
+    "@babel/runtime": "^7.10.4",
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-conventional": "8.3.4",
     "@fortawesome/free-solid-svg-icons": "5.13.1",


### PR DESCRIPTION
We should stop pinning this - nextjs uses a newer babel runtime and this somehow ends up in the application.

![image](https://user-images.githubusercontent.com/335607/124088959-5cd81700-da4b-11eb-88f1-aadb9914dbb0.png)
