### PR TITLE
fix(help): colour change for regular text in Help

### DIFF
--- a/src/components/molecules/Help/Help.tsx
+++ b/src/components/molecules/Help/Help.tsx
@@ -84,7 +84,7 @@ const Help = ({
           <Heading as="h3" className="pb-6">
             We're here to help
           </Heading>
-          <Text className="pb-8" color={colors.grey}>
+          <Text className="pb-8" color={colors.greyDarkest}>
             {HelpLineDetails[helpLine].text}
           </Text>
         </FlexColCenter>

--- a/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
+++ b/src/components/molecules/Help/__snapshots__/Help.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
-  color: #818F9B;
+  color: #2C3236;
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
@@ -320,7 +320,7 @@ exports[`<Help /> renders the default Help component with no a11y violations 1`]
         </h3>
         <span
           class="c6 pb-8"
-          color="#818F9B"
+          color="#2C3236"
         >
           We can't take applications over the phone. 
           <br />


### PR DESCRIPTION
use greyDarkest in order for regular text in Help component to be compliant with WCAG AA