### PR TITLE
fix(zopafooter): removing ISA link

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -53,10 +53,6 @@ const ZopaFooter = ({
               {renderLink({ href: `${baseUrl}/loans/home-improvement`, children: 'Home improvement loans' })}
             </li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/loans/wedding`, children: 'Wedding loans' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/invest`, children: 'Peer-to-peer investments' })}</li>
-            <li className="mb-4">
-              {renderLink({ href: `${baseUrl}/invest/isa`, children: 'Innovative Finance ISA' })}
-            </li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/credit-card`, children: 'Credit cards' })}</li>
             <li>{renderLink({ href: `${baseUrl}/savings-accounts`, children: 'Fixed Term Savings' })}</li>
           </List>
@@ -74,7 +70,8 @@ const ZopaFooter = ({
             <li className="mb-4">{renderLink({ href: `${baseUrl}/about/careers`, children: 'Careers' })}</li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/blog`, children: 'Blog' })}</li>
             <li className="mb-4">{renderLink({ href: `${baseUrl}/contact/complaints`, children: 'Complaints' })}</li>
-            <li>{renderLink({ href: `${baseUrl}/about/press`, children: 'Press office' })}</li>
+            <li className="mb-4">{renderLink({ href: `${baseUrl}/about/press`, children: 'Press office' })}</li>
+            <li>{renderLink({ href: `${baseUrl}/invest`, children: 'Peer-to-peer investments' })}</li>
           </List>
         </FlexCol>
         <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -453,28 +453,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
             <a
               class="c7 c8"
               color="#3B46C4"
-              href="https://www.zopa.com/invest"
-            >
-              Peer-to-peer investments
-            </a>
-          </li>
-          <li
-            class="mb-4"
-          >
-            <a
-              class="c7 c8"
-              color="#3B46C4"
-              href="https://www.zopa.com/invest/isa"
-            >
-              Innovative Finance ISA
-            </a>
-          </li>
-          <li
-            class="mb-4"
-          >
-            <a
-              class="c7 c8"
-              color="#3B46C4"
               href="https://www.zopa.com/credit-card"
             >
               Credit cards
@@ -591,13 +569,24 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
               Complaints
             </a>
           </li>
-          <li>
+          <li
+            class="mb-4"
+          >
             <a
               class="c7 c8"
               color="#3B46C4"
               href="https://www.zopa.com/about/press"
             >
               Press office
+            </a>
+          </li>
+          <li>
+            <a
+              class="c7 c8"
+              color="#3B46C4"
+              href="https://www.zopa.com/invest"
+            >
+              Peer-to-peer investments
             </a>
           </li>
         </ul>


### PR DESCRIPTION
removing ISA link and moving P2P link to about section
<img width="598" alt="Screenshot 2022-02-03 at 13 45 09" src="https://user-images.githubusercontent.com/67011746/152357118-434616b9-100b-406a-b6ab-6b16e651a49e.png">
 