### PR TITLE
Progress bar a11y

### DIFF
--- a/src/components/molecules/Progress/Progress.tsx
+++ b/src/components/molecules/Progress/Progress.tsx
@@ -102,7 +102,13 @@ const Progress: React.FC<ProgressProps> = ({ totalSteps, currentStep, withStep =
 
   return (
     <ProgressWrapper>
-      <ProgressBar aria-label={`Progress Bar showing step ${currentStep} of ${totalSteps}`} {...rest}>
+      <ProgressBar
+        role="progressbar"
+        aria-valuemax={totalSteps}
+        aria-valuenow={currentStep}
+        aria-label={`Static progress bar showing step ${currentStep} of ${totalSteps}`}
+        {...rest}
+      >
         {renderPoints()}
         <Progression position={getStepPosition(totalSteps, currentStep - 0.5)} progressColor={progressColor}>
           {withStep && (

--- a/src/components/molecules/Progress/__snapshots__/Progress.test.tsx.snap
+++ b/src/components/molecules/Progress/__snapshots__/Progress.test.tsx.snap
@@ -110,8 +110,11 @@ exports[`<Progress /> Accessibility renders the component with props with no a11
     class="c0"
   >
     <div
-      aria-label="Progress Bar showing step 2 of 5"
+      aria-label="Static progress bar showing step 2 of 5"
+      aria-valuemax="5"
+      aria-valuenow="2"
       class="c1"
+      role="progressbar"
     >
       <span
         class="c2"
@@ -245,8 +248,11 @@ exports[`<Progress /> Props renders empty progress bar 1`] = `
   class="c0"
 >
   <div
-    aria-label="Progress Bar showing step 0 of 5"
+    aria-label="Static progress bar showing step 0 of 5"
+    aria-valuemax="5"
+    aria-valuenow="0"
     class="c1"
+    role="progressbar"
   >
     <span
       class="c2"
@@ -379,8 +385,11 @@ exports[`<Progress /> Props renders full progress bar 1`] = `
   class="c0"
 >
   <div
-    aria-label="Progress Bar showing step 5 of 5"
+    aria-label="Static progress bar showing step 5 of 5"
+    aria-valuemax="5"
+    aria-valuenow="5"
     class="c1"
+    role="progressbar"
   >
     <span
       class="c2"

--- a/src/components/templates/ProductTemplate/ProductTemplateHeader/__snapshots__/ProductTemplateHeader.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateHeader/__snapshots__/ProductTemplateHeader.test.tsx.snap
@@ -196,8 +196,11 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
         class="c7"
       >
         <div
-          aria-label="Progress Bar showing step 1 of 2"
+          aria-label="Static progress bar showing step 1 of 2"
+          aria-valuemax="2"
+          aria-valuenow="1"
           class="c8"
+          role="progressbar"
         >
           <span
             class="c9"

--- a/src/components/templates/ProductTemplate/ProductTemplateProgress/__snapshots__/ProductTemplateProgress.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateProgress/__snapshots__/ProductTemplateProgress.test.tsx.snap
@@ -81,8 +81,11 @@ exports[`<ProductTemplateProgress /> renders with all the props 1`] = `
       class="c1"
     >
       <div
-        aria-label="Progress Bar showing step 1 of 2"
+        aria-label="Static progress bar showing step 1 of 2"
+        aria-valuemax="2"
+        aria-valuenow="1"
         class="c2"
+        role="progressbar"
       >
         <span
           class="c3"


### PR DESCRIPTION
#721

- reverted back to version with `role="progressbar` as it caused a11y violations  