### PR TITLE
Add theming to heading

### DIFF
--- a/src/components/atoms/Heading/Heading.md
+++ b/src/components/atoms/Heading/Heading.md
@@ -87,3 +87,20 @@ import { Heading } from '@zopauk/react-components';
   </Heading>
 </Fragment>;
 ```
+
+- Using forwardedAs:
+  If Heading is styled it should use the 'forwardedAs' prop in place of as.
+  If Heading is not styled the 'as' prop should be used.
+
+```jsx
+import { Fragment } from 'react';
+import styled from 'styled-components';
+import { Heading } from '@zopauk/react-components';
+
+const StyledHeading = styled(Heading)``;
+
+<Fragment>
+  <Heading as="h4">Heading uses as prop</Heading>
+  <StyledHeading forwardedAs="h4">Styled heading uses forwardedAs prop</StyledHeading>
+</Fragment>;
+```

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -27,6 +27,7 @@ export interface OptionalHeadingProps extends HTMLAttributes<HTMLHeadingElement>
 interface HeadingPropsWithAs extends OptionalHeadingProps {
   /**
    * The HTML5 tag you want to render your heading, it's used to determine the size of the heading as well.
+   * @default 'required if 'forwardedAs' is not provided.'
    */
   as: HeadingTags;
 }
@@ -34,7 +35,8 @@ interface HeadingPropsWithAs extends OptionalHeadingProps {
 interface HeadingPropsWithForwardedAs extends OptionalHeadingProps {
   /**
    * The HTML5 tag you want to render your heading, it's used to determine the size of the heading as well.
-   * to be used if Component has been wrapped in styled component in place of as.
+   * To be used if Component has been wrapped in styled components.
+   * @default 'required if 'as' is not provided.'
    */
   forwardedAs: HeadingTags;
 }

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -1,7 +1,8 @@
-import React, { FC, HTMLAttributes } from 'react';
+import { grid } from '../../../constants';
 import styled, { css } from 'styled-components';
-import { colors, grid, typography } from '../../../constants';
+import React, { FC, HTMLAttributes } from 'react';
 import { Colors } from '../../../constants/colors';
+import { useThemeContext, AppThemeProps, AppTheme } from '../../styles/Theme';
 
 export type HeadingTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
 
@@ -14,12 +15,12 @@ export interface StyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
    * Override the default size assigned to the rendered HTML tag.
    * @default `as`
    */
-  size?: keyof typeof typography.sizes.heading;
+  size?: keyof AppTheme['typography']['heading']['sizes'];
   /**
-   * Accepts a subset of the Zopa brand colors. Same as the ones accepted by `<Text />`.
+   * Accepts a subset of the Zopa brand colors by default. Same as the ones accepted by `<Text />`.
    * @default `colors.greyDarkest`
    */
-  color?: Colors['white'] | Colors['grey'] | Colors['greyDarkest'];
+  color?: Colors['white'] | Colors['grey'] | Colors['greyDarkest'] | string;
   /**
    * Where the rendered text should be aligned to.
    * @default 'inherit'
@@ -27,51 +28,39 @@ export interface StyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   align?: 'inherit' | 'left' | 'right' | 'center';
 }
 
-const {
-  sizes: { heading: headingSizes, lineHeight: lineHeightMap },
-} = typography;
-
-const letterSpacingMap = {
-  display: '-2.86px',
-  h1: '-1.25px',
-  h2: '-0.85px',
-  h3: '-0.45px',
-  h4: '-0.25px',
-  h5: '-0.02px',
-  h6: '-0.01px',
-};
-
-const Heading = styled.h1<StyledHeadingProps>`
-  ${({ as, size }) => {
+const StyledHeading = styled.h1<StyledHeadingProps & AppThemeProps>`
+  ${({ as, size, theme }) => {
     const tag = size || (as === 'span' ? 'h4' : as);
     return css`
-      font-size: ${headingSizes[tag]};
-      line-height: ${lineHeightMap[tag]};
-      letter-spacing: ${letterSpacingMap[tag]};
+      font-size: ${theme.typography.heading.sizes[tag]};
+      line-height: ${theme.typography.lineHeight[tag]};
+      letter-spacing: ${theme.typography.letterSpacingMap[tag]};
     `;
   }};
 
   margin: 0;
-  color: ${({ color = colors.greyDarkest }) => color};
+  color: ${({ color, theme }) => color || theme.typography.text.color};
   display: ${({ as }) => (as === 'span' ? 'block' : undefined)};
   text-align: ${({ align = 'inherit' }) => align};
-  font-family: ${typography.primary};
-  font-weight: ${({ as }) => typography.weights[['h1', 'display'].includes(as) ? 'extraBold' : 'bold']};
+  font-family: ${({ theme }) => theme.typography.primary};
+  font-weight: ${({ as, theme }) => theme.typography.weights[['h1', 'display'].includes(as) ? 'extraBold' : 'bold']};
 
-  ${({ as, size }) =>
+  ${({ as, size, theme }) =>
     as === 'h1' &&
     size === 'display' &&
     css`
       @media screen and (max-width: ${grid.breakpoints.l}px) {
-        font-size: ${headingSizes['h2']};
-        line-height: ${lineHeightMap['h2']};
-        letter-spacing: ${letterSpacingMap['h2']};
-        font-weight: ${typography.weights['bold']};
+        font-size: ${theme.typography.heading.sizes['h2']};
+        line-height: ${theme.typography.lineHeight['h2']};
+        letter-spacing: ${theme.typography.letterSpacingMap['h2']};
+        font-weight: ${theme.typography.weights['bold']};
       }
     `}
 `;
 
-// TODO: Styleguidist to be able to locate styled components. See #147.
-export const StyleguidistHeading: FC<StyledHeadingProps> = (props) => <Heading {...props} />;
+export const Heading: FC<StyledHeadingProps> = (props) => {
+  const theme = useThemeContext();
+  return <StyledHeading {...props} theme={theme} />;
+};
 
 export default Heading;

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -6,11 +6,7 @@ import { useThemeContext, AppThemeProps, AppTheme } from '../../styles/Theme';
 
 export type HeadingTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
 
-export interface StyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
-  /**
-   * The HTML5 tag you want to render your heading, it's used to determine the size of the heading as well.
-   */
-  as: HeadingTags;
+export interface OptionalHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   /**
    * Override the default size assigned to the rendered HTML tag.
    * @default `as`
@@ -28,14 +24,33 @@ export interface StyledHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   align?: 'inherit' | 'left' | 'right' | 'center';
 }
 
-const StyledHeading = styled.h1<StyledHeadingProps & AppThemeProps>`
+interface HeadingPropsWithAs extends OptionalHeadingProps {
+  /**
+   * The HTML5 tag you want to render your heading, it's used to determine the size of the heading as well.
+   */
+  as: HeadingTags;
+}
+
+interface HeadingPropsWithForwardedAs extends OptionalHeadingProps {
+  /**
+   * The HTML5 tag you want to render your heading, it's used to determine the size of the heading as well.
+   * to be used if Component has been wrapped in styled component in place of as.
+   */
+  forwardedAs: HeadingTags;
+}
+
+export type HeadingProps = HeadingPropsWithAs | HeadingPropsWithForwardedAs;
+
+const StyledHeading = styled.h1<HeadingPropsWithAs & AppThemeProps>`
   ${({ as, size, theme }) => {
-    const tag = size || (as === 'span' ? 'h4' : as);
-    return css`
-      font-size: ${theme.typography.heading.sizes[tag]};
-      line-height: ${theme.typography.lineHeight[tag]};
-      letter-spacing: ${theme.typography.letterSpacingMap[tag]};
-    `;
+    if (as) {
+      const tag = size || (as === 'span' ? 'h4' : as);
+      return css`
+        font-size: ${theme.typography.heading.sizes[tag]};
+        line-height: ${theme.typography.lineHeight[tag]};
+        letter-spacing: ${theme.typography.letterSpacingMap[tag]};
+      `;
+    }
   }};
 
   margin: 0;
@@ -58,9 +73,9 @@ const StyledHeading = styled.h1<StyledHeadingProps & AppThemeProps>`
     `}
 `;
 
-export const Heading: FC<StyledHeadingProps> = (props) => {
+export const Heading: FC<HeadingProps> = (props) => {
   const theme = useThemeContext();
-  return <StyledHeading {...props} theme={theme} />;
+  return <StyledHeading {...(props as HeadingPropsWithAs)} theme={theme} />;
 };
 
 export default Heading;

--- a/src/components/atoms/Heading/Heading.tsx
+++ b/src/components/atoms/Heading/Heading.tsx
@@ -77,7 +77,11 @@ const StyledHeading = styled.h1<HeadingPropsWithAs & AppThemeProps>`
 
 export const Heading: FC<HeadingProps> = (props) => {
   const theme = useThemeContext();
-  return <StyledHeading {...(props as HeadingPropsWithAs)} theme={theme} />;
+  const headingProps = props as HeadingPropsWithAs;
+  if (!headingProps?.as) {
+    console.warn('Heading component is missing the as prop');
+  }
+  return <StyledHeading {...headingProps} theme={theme} />;
 };
 
 export default Heading;

--- a/src/components/molecules/NumberText/NumberText.tsx
+++ b/src/components/molecules/NumberText/NumberText.tsx
@@ -126,7 +126,7 @@ const NumberText: React.FC<NumberTextProps> = ({
         </Title>
       ) : null}
       <Value
-        as="span"
+        forwardedAs="span"
         className={valueClassNames}
         numberPosition={numberPosition}
         numberFontSize={numberFontSize}

--- a/src/components/molecules/NumberText/__snapshots__/NumberText.test.tsx.snap
+++ b/src/components/molecules/NumberText/__snapshots__/NumberText.test.tsx.snap
@@ -40,18 +40,6 @@ exports[`<NumberText /> renders without errors 1`] = `
 }
 
 .c3 {
-  font-size: 46px;
-  line-height: 54px;
-  -webkit-letter-spacing: -1.25px;
-  -moz-letter-spacing: -1.25px;
-  -ms-letter-spacing: -1.25px;
-  letter-spacing: -1.25px;
-  margin: 0;
-  color: #2C3236;
-  display: block;
-  text-align: inherit;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 700;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;

--- a/src/components/molecules/NumberText/__snapshots__/NumberText.test.tsx.snap
+++ b/src/components/molecules/NumberText/__snapshots__/NumberText.test.tsx.snap
@@ -15,6 +15,21 @@ exports[`<NumberText /> renders without errors 1`] = `
   text-align: inherit;
 }
 
+.c3 {
+  font-size: 46px;
+  line-height: 54px;
+  -webkit-letter-spacing: -1.25px;
+  -moz-letter-spacing: -1.25px;
+  -ms-letter-spacing: -1.25px;
+  letter-spacing: -1.25px;
+  margin: 0;
+  color: #2C3236;
+  display: block;
+  text-align: inherit;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -39,7 +54,7 @@ exports[`<NumberText /> renders without errors 1`] = `
   order: 2;
 }
 
-.c3 {
+.c4 {
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -55,7 +70,7 @@ exports[`<NumberText /> renders without errors 1`] = `
       Overall Balance
     </span>
     <span
-      class="c3 mb-2"
+      class="c3 c4 mb-2"
     >
       £100,000.00
     </span>

--- a/src/components/organisms/Card/CardHeading/CardHeading.tsx
+++ b/src/components/organisms/Card/CardHeading/CardHeading.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import { colors } from '../../../../constants';
-import Heading, { StyledHeadingProps, HeadingTags } from '../../../atoms/Heading/Heading';
+import Heading, { OptionalHeadingProps, HeadingTags } from '../../../atoms/Heading/Heading';
 
-interface CardHeadingProps extends Omit<StyledHeadingProps, 'as'> {
+interface CardHeadingProps extends OptionalHeadingProps {
   as?: HeadingTags;
 }
 

--- a/src/components/organisms/Form/FormSection/__snapshots__/FormSection.test.tsx.snap
+++ b/src/components/organisms/Form/FormSection/__snapshots__/FormSection.test.tsx.snap
@@ -67,7 +67,7 @@ Object {
       class="py-6"
     >
       <h5
-        class="sc-brqgnP bndrEb mb-2"
+        class="sc-brqgnP LNhDn mb-2"
       >
         Form Section
       </h5>

--- a/src/components/styles/Theme.tsx
+++ b/src/components/styles/Theme.tsx
@@ -122,6 +122,10 @@ export interface AppTheme {
   typography: TypographyTheme;
 }
 
+export interface AppThemeProps {
+  theme: AppTheme;
+}
+
 export const zopaTheme: AppTheme = {
   alert: {
     brand: {

--- a/src/components/templates/ErrorPages/FiveHundred/__snapshots__/FiveHundred.test.tsx.snap
+++ b/src/components/templates/ErrorPages/FiveHundred/__snapshots__/FiveHundred.test.tsx.snap
@@ -35,20 +35,6 @@ exports[`<FiveHundred /> renders with all the props 1`] = `
   align-self: auto;
 }
 
-.c4 {
-  font-size: 24px;
-  line-height: 32px;
-  -webkit-letter-spacing: -0.25px;
-  -moz-letter-spacing: -0.25px;
-  -ms-letter-spacing: -0.25px;
-  letter-spacing: -0.25px;
-  margin: 0;
-  color: #2C3236;
-  text-align: center;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 800;
-}
-
 .c2 {
   background-color: #EFEFEF;
   display: -webkit-box;
@@ -68,6 +54,20 @@ exports[`<FiveHundred /> renders with all the props 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 24px;
+}
+
+.c4 {
+  font-size: 24px;
+  line-height: 32px;
+  -webkit-letter-spacing: -0.25px;
+  -moz-letter-spacing: -0.25px;
+  -ms-letter-spacing: -0.25px;
+  letter-spacing: -0.25px;
+  margin: 0;
+  color: #2C3236;
+  text-align: center;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 800;
 }
 
 .c5 {

--- a/src/components/templates/ErrorPages/Four0Four/__snapshots__/Four0Four.test.tsx.snap
+++ b/src/components/templates/ErrorPages/Four0Four/__snapshots__/Four0Four.test.tsx.snap
@@ -35,20 +35,6 @@ exports[`<Four0Four /> renders with all the props 1`] = `
   align-self: auto;
 }
 
-.c4 {
-  font-size: 24px;
-  line-height: 32px;
-  -webkit-letter-spacing: -0.25px;
-  -moz-letter-spacing: -0.25px;
-  -ms-letter-spacing: -0.25px;
-  letter-spacing: -0.25px;
-  margin: 0;
-  color: #2C3236;
-  text-align: center;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 800;
-}
-
 .c2 {
   background-color: #EFEFEF;
   display: -webkit-box;
@@ -68,6 +54,20 @@ exports[`<Four0Four /> renders with all the props 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 24px;
+}
+
+.c4 {
+  font-size: 24px;
+  line-height: 32px;
+  -webkit-letter-spacing: -0.25px;
+  -moz-letter-spacing: -0.25px;
+  -ms-letter-spacing: -0.25px;
+  letter-spacing: -0.25px;
+  margin: 0;
+  color: #2C3236;
+  text-align: center;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 800;
 }
 
 .c5 {

--- a/src/components/templates/ErrorPages/Maintenance/__snapshots__/Maintenance.test.tsx.snap
+++ b/src/components/templates/ErrorPages/Maintenance/__snapshots__/Maintenance.test.tsx.snap
@@ -35,20 +35,6 @@ exports[`<Maintenance /> renders with all the props 1`] = `
   align-self: auto;
 }
 
-.c4 {
-  font-size: 24px;
-  line-height: 32px;
-  -webkit-letter-spacing: -0.25px;
-  -moz-letter-spacing: -0.25px;
-  -ms-letter-spacing: -0.25px;
-  letter-spacing: -0.25px;
-  margin: 0;
-  color: #2C3236;
-  text-align: center;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 800;
-}
-
 .c2 {
   background-color: #EFEFEF;
   display: -webkit-box;
@@ -68,6 +54,20 @@ exports[`<Maintenance /> renders with all the props 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 24px;
+}
+
+.c4 {
+  font-size: 24px;
+  line-height: 32px;
+  -webkit-letter-spacing: -0.25px;
+  -moz-letter-spacing: -0.25px;
+  -ms-letter-spacing: -0.25px;
+  letter-spacing: -0.25px;
+  margin: 0;
+  color: #2C3236;
+  text-align: center;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 800;
 }
 
 .c5 {


### PR DESCRIPTION
## BREAKING CHANGE❗ 
- All <Heading/> uses which are wrapped in styled components should now pass 'forwardedAs' in place of the 'as' prop.
- Docs for forwardedAs: https://styled-components.com/docs/api#forwardedas-prop

## The challenge 🍿

Add theming to Heading component

## The solution 💯

Actual JL component:

![Screenshot 2022-05-24 at 18 06 23](https://user-images.githubusercontent.com/91553062/170099251-d74075e9-112b-4a81-a526-566c7d098020.png)

Miro designs:

![Screenshot 2022-05-24 at 18 45 10](https://user-images.githubusercontent.com/91553062/170099346-d6e08733-4b33-45c0-9d39-74f6e03058b8.png)

Rezza2 with JL font:

<img width="672" alt="Screenshot 2022-05-25 at 17 04 32" src="https://user-images.githubusercontent.com/91553062/170307243-fcd654cb-5089-44be-af7e-939810a728bf.png">
