### PR TITLE
fix(zopafooter): removing 'new products' link

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -72,7 +72,6 @@ const ZopaFooter = ({
             <li className="mb-4">{renderLink({ href: `${baseUrl}/about/awards`, children: 'Awards' })}</li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/about/careers`, children: 'Careers' })}</li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/blog`, children: 'Blog' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/feelgood`, children: 'New products' })}</li>
             <li>{renderLink({ href: `${baseUrl}/contact/complaints`, children: 'Complaints' })}</li>
           </List>
         </FlexCol>

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -565,17 +565,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
               Blog
             </a>
           </li>
-          <li
-            class="mb-4"
-          >
-            <a
-              class="c6 c7"
-              color="#3B46C4"
-              href="https://www.zopa.com/feelgood"
-            >
-              New products
-            </a>
-          </li>
           <li>
             <a
               class="c6 c7"


### PR DESCRIPTION
 removing 'new products' from ZopaFooter as /feelgood page no longer exists
 https://jira.zopa/browse/SHOPDEV-8774