### PR TITLE
feat: export severity type

### DIFF
--- a/src/components/atoms/Alert/Alert.tsx
+++ b/src/components/atoms/Alert/Alert.tsx
@@ -10,7 +10,7 @@ import {
 import Icon from '../Icon/Icon';
 import { colors, typography } from '../../../constants';
 
-type Severity = 'info' | 'alert' | 'warning' | 'success' | 'brand';
+export type Severity = 'info' | 'alert' | 'warning' | 'success' | 'brand';
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   severity?: Severity;

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,3 +75,5 @@ export * from './hooks/useViewport';
 export * from './hooks/useAccordion';
 // Helpers
 export * from './helpers/responsiveness';
+// Types
+export type { Severity } from './components/atoms/Alert/Alert';


### PR DESCRIPTION
Export severity type so it can be used consistently in customer components outside of library.