### PR TITLE
Add theme to error pages

### DIFF
--- a/src/components/templates/ErrorPages/FiveHundred/FiveHundred.tsx
+++ b/src/components/templates/ErrorPages/FiveHundred/FiveHundred.tsx
@@ -11,6 +11,7 @@ import { breakpoints } from '../../../../constants/breakpoints';
 import { colors } from '../../../../constants';
 import { ErrorTemplateProps } from '../types';
 import { StyledIcon, StyledLink } from '../styles';
+import { ThemeProvider, useThemeContext } from '../../../styles/Theme';
 
 export interface FiveHundredErrorProps extends ErrorTemplateProps {
   linkUrl?: string;
@@ -23,37 +24,40 @@ const FiveHundred = ({
   linkText = 'Go to Zopa home',
 }: FiveHundredErrorProps) => {
   const { width = 0 } = useViewport();
+  const theme = useThemeContext();
 
   return (
     <div data-automation="ZA.ErrorPage.FiveHundred">
-      <FlexRow justify="center">
-        <FlexCol xs="auto" className="mb-7">
-          <StyledIcon bgColor={colors.greyLighter} variant={icon} size="3x" color={colors.greyDark} />
-        </FlexCol>
-      </FlexRow>
-      <Heading as="h1" size={width <= breakpoints.desktop ? 'h4' : 'h3'} align="center" className="mb-4">
-        Sorry, there’s been a problem
-      </Heading>
-      <Text as="p" size={width <= breakpoints.desktop ? 'body' : 'lead'} align="center" className="mb-7">
-        We’re working to fix this problem and we’ll be up and running shortly.
-      </Text>
-      <Text as="p" size="small" align="center" className="mb-8">
-        Keep seeing this page?{' '}
-        <Link href="http://www.wikihow.com/Clear-Your-Browser%27s-Cookies" target="_blank" showTargetIcon={false}>
-          Try clearing your browser cookies
-        </Link>{' '}
-        or come back later
-      </Text>
-      <FlexRow justify="center">
-        <FlexCol xs="auto">
-          <StyledLink className="mb-10" href={linkUrl} styling="secondary">
-            {linkText}
-          </StyledLink>
-        </FlexCol>
-      </FlexRow>
-      <Text as="p" size="small" align="center">
-        Error code: 500
-      </Text>
+      <ThemeProvider theme={theme}>
+        <FlexRow justify="center">
+          <FlexCol xs="auto" className="mb-7">
+            <StyledIcon bgColor={colors.greyLighter} variant={icon} size="3x" color={colors.greyDark} />
+          </FlexCol>
+        </FlexRow>
+        <Heading as="h1" size={width <= breakpoints.desktop ? 'h4' : 'h3'} align="center" className="mb-4">
+          Sorry, there’s been a problem
+        </Heading>
+        <Text as="p" size={width <= breakpoints.desktop ? 'body' : 'lead'} align="center" className="mb-7">
+          We’re working to fix this problem and we’ll be up and running shortly.
+        </Text>
+        <Text as="p" size="small" align="center" className="mb-8">
+          Keep seeing this page?{' '}
+          <Link href="http://www.wikihow.com/Clear-Your-Browser%27s-Cookies" target="_blank" showTargetIcon={false}>
+            Try clearing your browser cookies
+          </Link>{' '}
+          or come back later
+        </Text>
+        <FlexRow justify="center">
+          <FlexCol xs="auto">
+            <StyledLink className="mb-10" href={linkUrl} styling="secondary">
+              {linkText}
+            </StyledLink>
+          </FlexCol>
+        </FlexRow>
+        <Text as="p" size="small" align="center">
+          Error code: 500
+        </Text>
+      </ThemeProvider>
     </div>
   );
 };

--- a/src/components/templates/ErrorPages/Four0Four/Four0Four.tsx
+++ b/src/components/templates/ErrorPages/Four0Four/Four0Four.tsx
@@ -10,6 +10,7 @@ import { breakpoints } from '../../../../constants/breakpoints';
 import { colors } from '../../../../constants';
 import { ErrorTemplateProps } from '../types';
 import { StyledIcon, StyledLink } from '../styles';
+import { ThemeProvider, useThemeContext } from '../../../styles/Theme';
 
 export interface Four0FourErrorProps extends ErrorTemplateProps {
   linkUrl?: string;
@@ -22,30 +23,33 @@ const Four0Four = ({
   linkText = 'Go to Zopa home',
 }: Four0FourErrorProps) => {
   const { width = 0 } = useViewport();
+  const theme = useThemeContext();
 
   return (
     <div data-automation="ZA.ErrorPage.Four0Four">
-      <FlexRow justify="center">
-        <FlexCol xs="auto" className="mb-7">
-          <StyledIcon bgColor={colors.greyLighter} variant={icon} size="3x" color={colors.greyDark} />
-        </FlexCol>
-      </FlexRow>
-      <Heading as="h1" size={width <= breakpoints.desktop ? 'h4' : 'h3'} align="center" className="mb-4">
-        Sorry, there’s been a problem
-      </Heading>
-      <Text as="p" size={width <= breakpoints.desktop ? 'body' : 'lead'} align="center" className="mb-8">
-        Seems like the page you’re looking for doesn’t exist.
-      </Text>
-      <FlexRow justify="center">
-        <FlexCol xs="auto">
-          <StyledLink className="mb-10" href={linkUrl} styling="secondary">
-            {linkText}
-          </StyledLink>
-        </FlexCol>
-      </FlexRow>
-      <Text as="p" size="small" align="center">
-        Error code: 404
-      </Text>
+      <ThemeProvider theme={theme}>
+        <FlexRow justify="center">
+          <FlexCol xs="auto" className="mb-7">
+            <StyledIcon bgColor={colors.greyLighter} variant={icon} size="3x" color={colors.greyDark} />
+          </FlexCol>
+        </FlexRow>
+        <Heading as="h1" size={width <= breakpoints.desktop ? 'h4' : 'h3'} align="center" className="mb-4">
+          Sorry, there’s been a problem
+        </Heading>
+        <Text as="p" size={width <= breakpoints.desktop ? 'body' : 'lead'} align="center" className="mb-8">
+          Seems like the page you’re looking for doesn’t exist.
+        </Text>
+        <FlexRow justify="center">
+          <FlexCol xs="auto">
+            <StyledLink className="mb-10" href={linkUrl} styling="secondary">
+              {linkText}
+            </StyledLink>
+          </FlexCol>
+        </FlexRow>
+        <Text as="p" size="small" align="center">
+          Error code: 404
+        </Text>
+      </ThemeProvider>
     </div>
   );
 };

--- a/src/components/templates/ErrorPages/Maintenance/Maintenance.tsx
+++ b/src/components/templates/ErrorPages/Maintenance/Maintenance.tsx
@@ -12,6 +12,7 @@ import { colors } from '../../../../constants';
 import { HelpLine, HelpLineDetails } from '../../../molecules/Help/Help';
 import { ErrorTemplateProps } from '../types';
 import { StyledIcon } from '../styles';
+import { ThemeProvider, useThemeContext } from '../../../styles/Theme';
 
 export interface MaintenanceFiveHundredErrorProps extends ErrorTemplateProps {
   helpLine?: HelpLine;
@@ -19,26 +20,30 @@ export interface MaintenanceFiveHundredErrorProps extends ErrorTemplateProps {
 
 const Maintenance = ({ helpLine = HelpLine.borrowers, icon = faTools }: MaintenanceFiveHundredErrorProps) => {
   const { width = 0 } = useViewport();
+  const theme = useThemeContext();
+
   return (
     <div data-automation="ZA.ErrorPage.Maintenance">
-      <FlexRow justify="center">
-        <FlexCol xs="auto" className="mb-7">
-          <StyledIcon bgColor={colors.greyLighter} variant={icon} size="3x" color={colors.greyDark} />
-        </FlexCol>
-      </FlexRow>
-      <Heading as="h1" size={width <= breakpoints.desktop ? 'h4' : 'h3'} align="center" className="mb-4">
-        We'll be back soon!
-      </Heading>
-      <Text as="p" size={width <= breakpoints.desktop ? 'body' : 'lead'} align="center" className="mb-7">
-        Sorry for the inconvenience but we're doing some essential work on our website right now.
-      </Text>
-      <Text as="p" size="small" align="center" className="mb-7">
-        Please come back later or give us a call on
-        <Link href={`tel:${HelpLineDetails[helpLine].telephone.tel}`}>
-          {HelpLineDetails[helpLine].telephone.label}
-        </Link>{' '}
-        and we'll help you out.
-      </Text>
+      <ThemeProvider theme={theme}>
+        <FlexRow justify="center">
+          <FlexCol xs="auto" className="mb-7">
+            <StyledIcon bgColor={colors.greyLighter} variant={icon} size="3x" color={colors.greyDark} />
+          </FlexCol>
+        </FlexRow>
+        <Heading as="h1" size={width <= breakpoints.desktop ? 'h4' : 'h3'} align="center" className="mb-4">
+          We'll be back soon!
+        </Heading>
+        <Text as="p" size={width <= breakpoints.desktop ? 'body' : 'lead'} align="center" className="mb-7">
+          Sorry for the inconvenience but we're doing some essential work on our website right now.
+        </Text>
+        <Text as="p" size="small" align="center" className="mb-7">
+          Please come back later or give us a call on
+          <Link href={`tel:${HelpLineDetails[helpLine].telephone.tel}`}>
+            {HelpLineDetails[helpLine].telephone.label}
+          </Link>{' '}
+          and we'll help you out.
+        </Text>
+      </ThemeProvider>
     </div>
   );
 };


### PR DESCRIPTION
- add `ThemeProvider` wrapper to error pages to be able to pass theme to components within these templates
