### PR TITLE
Add-alert-dark-as-text-color

### DIFF
--- a/src/components/atoms/Text/Text.md
+++ b/src/components/atoms/Text/Text.md
@@ -77,7 +77,9 @@ import { Text, colors } from '@zopauk/react-components';
   <Text color={colors.success} className="mb-6" as="p">
     Success
   </Text>
-  <Text color={colors.alert}>Alert</Text>
+  <Text color={colors.alert} className="mb-6" as="p">
+    Alert
+  </Text>
   <Text color={colors.alertDark}>Alert Dark</Text>
 </Fragment>;
 ```

--- a/src/components/atoms/Text/Text.md
+++ b/src/components/atoms/Text/Text.md
@@ -78,6 +78,7 @@ import { Text, colors } from '@zopauk/react-components';
     Success
   </Text>
   <Text color={colors.alert}>Alert</Text>
+  <Text color={colors.alertDark}>Alert Dark</Text>
 </Fragment>;
 ```
 

--- a/src/components/atoms/Text/Text.test.tsx
+++ b/src/components/atoms/Text/Text.test.tsx
@@ -97,6 +97,7 @@ describe('<Text />', () => {
     ${colors.greyDarkest} | ${'Grey Darkest'}
     ${colors.success}     | ${'Success'}
     ${colors.alert}       | ${'Alert'}
+    ${colors.alertDark}   | ${'Alert Dark'}
   `('can render in different colors: $name – $hex', ({ hex }) => {
     const { container } = render(<Text color={hex}>Text</Text>);
     expect(container.firstChild).toHaveStyleRule('color', hex);

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -41,6 +41,7 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
     | Colors['greyDarkest']
     | Colors['success']
     | Colors['alert']
+    | Colors['alertDark']
     | 'inherit';
 }
 


### PR DESCRIPTION
## What

We are starting to require text to be alert dark coloured in upcoming designs so this change will be required.