### PR TITLE
fix(link): add theme to svg hover and active styles

### DIFF
--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -42,9 +42,15 @@ const StyledLink = styled.a<LinkProps>`
   color: ${({ theme }) => theme.link.color};
   &:hover {
     color: ${({ theme }) => theme.link.hover.color};
+    svg path {
+      fill: ${({ negative, theme }) => (negative ? 'black' : theme.link.hover.color)};
+    }
   }
   &:active {
     color: ${({ theme }) => theme.link.active.color};
+    svg path {
+      fill: ${({ negative, theme }) => (negative ? 'black' : theme.link.active.color)};
+    }
   }
 `;
 

--- a/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/atoms/Link/__snapshots__/Link.test.tsx.snap
@@ -39,8 +39,16 @@ exports[`<Link /> doesnt render the link with a target icon 1`] = `
   color: auto;
 }
 
+.c0:hover svg path {
+  fill: auto;
+}
+
 .c0:active {
   color: auto;
+}
+
+.c0:active svg path {
+  fill: auto;
 }
 
 <a
@@ -92,8 +100,16 @@ exports[`<Link /> renders for being displayed on top of dark backgrounds 1`] = `
   color: auto;
 }
 
+.c0:hover svg path {
+  fill: black;
+}
+
 .c0:active {
   color: auto;
+}
+
+.c0:active svg path {
+  fill: black;
 }
 
 .c1 {
@@ -168,8 +184,16 @@ exports[`<Link /> renders the link with default values and the svg is hidden wit
   color: auto;
 }
 
+.c0:hover svg path {
+  fill: auto;
+}
+
 .c0:active {
   color: auto;
+}
+
+.c0:active svg path {
+  fill: auto;
 }
 
 <a
@@ -220,8 +244,16 @@ exports[`<Link /> renders the link with target _blank with the svg visible 1`] =
   color: auto;
 }
 
+.c0:hover svg path {
+  fill: auto;
+}
+
 .c0:active {
   color: auto;
+}
+
+.c0:active svg path {
+  fill: auto;
 }
 
 .c1 {

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -208,8 +208,16 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c14 {

--- a/src/components/organisms/Carousel/Carousel/__snapshots__/Carousel.test.tsx.snap
+++ b/src/components/organisms/Carousel/Carousel/__snapshots__/Carousel.test.tsx.snap
@@ -39,8 +39,16 @@ exports[`<Carousel /> renders with no a11y violations 1`] = `
   color: auto;
 }
 
+.c3:hover svg path {
+  fill: auto;
+}
+
 .c3:active {
   color: auto;
+}
+
+.c3:active svg path {
+  fill: auto;
 }
 
 .c2 {

--- a/src/components/organisms/Carousel/CarouselSlide/__snapshots__/CarouselSlide.test.tsx.snap
+++ b/src/components/organisms/Carousel/CarouselSlide/__snapshots__/CarouselSlide.test.tsx.snap
@@ -39,8 +39,16 @@ exports[`<Carousel.Slide /> renders with no a11y violations 1`] = `
   color: auto;
 }
 
+.c3:hover svg path {
+  fill: auto;
+}
+
 .c3:active {
   color: auto;
+}
+
+.c3:active svg path {
+  fill: auto;
 }
 
 .c2 {

--- a/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
+++ b/src/components/organisms/Navbar/Navbar/__snapshots__/Navbar.test.tsx.snap
@@ -45,8 +45,16 @@ exports[`<Navbar /> should render component with all the props and no a11y viola
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c8 {
@@ -1010,8 +1018,16 @@ exports[`<Navbar /> should render large device navigation with default props and
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c8 {
@@ -1925,8 +1941,16 @@ exports[`<Navbar /> should render small device navigation with default props wit
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c8 {
@@ -2890,8 +2914,16 @@ exports[`<Navbar /> should render the collapsed styled on large device navigatio
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c8 {

--- a/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarDropdown/__snapshots__/NavbarDropdown.test.tsx.snap
@@ -48,8 +48,16 @@ exports[`<NavbarDropdown /> renders with no a11y violations 1`] = `
   color: auto;
 }
 
+.c1:hover svg path {
+  fill: auto;
+}
+
 .c1:active {
   color: auto;
+}
+
+.c1:active svg path {
+  fill: auto;
 }
 
 .c2 {

--- a/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLink/__snapshots__/NavbarLink.test.tsx.snap
@@ -39,8 +39,16 @@ exports[`<Navbar.Link /> should render component with default props 1`] = `
   color: auto;
 }
 
+.c0:hover svg path {
+  fill: auto;
+}
+
 .c0:active {
   color: auto;
+}
+
+.c0:active svg path {
+  fill: auto;
 }
 
 .c1 {
@@ -123,8 +131,16 @@ exports[`<Navbar.Link /> should render component with specific props 1`] = `
   color: auto;
 }
 
+.c0:hover svg path {
+  fill: auto;
+}
+
 .c0:active {
   color: auto;
+}
+
+.c0:active svg path {
+  fill: auto;
 }
 
 .c1 {

--- a/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
+++ b/src/components/organisms/Navbar/NavbarLinksList/__snapshots__/NavbarLinksList.test.tsx.snap
@@ -50,8 +50,16 @@ Object {
   color: auto;
 }
 
+.c1:hover svg path {
+  fill: auto;
+}
+
 .c1:active {
   color: auto;
+}
+
+.c1:active svg path {
+  fill: auto;
 }
 
 .c2 {
@@ -302,7 +310,7 @@ Object {
       <a
         aria-expanded="false"
         aria-haspopup="true"
-        class="sc-htpNat cRYLto sc-ifAKCX bIyiel"
+        class="sc-htpNat Umdkr sc-ifAKCX bIyiel"
         color="#3B46C4"
         data-automation="ZA.navbar-item"
         href="#"

--- a/src/components/templates/ErrorPages/FiveHundred/__snapshots__/FiveHundred.test.tsx.snap
+++ b/src/components/templates/ErrorPages/FiveHundred/__snapshots__/FiveHundred.test.tsx.snap
@@ -136,8 +136,16 @@ exports[`<FiveHundred /> renders with all the props 1`] = `
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c3 {

--- a/src/components/templates/ErrorPages/Four0Four/__snapshots__/Four0Four.test.tsx.snap
+++ b/src/components/templates/ErrorPages/Four0Four/__snapshots__/Four0Four.test.tsx.snap
@@ -136,8 +136,16 @@ exports[`<Four0Four /> renders with all the props 1`] = `
   color: auto;
 }
 
+.c6:hover svg path {
+  fill: auto;
+}
+
 .c6:active {
   color: auto;
+}
+
+.c6:active svg path {
+  fill: auto;
 }
 
 .c3 {

--- a/src/components/templates/ErrorPages/Maintenance/__snapshots__/Maintenance.test.tsx.snap
+++ b/src/components/templates/ErrorPages/Maintenance/__snapshots__/Maintenance.test.tsx.snap
@@ -136,8 +136,16 @@ exports[`<Maintenance /> renders with all the props 1`] = `
   color: auto;
 }
 
+.c7:hover svg path {
+  fill: auto;
+}
+
 .c7:active {
   color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c3 {

--- a/src/components/templates/ProductTemplate/ProductTemplateHeader/__snapshots__/ProductTemplateHeader.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateHeader/__snapshots__/ProductTemplateHeader.test.tsx.snap
@@ -53,8 +53,16 @@ exports[`<ProductTemplateHeader /> renders with all the props 1`] = `
   color: auto;
 }
 
+.c2:hover svg path {
+  fill: auto;
+}
+
 .c2:active {
   color: auto;
+}
+
+.c2:active svg path {
+  fill: auto;
 }
 
 .c3 {

--- a/src/components/templates/ProductTemplate/ProductTemplateNavigation/__snapshots__/ProductTemplateNavigation.test.tsx.snap
+++ b/src/components/templates/ProductTemplate/ProductTemplateNavigation/__snapshots__/ProductTemplateNavigation.test.tsx.snap
@@ -74,8 +74,16 @@ exports[`<ProductTemplateNavigation /> renders with a string prevStep 1`] = `
   color: auto;
 }
 
+.c1:hover svg path {
+  fill: auto;
+}
+
 .c1:active {
   color: auto;
+}
+
+.c1:active svg path {
+  fill: auto;
 }
 
 .c2 {


### PR DESCRIPTION
- svgs as links take up `hover` and `active` color from theme  