### PR TITLE
fix(accordionsection): add visibility to content

### DIFF
--- a/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
+++ b/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
@@ -10,6 +10,7 @@ interface AccordionSectionProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const AccordionContent = styled.div<{ visible: boolean }>`
   visibility: ${({ visible }) => (visible ? 'hidden' : 'visible')};
+  transition: visibility 200ms;
 `;
 
 const AccordionSection: FC<AccordionSectionProps> = ({ children, id, index, ...rest }) => {

--- a/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
+++ b/src/components/organisms/Accordion/AccordionSection/AccordionSection.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import styled from 'styled-components';
 
 import { useAccordionContext } from '../context';
 
@@ -7,14 +8,22 @@ interface AccordionSectionProps extends React.HTMLAttributes<HTMLDivElement> {
   index: number;
 }
 
+const AccordionContent = styled.div<{ visible: boolean }>`
+  visibility: ${({ visible }) => (visible ? 'hidden' : 'visible')};
+`;
+
 const AccordionSection: FC<AccordionSectionProps> = ({ children, id, index, ...rest }) => {
   const { getSectionProps } = useAccordionContext();
   const { ref, ...sectionPropsRest } = getSectionProps(id, index);
   return (
     <div {...sectionPropsRest} {...rest}>
-      <div ref={ref} tabIndex={sectionPropsRest['aria-hidden'] ? -1 : undefined}>
+      <AccordionContent
+        ref={ref}
+        tabIndex={sectionPropsRest['aria-hidden'] ? -1 : undefined}
+        visible={sectionPropsRest['aria-hidden']}
+      >
         {children}
-      </div>
+      </AccordionContent>
     </div>
   );
 };

--- a/src/components/organisms/Accordion/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/components/organisms/Accordion/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccordionSection /> renders the component with no a11y violations 1`] = `
+.c0 {
+  visibility: hidden;
+}
+
 <div
   aria-hidden="true"
   aria-labelledby="one"
@@ -10,6 +14,7 @@ exports[`<AccordionSection /> renders the component with no a11y violations 1`] 
   style="overflow: hidden; transition: height 200ms linear; height: 0px;"
 >
   <div
+    class="c0"
     tabindex="-1"
   >
     Content

--- a/src/components/organisms/Accordion/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/components/organisms/Accordion/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
@@ -3,6 +3,8 @@
 exports[`<AccordionSection /> renders the component with no a11y violations 1`] = `
 .c0 {
   visibility: hidden;
+  -webkit-transition: visibility 200ms;
+  transition: visibility 200ms;
 }
 
 <div


### PR DESCRIPTION
## The challenge 🍿

Toggle visibility on content based on if the accordion is open so that you cant tab into any focusable elements

## The solution 💯

By checking the `visible={sectionPropsRest['aria-hidden']}` we can determine if the accordion is open and toggle `visibility: ${({ visible }) => (visible ? 'hidden' : 'visible')};` with `styled-components` 

## Jira 🎟

- [Jira issue](https://jira.zopa/browse/SHOPDEV-8703)

<!--
Help the reviewer by:

- pasting screen recording or captures
- be concise and clear about your changes
- linking to external content and docs as needed
-->
