### PR TITLE
Add theming to footer

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, FC } from 'react';
+import React, { HTMLAttributes, FC, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import FlexContainer from '../../layout/FlexContainer/FlexContainer';
 import FlexRow from '../../layout/FlexRow/FlexRow';
@@ -13,6 +13,7 @@ import linkedin from '../../../content/images/social/linkedin.svg';
 import Logo from '../../atoms/Logo/Logo';
 import { typography } from '../../../constants';
 import Link from '../../atoms/Link/Link';
+import { useThemeContext } from '../../styles/Theme';
 
 export const footerLinkStyle = css`
   font-weight: ${typography.weights.regular};
@@ -31,123 +32,145 @@ const StyledLink = styled(Link)`
 export interface FooterProps extends HTMLAttributes<HTMLDivElement> {
   baseUrl?: string;
   renderLink?: FC<Record<'href', string> & HTMLAttributes<HTMLAnchorElement>>;
+  legalAmendment?: ReactNode;
 }
 
 const ZopaFooter = ({
   baseUrl = 'https://www.zopa.com',
   renderLink = (props) => <StyledLink {...props} />,
+  legalAmendment = <></>,
   ...rest
-}: FooterProps) => (
-  <Footer data-automation="ZA.footer" {...rest}>
-    <FlexContainer gutter={16}>
-      <FlexRow className="mb-6">
-        <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
-          <Heading className="mb-4 s:mb-6">What we do</Heading>
-          <List>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/car-finance`, children: 'Car hire purchase' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/loans/car-loans`, children: 'Car loans' })}</li>
-            <li className="mb-4">
-              {renderLink({ href: `${baseUrl}/loans/debt-consolidation`, children: 'Debt consolidation loans' })}
-            </li>
-            <li className="mb-4">
-              {renderLink({ href: `${baseUrl}/loans/home-improvement`, children: 'Home improvement loans' })}
-            </li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/loans/wedding`, children: 'Wedding loans' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/credit-card`, children: 'Credit cards' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/smart-saver`, children: 'Smart Saver' })}</li>
-            <li>{renderLink({ href: `${baseUrl}/savings-accounts`, children: 'Fixed Term Savings' })}</li>
-          </List>
-        </FlexCol>
-        <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
-          <Heading className="mb-4 s:mb-6">About Zopa</Heading>
-          <List>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/about`, children: 'About us' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/about/our-story`, children: 'Our story' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/about/board`, children: 'Meet the board' })}</li>
-            <li className="mb-4">
-              {renderLink({ href: `${baseUrl}/about/leadership`, children: 'Meet the leadership team' })}
-            </li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/about/awards`, children: 'Awards' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/about/careers`, children: 'Careers' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/blog`, children: 'Blog' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/contact/complaints`, children: 'Complaints' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/about/press`, children: 'Press office' })}</li>
-            <li>{renderLink({ href: `${baseUrl}/invest`, children: 'Peer-to-peer investments' })}</li>
-          </List>
-        </FlexCol>
-        <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
-          <Heading className="mb-4 s:mb-6">Legal</Heading>
-          <List>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/privacy-notice`, children: 'Privacy notice' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/cookie-policy`, children: 'Cookie policy' })}</li>
-            <li className="mb-4">
-              {renderLink({ href: `${baseUrl}/conflicts-policy`, children: 'Conflicts policy' })}
-            </li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/modern-slavery`, children: 'Modern slavery' })}</li>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/terms-of-use`, children: 'Terms of use' })}</li>
-            <li className="mb-4">
-              {renderLink({ href: `${baseUrl}/investor-principles`, children: 'Investor principles' })}
-            </li>
-            <li>{renderLink({ href: `${baseUrl}/remuneration`, children: 'Remuneration' })}</li>
-          </List>
-        </FlexCol>
-        <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
-          <Heading className="mb-4 s:mb-6">Navigation</Heading>
-          <List>
-            <li className="mb-4">{renderLink({ href: `${baseUrl}/help`, children: 'Help' })}</li>
-            <li>{renderLink({ href: `${baseUrl}/sitemap`, children: 'Sitemap' })}</li>
-          </List>
-        </FlexCol>
-      </FlexRow>
-      <FlexRow>
-        <LogoBlock>
-          {renderLink({ href: baseUrl, title: 'Logo', children: <Logo width="165px" height="30px" /> })}
-        </LogoBlock>
-        <SocialBlock>
-          <SocialLink
-            href="https://facebook.com/zopa"
-            aria-label="Facebook"
-            title="Facebook opens in a new tab"
-            variant={facebook}
-          />
-          <SocialLink
-            href="https://twitter.com/zopa"
-            aria-label="Twitter"
-            title="Twitter opens in a new tab"
-            variant={twitter}
-          />
-          <SocialLink
-            href="https://www.instagram.com/Zopamoney/"
-            aria-label="Instagram"
-            title="Instagram opens in a new tab"
-            variant={instagram}
-          />
-          <SocialLink
-            href="https://www.linkedin.com/company/zopa/"
-            aria-label="Linkedin"
-            title="Linkedin opens in a new tab"
-            variant={linkedin}
-          />
-        </SocialBlock>
-        <LegalBlock>
-          <Text as="p" color={colors.greyDark} size="small" className="mb-4">
-            Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial
-            Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services Register
-            (800542). Zopa Bank Limited (10627575) is incorporated in England &amp; Wales and has its registered office
-            at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
-          </Text>
-          <Text as="p" color={colors.greyDark} size="small" className="mb-4">
-            © Zopa Bank Limited {new Date().getFullYear()} All rights reserved. 'Zopa' is a trademark of Zopa Bank
-            Limited.
-          </Text>
-          <Text as="p" color={colors.greyDark} size="small">
-            Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the Office
-            of the Information Commissioner (ZA275984).
-          </Text>
-        </LegalBlock>
-      </FlexRow>
-    </FlexContainer>
-  </Footer>
-);
+}: FooterProps) => {
+  const theme = useThemeContext();
+  return (
+    <Footer data-automation="ZA.footer" theme={theme} {...rest}>
+      <FlexContainer gutter={16}>
+        {theme.footer.showFooterLinks && (
+          <FlexRow className="mb-6">
+            <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
+              <Heading className="mb-4 s:mb-6">What we do</Heading>
+              <List>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/car-finance`, children: 'Car hire purchase' })}
+                </li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/loans/car-loans`, children: 'Car loans' })}</li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/loans/debt-consolidation`, children: 'Debt consolidation loans' })}
+                </li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/loans/home-improvement`, children: 'Home improvement loans' })}
+                </li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/loans/wedding`, children: 'Wedding loans' })}</li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/credit-card`, children: 'Credit cards' })}</li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/smart-saver`, children: 'Smart Saver' })}</li>
+                <li>{renderLink({ href: `${baseUrl}/savings-accounts`, children: 'Fixed Term Savings' })}</li>
+              </List>
+            </FlexCol>
+            <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
+              <Heading className="mb-4 s:mb-6">About Zopa</Heading>
+              <List>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/about`, children: 'About us' })}</li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/about/our-story`, children: 'Our story' })}</li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/about/board`, children: 'Meet the board' })}</li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/about/leadership`, children: 'Meet the leadership team' })}
+                </li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/about/awards`, children: 'Awards' })}</li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/about/careers`, children: 'Careers' })}</li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/blog`, children: 'Blog' })}</li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/contact/complaints`, children: 'Complaints' })}
+                </li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/about/press`, children: 'Press office' })}</li>
+                <li>{renderLink({ href: `${baseUrl}/invest`, children: 'Peer-to-peer investments' })}</li>
+              </List>
+            </FlexCol>
+            <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
+              <Heading className="mb-4 s:mb-6">Legal</Heading>
+              <List>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/privacy-notice`, children: 'Privacy notice' })}
+                </li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/cookie-policy`, children: 'Cookie policy' })}</li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/conflicts-policy`, children: 'Conflicts policy' })}
+                </li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/modern-slavery`, children: 'Modern slavery' })}
+                </li>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/terms-of-use`, children: 'Terms of use' })}</li>
+                <li className="mb-4">
+                  {renderLink({ href: `${baseUrl}/investor-principles`, children: 'Investor principles' })}
+                </li>
+                <li>{renderLink({ href: `${baseUrl}/remuneration`, children: 'Remuneration' })}</li>
+              </List>
+            </FlexCol>
+            <FlexCol xs={12} s={6} l={3} className="mb-8 s:mb-9">
+              <Heading className="mb-4 s:mb-6">Navigation</Heading>
+              <List>
+                <li className="mb-4">{renderLink({ href: `${baseUrl}/help`, children: 'Help' })}</li>
+                <li>{renderLink({ href: `${baseUrl}/sitemap`, children: 'Sitemap' })}</li>
+              </List>
+            </FlexCol>
+          </FlexRow>
+        )}
+        <FlexRow>
+          {theme.footer.showLogoBlock && (
+            <LogoBlock>
+              {renderLink({ href: baseUrl, title: 'Logo', children: <Logo width="165px" height="30px" /> })}
+            </LogoBlock>
+          )}
+          {theme.footer.showSocialBlock && (
+            <SocialBlock>
+              <SocialLink
+                href="https://facebook.com/zopa"
+                aria-label="Facebook"
+                title="Facebook opens in a new tab"
+                variant={facebook}
+              />
+              <SocialLink
+                href="https://twitter.com/zopa"
+                aria-label="Twitter"
+                title="Twitter opens in a new tab"
+                variant={twitter}
+              />
+              <SocialLink
+                href="https://www.instagram.com/Zopamoney/"
+                aria-label="Instagram"
+                title="Instagram opens in a new tab"
+                variant={instagram}
+              />
+              <SocialLink
+                href="https://www.linkedin.com/company/zopa/"
+                aria-label="Linkedin"
+                title="Linkedin opens in a new tab"
+                variant={linkedin}
+              />
+            </SocialBlock>
+          )}
+          {theme.footer.showLegalBlock && (
+            <LegalBlock xs={12} l={theme.footer.isLegalBlockFullWidth ? 12 : 5}>
+              <Text as="p" color={colors.greyDark} size="small" className="mb-4">
+                Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial
+                Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services
+                Register (800542). Zopa Bank Limited (10627575) is incorporated in England &amp; Wales and has its
+                registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
+              </Text>
+              <Text as="p" color={colors.greyDark} size="small" className="mb-4">
+                © Zopa Bank Limited {new Date().getFullYear()} All rights reserved. 'Zopa' is a trademark of Zopa Bank
+                Limited.
+              </Text>
+              <Text as="p" color={colors.greyDark} size="small" className={legalAmendment ? 'mb-4' : ''}>
+                Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the
+                Office of the Information Commissioner (ZA275984).
+              </Text>
+              {legalAmendment}
+            </LegalBlock>
+          )}
+        </FlexRow>
+      </FlexContainer>
+    </Footer>
+  );
+};
 
 export default ZopaFooter;

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -850,7 +850,7 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
            All rights reserved. 'Zopa' is a trademark of Zopa Bank Limited.
         </p>
         <p
-          class="c21"
+          class="c21 mb-4"
           color="#4A545E"
         >
           Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the Office of the Information Commissioner (ZA275984).

--- a/src/components/molecules/ZopaFooter/styles/Footer.tsx
+++ b/src/components/molecules/ZopaFooter/styles/Footer.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { colors, grid, spacing } from '../../../../constants';
 
 export const Footer = styled.footer`
-  background-color: ${colors.white};
+  background-color: ${({ theme }) => theme.footer.bgColor};
   padding-bottom: ${spacing[9]};
   padding-top: ${spacing[10]};
 

--- a/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import FlexCol from '../../../layout/FlexCol/FlexCol';
 import { grid } from '../../../../constants';
 
-export const LegalBlock = styled(FlexCol).attrs({ xs: 12, l: 5 })`
+export const LegalBlock = styled(FlexCol)`
   order: 3;
 
   @media (min-width: ${grid.breakpoints.l}px) {

--- a/src/components/styles/Theme.tsx
+++ b/src/components/styles/Theme.tsx
@@ -56,6 +56,15 @@ interface ErrorMessageTheme {
   backgroundColor: string;
 }
 
+interface FooterTheme {
+  bgColor: string;
+  showFooterLinks: boolean;
+  showLogoBlock: boolean;
+  showSocialBlock: boolean;
+  showLegalBlock: boolean;
+  isLegalBlockFullWidth: boolean;
+}
+
 interface InputTheme {
   color: string;
   borderRadius: string;
@@ -157,6 +166,7 @@ export interface AppTheme {
   button: ButtonsTheme;
   card: CardTheme;
   errorMessage: ErrorMessageTheme;
+  footer: FooterTheme;
   input: InputTheme;
   link: LinkTheme;
   progressBar: ProgressBarTheme;
@@ -259,6 +269,14 @@ export const zopaTheme: AppTheme = {
   errorMessage: {
     textColor: `${colors.alertDark}`,
     backgroundColor: `${colors.alertLight}`,
+  },
+  footer: {
+    bgColor: colors.white,
+    showFooterLinks: true,
+    showLogoBlock: true,
+    showSocialBlock: true,
+    showLegalBlock: true,
+    isLegalBlockFullWidth: false,
   },
   input: {
     color: colors.grey,


### PR DESCRIPTION
Add theming to ZopaFooter to be able to:
- show/hide `LogoBlock`, `LegalBlock` and `SocialBlock`
- stretch `LegalBlock` full width 
- add optional `legalAmendment` prop to amend `LegalBlock`