### PR TITLE
Accordion: remove aria-disabled attribute

### DIFF
--- a/src/components/organisms/Accordion/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/src/components/organisms/Accordion/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -71,7 +71,6 @@ exports[`<AccordionHeader /> renders the component with no a11y violations 1`] =
 
 <button
   aria-controls="one-section"
-  aria-disabled="false"
   aria-expanded="false"
   class="c0"
   data-automation="header"

--- a/src/hooks/useAccordion/__snapshots__/useAccordion.test.ts.snap
+++ b/src/hooks/useAccordion/__snapshots__/useAccordion.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`useAccordion should render correct tab and section props 1`] = `
 Object {
   "aria-controls": "id-section",
-  "aria-disabled": false,
   "aria-expanded": false,
   "id": "id",
   "key": "id",

--- a/src/hooks/useAccordion/useAccordion.ts
+++ b/src/hooks/useAccordion/useAccordion.ts
@@ -4,7 +4,6 @@ import { mod } from '../../helpers/utils';
 
 export interface AccordionHeaderProps {
   'aria-controls': string;
-  'aria-disabled': boolean;
   'aria-expanded': boolean;
   id: string;
   key: string;
@@ -116,7 +115,6 @@ export const useAccordion = (props?: {}) => {
 
   const getHeaderProps: GetAccordionHeaderProps = (id, index) => ({
     'aria-controls': getLinkingId(id),
-    'aria-disabled': isActiveSection(index),
     'aria-expanded': isActiveSection(index),
     id,
     key: id,


### PR DESCRIPTION
Accessibility: This attribute is not needed, having it can cause confusion for screen readers users