### PR TITLE
fix(zopafooter): theming bug

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -5,7 +5,6 @@ import FlexRow from '../../layout/FlexRow/FlexRow';
 import FlexCol from '../../layout/FlexCol/FlexCol';
 import Text from '../../atoms/Text/Text';
 import { Footer, Heading, LegalBlock, List, LogoBlock, SocialBlock, SocialLink } from './styles';
-import { colors } from '../../../constants';
 import facebook from '../../../content/images/social/facebook.svg';
 import twitter from '../../../content/images/social/twitter.svg';
 import instagram from '../../../content/images/social/instagram.svg';
@@ -42,8 +41,9 @@ const ZopaFooter = ({
   ...rest
 }: FooterProps) => {
   const theme = useThemeContext();
+
   return (
-    <Footer data-automation="ZA.footer" theme={theme} {...rest}>
+    <Footer data-automation="ZA.footer" theme={theme} {...rest} className={theme.footer.className}>
       <FlexContainer gutter={16}>
         {theme.footer.showFooterLinks && (
           <FlexRow className="mb-6">
@@ -149,18 +149,18 @@ const ZopaFooter = ({
             </SocialBlock>
           )}
           {theme.footer.showLegalBlock && (
-            <LegalBlock xs={12} l={theme.footer.isLegalBlockFullWidth ? 12 : 5}>
-              <Text as="p" color={colors.greyDark} size="small" className="mb-4">
+            <LegalBlock xs={12} l={theme.footer.legalBlock.isFullWidth ? 12 : 5} theme={theme}>
+              <Text as="p" color={theme.footer.legalBlock.color} size="small" className="mb-4">
                 Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial
                 Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services
                 Register (800542). Zopa Bank Limited (10627575) is incorporated in England &amp; Wales and has its
                 registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
               </Text>
-              <Text as="p" color={colors.greyDark} size="small" className="mb-4">
+              <Text as="p" color={theme.footer.legalBlock.color} size="small" className="mb-4">
                 © Zopa Bank Limited {new Date().getFullYear()} All rights reserved. 'Zopa' is a trademark of Zopa Bank
                 Limited.
               </Text>
-              <Text as="p" color={colors.greyDark} size="small" className={legalAmendment ? 'mb-4' : ''}>
+              <Text as="p" color={theme.footer.legalBlock.color} size="small" className={legalAmendment ? 'mb-4' : ''}>
                 Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the
                 Office of the Information Commissioner (ZA275984).
               </Text>

--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -150,17 +150,17 @@ const ZopaFooter = ({
           )}
           {theme.footer.showLegalBlock && (
             <LegalBlock xs={12} l={theme.footer.legalBlock.isFullWidth ? 12 : 5} theme={theme}>
-              <Text as="p" color={theme.footer.legalBlock.color} size="small" className="mb-4">
+              <Text as="p" color={theme.footer.legalBlock.color} className="mb-4">
                 Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial
                 Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services
                 Register (800542). Zopa Bank Limited (10627575) is incorporated in England &amp; Wales and has its
                 registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
               </Text>
-              <Text as="p" color={theme.footer.legalBlock.color} size="small" className="mb-4">
+              <Text as="p" color={theme.footer.legalBlock.color} className="mb-4">
                 © Zopa Bank Limited {new Date().getFullYear()} All rights reserved. 'Zopa' is a trademark of Zopa Bank
                 Limited.
               </Text>
-              <Text as="p" color={theme.footer.legalBlock.color} size="small" className={legalAmendment ? 'mb-4' : ''}>
+              <Text as="p" color={theme.footer.legalBlock.color} className={legalAmendment ? 'mb-4' : ''}>
                 Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the
                 Office of the Information Commissioner (ZA275984).
               </Text>

--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -150,17 +150,17 @@ const ZopaFooter = ({
           )}
           {theme.footer.showLegalBlock && (
             <LegalBlock xs={12} l={theme.footer.legalBlock.isFullWidth ? 12 : 5} theme={theme}>
-              <Text as="p" color={theme.footer.legalBlock.color} className="mb-4">
+              <Text as="p" color={theme.footer.legalBlock.color} size="small" className="mb-4">
                 Zopa Bank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial
                 Conduct Authority and the Prudential Regulation Authority, and entered on the Financial Services
                 Register (800542). Zopa Bank Limited (10627575) is incorporated in England &amp; Wales and has its
                 registered office at: 1st Floor, Cottons Centre, Tooley Street, London, SE1 2QG.
               </Text>
-              <Text as="p" color={theme.footer.legalBlock.color} className="mb-4">
+              <Text as="p" color={theme.footer.legalBlock.color} size="small" className="mb-4">
                 © Zopa Bank Limited {new Date().getFullYear()} All rights reserved. 'Zopa' is a trademark of Zopa Bank
                 Limited.
               </Text>
-              <Text as="p" color={theme.footer.legalBlock.color} className={legalAmendment ? 'mb-4' : ''}>
+              <Text as="p" color={theme.footer.legalBlock.color} size="small" className={legalAmendment ? 'mb-4' : ''}>
                 Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the
                 Office of the Information Commissioner (ZA275984).
               </Text>

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -108,8 +108,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
 
 .c0 {
   background-color: #FFFFFF;
-  padding-bottom: 56px;
-  padding-top: 64px;
 }
 
 .c5 {
@@ -148,6 +146,11 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
+}
+
+.c20 p {
+  font-size: 14px;
+  color: #4A545E;
 }
 
 .c6 {
@@ -351,12 +354,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
 }
 
 @media (min-width:992px) {
-  .c0 {
-    padding-top: 104px;
-  }
-}
-
-@media (min-width:992px) {
   .c20 {
     -webkit-order: 2;
     -ms-flex-order: 2;
@@ -380,7 +377,7 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
 }
 
 <footer
-  class="c0"
+  class="c0 pb-9 pt-10 l:pt-11"
   data-automation="ZA.footer"
 >
   <div

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -99,8 +99,8 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   -ms-letter-spacing: 0;
   letter-spacing: 0;
   color: #4A545E;
-  font-size: 16px;
-  line-height: 24px;
+  font-size: 14px;
+  line-height: 20px;
   font-weight: 400;
   font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
   text-align: inherit;
@@ -146,12 +146,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
-}
-
-.c20 p {
-  font-size: 14px;
-  color: #4A545E;
-  line-height: 20px;
 }
 
 .c6 {

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -99,8 +99,8 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   -ms-letter-spacing: 0;
   letter-spacing: 0;
   color: #4A545E;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 16px;
+  line-height: 24px;
   font-weight: 400;
   font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
   text-align: inherit;
@@ -151,6 +151,7 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
 .c20 p {
   font-size: 14px;
   color: #4A545E;
+  line-height: 20px;
 }
 
 .c6 {

--- a/src/components/molecules/ZopaFooter/styles/Footer.tsx
+++ b/src/components/molecules/ZopaFooter/styles/Footer.tsx
@@ -1,12 +1,5 @@
 import styled from 'styled-components';
-import { colors, grid, spacing } from '../../../../constants';
 
 export const Footer = styled.footer`
   background-color: ${({ theme }) => theme.footer.bgColor};
-  padding-bottom: ${spacing[9]};
-  padding-top: ${spacing[10]};
-
-  @media (min-width: ${grid.breakpoints.l}px) {
-    padding-top: ${spacing[11]};
-  }
 `;

--- a/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
@@ -5,11 +5,6 @@ import { grid } from '../../../../constants';
 
 export const LegalBlock = styled(FlexCol)`
   order: 3;
-  p {
-    font-size: ${({ theme }) => theme.footer.legalBlock.fontSize};
-    color: ${({ theme }) => theme.footer.legalBlock.color};
-    line-height: ${({ theme }) => theme.footer.legalBlock.lineHeight};
-  }
 
   @media (min-width: ${grid.breakpoints.l}px) {
     order: 2;

--- a/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
@@ -8,6 +8,7 @@ export const LegalBlock = styled(FlexCol)`
   p {
     font-size: ${({ theme }) => theme.footer.legalBlock.fontSize};
     color: ${({ theme }) => theme.footer.legalBlock.color};
+    line-height: ${({ theme }) => theme.footer.legalBlock.lineHeight};
   }
 
   @media (min-width: ${grid.breakpoints.l}px) {

--- a/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
+++ b/src/components/molecules/ZopaFooter/styles/LegalBlock.tsx
@@ -1,9 +1,14 @@
 import styled from 'styled-components';
 import FlexCol from '../../../layout/FlexCol/FlexCol';
+import Text from '../../../atoms/Text/Text';
 import { grid } from '../../../../constants';
 
 export const LegalBlock = styled(FlexCol)`
   order: 3;
+  p {
+    font-size: ${({ theme }) => theme.footer.legalBlock.fontSize};
+    color: ${({ theme }) => theme.footer.legalBlock.color};
+  }
 
   @media (min-width: ${grid.breakpoints.l}px) {
     order: 2;

--- a/src/components/styles/Theme.tsx
+++ b/src/components/styles/Theme.tsx
@@ -67,8 +67,6 @@ interface FooterTheme {
   legalBlock: {
     isFullWidth: boolean;
     color: string;
-    fontSize: string;
-    lineHeight: string;
   };
 }
 
@@ -344,8 +342,6 @@ export const zopaTheme: AppTheme = {
     legalBlock: {
       isFullWidth: false,
       color: colors.greyDark,
-      fontSize: typography.sizes.text.small,
-      lineHeight: typography.sizes.lineHeight.small,
     },
   },
   input: {

--- a/src/components/styles/Theme.tsx
+++ b/src/components/styles/Theme.tsx
@@ -68,6 +68,7 @@ interface FooterTheme {
     isFullWidth: boolean;
     color: string;
     fontSize: string;
+    lineHeight: string;
   };
 }
 
@@ -344,6 +345,7 @@ export const zopaTheme: AppTheme = {
       isFullWidth: false,
       color: colors.greyDark,
       fontSize: typography.sizes.text.small,
+      lineHeight: typography.sizes.lineHeight.small,
     },
   },
   input: {

--- a/src/components/styles/Theme.tsx
+++ b/src/components/styles/Theme.tsx
@@ -59,11 +59,16 @@ interface ErrorMessageTheme {
 
 interface FooterTheme {
   bgColor: string;
+  className: string;
   showFooterLinks: boolean;
   showLogoBlock: boolean;
   showSocialBlock: boolean;
   showLegalBlock: boolean;
-  isLegalBlockFullWidth: boolean;
+  legalBlock: {
+    isFullWidth: boolean;
+    color: string;
+    fontSize: string;
+  };
 }
 
 interface InputTheme {
@@ -330,11 +335,16 @@ export const zopaTheme: AppTheme = {
   },
   footer: {
     bgColor: colors.white,
+    className: 'pb-9 pt-10 l:pt-11',
     showFooterLinks: true,
     showLogoBlock: true,
     showSocialBlock: true,
     showLegalBlock: true,
-    isLegalBlockFullWidth: false,
+    legalBlock: {
+      isFullWidth: false,
+      color: colors.greyDark,
+      fontSize: typography.sizes.text.small,
+    },
   },
   input: {
     color: colors.greyDark,


### PR DESCRIPTION
- refactor `Footer` wrapper with Tailwind & add classname to footer type to be able to change padding with theme
- refactor to get text color for `LegalBlock` from theme 
- reorganise footer theme type