### PR TITLE
build(rollup): use interop: 'auto'

### DIFF
--- a/etc/rollup/config.mjs
+++ b/etc/rollup/config.mjs
@@ -23,12 +23,14 @@ export default {
       sourcemap: true,
       exports: 'named',
       preserveModules: true,
+      interop: 'auto'
     },
     {
       dir: 'es',
       format: 'es',
       sourcemap: true,
       preserveModules: true,
+      interop: 'auto'
     },
   ],
   external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],


### PR DESCRIPTION
Rollup causes issues with the default settings for apps (*.div is not a function etc)

See: https://github.com/rollup/rollup/issues/3684