### PR TITLE
fix: update footer copy handler for more consistency

### DIFF
--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -1,18 +1,18 @@
-import React, { HTMLAttributes, FC, ReactNode } from 'react';
+import Text from '../../atoms/Text/Text';
+import Logo from '../../atoms/Logo/Logo';
+import Link from '../../atoms/Link/Link';
+import { typography } from '../../../constants';
 import styled, { css } from 'styled-components';
-import FlexContainer from '../../layout/FlexContainer/FlexContainer';
+import React, { HTMLAttributes, FC } from 'react';
 import FlexRow from '../../layout/FlexRow/FlexRow';
 import FlexCol from '../../layout/FlexCol/FlexCol';
-import Text from '../../atoms/Text/Text';
-import { Footer, Heading, LegalBlock, List, LogoBlock, SocialBlock, SocialLink } from './styles';
-import facebook from '../../../content/images/social/facebook.svg';
-import twitter from '../../../content/images/social/twitter.svg';
-import instagram from '../../../content/images/social/instagram.svg';
-import linkedin from '../../../content/images/social/linkedin.svg';
-import Logo from '../../atoms/Logo/Logo';
-import { typography } from '../../../constants';
-import Link from '../../atoms/Link/Link';
 import { useThemeContext } from '../../styles/Theme';
+import twitter from '../../../content/images/social/twitter.svg';
+import facebook from '../../../content/images/social/facebook.svg';
+import linkedin from '../../../content/images/social/linkedin.svg';
+import instagram from '../../../content/images/social/instagram.svg';
+import FlexContainer from '../../layout/FlexContainer/FlexContainer';
+import { Footer, Heading, LegalBlock, List, LogoBlock, SocialBlock, SocialLink } from './styles';
 
 export const footerLinkStyle = css`
   font-weight: ${typography.weights.regular};
@@ -31,17 +31,13 @@ const StyledLink = styled(Link)`
 export interface FooterProps extends HTMLAttributes<HTMLDivElement> {
   baseUrl?: string;
   renderLink?: FC<Record<'href', string> & HTMLAttributes<HTMLAnchorElement>>;
-  partnerInfo?: ReactNode;
-  lenderInfo?: ReactNode;
-  legalAmendment?: ReactNode;
+  additionalCopy?: string[];
 }
 
 const ZopaFooter = ({
   baseUrl = 'https://www.zopa.com',
   renderLink = (props) => <StyledLink {...props} />,
-  lenderInfo = <></>,
-  partnerInfo = <></>,
-  legalAmendment = <></>,
+  additionalCopy = [],
   ...rest
 }: FooterProps) => {
   const theme = useThemeContext();
@@ -164,13 +160,20 @@ const ZopaFooter = ({
                 © Zopa Bank Limited {new Date().getFullYear()} All rights reserved. 'Zopa' is a trademark of Zopa Bank
                 Limited.
               </Text>
-              <Text as="p" color={theme.footer.legalBlock.color} size="small" className={legalAmendment ? 'mb-4' : ''}>
+              <Text
+                as="p"
+                color={theme.footer.legalBlock.color}
+                size="small"
+                className={additionalCopy.length ? 'mb-4' : ''}
+              >
                 Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the
                 Office of the Information Commissioner (ZA275984).
               </Text>
-              {lenderInfo}
-              {partnerInfo}
-              {legalAmendment}
+              {additionalCopy.map((copy, i) => (
+                <Text as="p" color={theme.footer.legalBlock.color} size="small" key={i} className={'mb-4'}>
+                  {copy}
+                </Text>
+              ))}
             </LegalBlock>
           )}
         </FlexRow>

--- a/src/components/molecules/ZopaFooter/ZopaFooter.tsx
+++ b/src/components/molecules/ZopaFooter/ZopaFooter.tsx
@@ -170,7 +170,13 @@ const ZopaFooter = ({
                 Office of the Information Commissioner (ZA275984).
               </Text>
               {additionalCopy.map((copy, i) => (
-                <Text as="p" color={theme.footer.legalBlock.color} size="small" key={i} className={'mb-4'}>
+                <Text
+                  as="p"
+                  color={theme.footer.legalBlock.color}
+                  size="small"
+                  key={i}
+                  className={i > additionalCopy.length ? 'mb-0' : 'mb-4'}
+                >
                   {copy}
                 </Text>
               ))}

--- a/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
+++ b/src/components/molecules/ZopaFooter/__snapshots__/ZopaFooter.test.tsx.snap
@@ -1,13 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
-.c1 {
-  width: 100%;
-  max-width: 100%;
-  padding-right: 16px;
-  padding-left: 16px;
-  margin-left: auto;
-  margin-right: auto;
+.c4 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #2C3236;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 700;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  text-align: inherit;
+  display: block;
+}
+
+.c21 {
+  margin: 0;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  color: #4A545E;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  text-align: inherit;
+}
+
+.c11 {
+  -webkit-transition: fill 0.3s ease;
+  transition: fill 0.3s ease;
+  fill: #00D9C5;
+}
+
+.c7 {
+  background-color: transparent;
+  font-size: inherit;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 600;
+  line-height: inherit;
+  color: #3B46C4;
+  cursor: pointer;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-user-select: auto;
+  -moz-user-select: auto;
+  -ms-user-select: auto;
+  user-select: auto;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: 0;
+  border: none;
+  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 600;
+  color: auto;
+}
+
+.c7:hover,
+.c7:active {
+  color: #21247F;
+}
+
+.c7:hover svg path,
+.c7:active svg path {
+  fill: #21247F;
+}
+
+.c7:hover {
+  color: auto;
+}
+
+.c7:hover svg path {
+  fill: auto;
+}
+
+.c7:active {
+  color: auto;
+}
+
+.c7:active svg path {
+  fill: auto;
 }
 
 .c2 {
@@ -77,33 +153,13 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   align-self: auto;
 }
 
-.c4 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  color: #2C3236;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 700;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  text-align: inherit;
-  display: block;
-}
-
-.c21 {
-  margin: 0;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  color: #4A545E;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  text-align: inherit;
+.c1 {
+  width: 100%;
+  max-width: 100%;
+  padding-right: 16px;
+  padding-left: 16px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .c0 {
@@ -170,64 +226,8 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
   order: 2;
 }
 
-.c7 {
-  background-color: transparent;
-  font-size: inherit;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 600;
-  line-height: inherit;
-  color: #3B46C4;
-  cursor: pointer;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  user-select: auto;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  padding: 0;
-  border: none;
-  font-family: "Open Sans",Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 600;
-  color: auto;
-}
-
-.c7:hover,
-.c7:active {
-  color: #21247F;
-}
-
-.c7:hover svg path,
-.c7:active svg path {
-  fill: #21247F;
-}
-
-.c7:hover {
-  color: auto;
-}
-
-.c7:hover svg path {
-  fill: auto;
-}
-
-.c7:active {
-  color: auto;
-}
-
-.c7:active svg path {
-  fill: auto;
-}
-
 .c14 {
   margin: 0 8px;
-}
-
-.c11 {
-  -webkit-transition: fill 0.3s ease;
-  transition: fill 0.3s ease;
-  fill: #00D9C5;
 }
 
 .c8 {
@@ -240,30 +240,6 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
 .c8:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-@media (min-width:576px) {
-  .c1 {
-    max-width: 540px;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    max-width: 720px;
-  }
-}
-
-@media (min-width:992px) {
-  .c1 {
-    max-width: 960px;
-  }
-}
-
-@media (min-width:1300px) {
-  .c1 {
-    max-width: 1224px;
-  }
 }
 
 @media (min-width:0px) {
@@ -353,6 +329,30 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
     -ms-flex: 0 0 41.66666666666667%;
     flex: 0 0 41.66666666666667%;
     max-width: 41.66666666666667%;
+  }
+}
+
+@media (min-width:576px) {
+  .c1 {
+    max-width: 540px;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    max-width: 720px;
+  }
+}
+
+@media (min-width:992px) {
+  .c1 {
+    max-width: 960px;
+  }
+}
+
+@media (min-width:1300px) {
+  .c1 {
+    max-width: 1224px;
   }
 }
 
@@ -850,7 +850,7 @@ exports[`<ZopaFooter /> renders the component with no a11y violations 1`] = `
            All rights reserved. 'Zopa' is a trademark of Zopa Bank Limited.
         </p>
         <p
-          class="c21 mb-4"
+          class="c21"
           color="#4A545E"
         >
           Zopa is a member of Cifas – the UK’s leading anti-fraud association, and we are registered with the Office of the Information Commissioner (ZA275984).


### PR DESCRIPTION
The previous implementation meant that the colour of the additional footer text had to be handled separately from the footer itself. This change allows the text to be handled the same way regardless of source.