### PR TITLE
Fix radiofield

### DIFF
--- a/src/components/molecules/RadioField/RadioField.md
+++ b/src/components/molecules/RadioField/RadioField.md
@@ -10,6 +10,7 @@
 
 - `htmlFor` prop on the `<InputLabel />` component.
 - `id` prop on `<InputRadio />` so that is easily to query (.i.e automated tests).
+- `hideControl` prop for `<InputLabel />` component hides radio button, centers the text, increases text weight to bold - can be used as Option Button.
 
 ### Examples
 

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -38,7 +38,7 @@ const FieldContainer = styled(SizedContainer)`
 const Label = styled(InputLabel)<InputStatus>`
   display: flex;
   line-height: 1.4;
-  font-weight: ${typography.weights.regular};
+  font-weight: ${(props) => (props.hideControl ? typography.weights.bold : typography.weights.regular)};
   font-size: ${typography.sizes.text.body};
   color: ${colors.greyDarkest};
   padding: 14px 16px;
@@ -48,7 +48,7 @@ const Label = styled(InputLabel)<InputStatus>`
   border-radius: 8px;
   position: relative;
   margin-bottom: 0;
-  text-align: left;
+  justify-content: ${(props) => (props.hideControl ? `center` : `left`)};
   &:before {
     content: '';
     flex-shrink: 0;
@@ -168,7 +168,7 @@ const RadioField = ({
         type="radio"
         {...rest}
       />
-      <Label htmlFor={id} hasError={hasError} isValid={isValid}>
+      <Label htmlFor={id} hasError={hasError} isValid={isValid} hideControl={hideControl}>
         {label}
       </Label>
     </FieldContainer>

--- a/src/components/molecules/RadioField/RadioField.tsx
+++ b/src/components/molecules/RadioField/RadioField.tsx
@@ -35,7 +35,11 @@ const FieldContainer = styled(SizedContainer)`
   }
 `;
 
-const Label = styled(InputLabel)<InputStatus>`
+interface LabelProps extends InputStatus {
+  hideControl?: boolean;
+}
+
+const Label = styled(InputLabel)<LabelProps>`
   display: flex;
   line-height: 1.4;
   font-weight: ${(props) => (props.hideControl ? typography.weights.bold : typography.weights.regular)};

--- a/src/components/molecules/RadioField/__snapshots__/RadioField.test.tsx.snap
+++ b/src/components/molecules/RadioField/__snapshots__/RadioField.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<RadioField /> renders the component with no control icon and no a11y v
   display: -ms-flexbox;
   display: flex;
   line-height: 1.4;
-  font-weight: 400;
+  font-weight: 700;
   font-size: 16px;
   color: #2C3236;
   padding: 14px 16px;
@@ -43,7 +43,10 @@ exports[`<RadioField /> renders the component with no control icon and no a11y v
   border-radius: 8px;
   position: relative;
   margin-bottom: 0;
-  text-align: left;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c3:before {
@@ -207,7 +210,10 @@ exports[`<RadioField /> renders the component with props with no a11y violations
   border-radius: 8px;
   position: relative;
   margin-bottom: 0;
-  text-align: left;
+  -webkit-box-pack: left;
+  -webkit-justify-content: left;
+  -ms-flex-pack: left;
+  justify-content: left;
 }
 
 .c3:before {

--- a/src/components/molecules/RadioGroupField/__snapshots__/RadioGroupField.test.tsx.snap
+++ b/src/components/molecules/RadioGroupField/__snapshots__/RadioGroupField.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`<RadioGroupField /> renders the component with no control icon and no a
   display: -ms-flexbox;
   display: flex;
   line-height: 1.4;
-  font-weight: 400;
+  font-weight: 700;
   font-size: 16px;
   color: #2C3236;
   padding: 14px 16px;
@@ -77,7 +77,10 @@ exports[`<RadioGroupField /> renders the component with no control icon and no a
   border-radius: 8px;
   position: relative;
   margin-bottom: 0;
-  text-align: left;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8:before {
@@ -346,7 +349,10 @@ exports[`<RadioGroupField /> renders the component with props with no a11y viola
   border-radius: 8px;
   position: relative;
   margin-bottom: 0;
-  text-align: left;
+  -webkit-box-pack: left;
+  -webkit-justify-content: left;
+  -ms-flex-pack: left;
+  justify-content: left;
 }
 
 .c8:before {


### PR DESCRIPTION
**Motivation**

- According to the Zopa design system, a radio button without the control circle should have bold text which is center aligned

**What has changed**

- the hideControl prop in `RadioField` component now decides whether the text will be bold and center aligned
- Updated relevant snapshots